### PR TITLE
Segment clamping comparison

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1513,13 +1513,11 @@ function renderChapter(data, book, opts) {
       hlSegments = null;
       if (pathBase) history.replaceState(null, "", pathBase + location.search);
     } else {
-      const needsRewrite = clamped.length !== hlSegments.length ||
-        clamped.some((s, i) => s.end !== hlSegments[i].end);
+      const serializeSeg = s => s.part ? `${s.start}${s.part}` : s.start === s.end ? `${s.start}` : `${s.start}-${s.end}`;
+      const newSpec = clamped.map(serializeSeg).join(",");
+      const needsRewrite = newSpec !== hlSegments.map(serializeSeg).join(",");
       hlSegments = clamped;
       if (needsRewrite && pathBase) {
-        const newSpec = clamped
-          .map(s => s.part ? `${s.start}${s.part}` : s.start === s.end ? `${s.start}` : `${s.start}-${s.end}`)
-          .join(",");
         history.replaceState(null, "", `${pathBase}/${newSpec}${location.search}`);
       }
     }


### PR DESCRIPTION
Compare serialized highlight segment specs to robustly detect URL rewrite needs, fixing a fragile comparison that missed changes to segment parts.

The original `needsRewrite` check compared `clamped` and `hlSegments` by index, only checking the `end` field. This was problematic because it didn't account for changes in other segment fields (like `part`) and was fragile to future changes in filtering/mapping logic, potentially leading to stale URLs. Comparing the full serialized spec strings ensures all relevant segment properties are considered for the rewrite decision.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, localized change to client-side URL normalization logic for highlighted verse segments. Main risk is minor URL rewrite behavior changes for edge-case highlight specs (e.g., parts/ranges).
> 
> **Overview**
> Tightens URL normalization for multi-segment verse highlights by generating a canonical serialized spec for `clamped` segments and using it to decide whether `history.replaceState` should rewrite the path.
> 
> This replaces the prior `needsRewrite` heuristic (length + `end`-only, index-based comparison) so changes to other segment properties (notably `part`) and future mapping/filtering differences don’t leave stale highlight specs in the URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 844827aaa37a155ff3a7fb1a0517ba327f823900. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->