### PR TITLE
style: 연속 절 강조·선택은 바깥쪽 모서리만 라운드 처리

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1948,6 +1948,17 @@ body.verse-select-active .verse[data-vref]:hover {
   border-radius: 5px;
 }
 
+/* In a run of consecutive selected verses, flatten the corners that abut
+   another selected verse so the run reads as a single highlighted block. */
+.verse.verse-selected.verse-selected-join-prev {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+.verse.verse-selected.verse-selected-join-next {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
 /* ── Verse selection action bar ── */
 
 #verse-select-bar {

--- a/css/style.css
+++ b/css/style.css
@@ -1030,7 +1030,9 @@ mark.search-highlight {
 }
 
 /* In a run of consecutive highlighted verses, flatten the corners that abut
-   another highlighted verse so the run reads as a single block. */
+   another highlighted verse so the run reads as a single block.
+   Inline verses (default) stack horizontally → flatten left/right edges.
+   Block verses (poetry) stack vertically   → flatten top/bottom edges. */
 .verse-highlight.verse-highlight-join-prev {
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;
@@ -1038,6 +1040,21 @@ mark.search-highlight {
 .verse-highlight.verse-highlight-join-next {
   border-top-right-radius: 0;
   border-bottom-right-radius: 0;
+}
+.verse.verse-poetry.verse-highlight.verse-highlight-join-prev {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  border-bottom-left-radius: 5px;
+  border-bottom-right-radius: 5px;
+}
+.verse.verse-poetry.verse-highlight.verse-highlight-join-next {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  border-top-left-radius: 5px;
+  border-top-right-radius: 5px;
+}
+.verse.verse-poetry.verse-highlight.verse-highlight-join-prev.verse-highlight-join-next {
+  border-radius: 0;
 }
 
 [data-theme="dark"] .verse-highlight {
@@ -1960,7 +1977,9 @@ body.verse-select-active .verse[data-vref]:hover {
 }
 
 /* In a run of consecutive selected verses, flatten the corners that abut
-   another selected verse so the run reads as a single highlighted block. */
+   another selected verse so the run reads as a single highlighted block.
+   Inline verses (default) stack horizontally → flatten left/right edges.
+   Block verses (poetry) stack vertically   → flatten top/bottom edges. */
 .verse.verse-selected.verse-selected-join-prev {
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;
@@ -1968,6 +1987,21 @@ body.verse-select-active .verse[data-vref]:hover {
 .verse.verse-selected.verse-selected-join-next {
   border-top-right-radius: 0;
   border-bottom-right-radius: 0;
+}
+.verse.verse-poetry.verse-selected.verse-selected-join-prev {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  border-bottom-left-radius: 5px;
+  border-bottom-right-radius: 5px;
+}
+.verse.verse-poetry.verse-selected.verse-selected-join-next {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  border-top-left-radius: 5px;
+  border-top-right-radius: 5px;
+}
+.verse.verse-poetry.verse-selected.verse-selected-join-prev.verse-selected-join-next {
+  border-radius: 0;
 }
 
 /* ── Verse selection action bar ── */

--- a/css/style.css
+++ b/css/style.css
@@ -1029,6 +1029,17 @@ mark.search-highlight {
   padding: 0.1em 0.15em;
 }
 
+/* In a run of consecutive highlighted verses, flatten the corners that abut
+   another highlighted verse so the run reads as a single block. */
+.verse-highlight.verse-highlight-join-prev {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+.verse-highlight.verse-highlight-join-next {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
 [data-theme="dark"] .verse-highlight {
   background: rgba(196, 154, 108, 0.12) !important;
 }

--- a/js/app.js
+++ b/js/app.js
@@ -1681,6 +1681,22 @@ function renderChapter(data, book, opts) {
     isFirst = false;
   }
 
+  // Flatten inner corners between adjacent highlighted verses so a run from
+  // a search/bookmark deep link renders as a single block.
+  {
+    const verses = [...article.querySelectorAll(".verse[data-vref]")];
+    for (let i = 0; i < verses.length; i++) {
+      const v = verses[i];
+      if (!v.classList.contains("verse-highlight")) continue;
+      if (i > 0 && verses[i - 1].classList.contains("verse-highlight")) {
+        v.classList.add("verse-highlight-join-prev");
+      }
+      if (i < verses.length - 1 && verses[i + 1].classList.contains("verse-highlight")) {
+        v.classList.add("verse-highlight-join-next");
+      }
+    }
+  }
+
   // Track current chapter context for verse selection mode
   _currentBookId = book.id;
   _currentChapter = ch;

--- a/js/app.js
+++ b/js/app.js
@@ -1727,6 +1727,7 @@ function renderChapter(data, book, opts) {
         article.querySelectorAll(".verse[data-vref]").forEach(v => {
           v.classList.toggle("verse-selected", _selectedVerseRefs.has(v.getAttribute("data-vref")));
         });
+        updateVerseSelectionBoundaries(article);
         updateVerseSelectBar();
       }
     }, 300);
@@ -1762,6 +1763,7 @@ function renderChapter(data, book, opts) {
         }
         v.classList.toggle("verse-selected", _selectedVerseRefs.has(vref));
       });
+      updateVerseSelectionBoundaries(article);
       updateVerseSelectBar();
       return;
     }
@@ -1780,6 +1782,7 @@ function renderChapter(data, book, opts) {
           _verseSelectDrag.allVerses.forEach(v => {
             v.classList.toggle("verse-selected", _selectedVerseRefs.has(v.getAttribute("data-vref")));
           });
+          updateVerseSelectionBoundaries(article);
           updateVerseSelectBar();
         }
       }
@@ -4289,6 +4292,21 @@ function openImportModal(incoming) {
 
 // ── Verse selection mode ──
 
+// Flatten the inner corners between adjacent selected verses so a run of
+// consecutive selections renders as a single highlighted block.
+function updateVerseSelectionBoundaries(scope) {
+  const root = scope || document;
+  const verses = [...root.querySelectorAll(".verse[data-vref]")];
+  for (let i = 0; i < verses.length; i++) {
+    const v = verses[i];
+    const sel = v.classList.contains("verse-selected");
+    const prevSel = sel && i > 0 && verses[i - 1].classList.contains("verse-selected");
+    const nextSel = sel && i < verses.length - 1 && verses[i + 1].classList.contains("verse-selected");
+    v.classList.toggle("verse-selected-join-prev", prevSel);
+    v.classList.toggle("verse-selected-join-next", nextSel);
+  }
+}
+
 function enterVerseSelectMode(bookId, chapter) {
   _verseSelectMode = true;
   _selectedVerseRefs.clear();
@@ -4305,7 +4323,8 @@ function exitVerseSelectMode() {
   _selectedVerseRefs.clear();
   document.body.classList.remove("verse-select-active");
   $verseSelectBar.hidden = true;
-  document.querySelectorAll(".verse-selected").forEach(v => v.classList.remove("verse-selected"));
+  document.querySelectorAll(".verse-selected, .verse-selected-join-prev, .verse-selected-join-next")
+    .forEach(v => v.classList.remove("verse-selected", "verse-selected-join-prev", "verse-selected-join-next"));
 }
 
 function updateVerseSelectBar() {


### PR DESCRIPTION
## 요약

연속된 절을 북마크용으로 선택하거나, 검색·딥링크로 강조 표시할 때 절마다 `border-radius: 5px`이 적용돼 사이마다 둥근 모서리가 보이던 문제를 수정. 런(run)의 시작/끝 바깥쪽 모서리만 라운드를 유지하고, 안쪽 경계는 평평하게 이어 보이게 한다.

## 변경

- **북마크 절 선택 (`.verse-selected`)**
  - `verse-selected-join-prev` / `verse-selected-join-next` 클래스 추가 (`css/style.css`)
  - `updateVerseSelectionBoundaries()` 헬퍼 추가, 선택 토글 3개 지점(롱프레스 진입, 드래그 이동, 단순 탭)에서 호출 (`js/app.js`)
  - `exitVerseSelectMode()`에서 join 보조 클래스도 함께 정리

- **검색·딥링크 강조 (`.verse-highlight`)**
  - 동일한 join 클래스 쌍 추가
  - 강조는 동적 토글이 아니라 렌더 시점 1회 결정이므로, 렌더 루프 종료 직후 정적 패스로 `[data-vref]` 순회하며 join 클래스 부여

## 동작

- 단일 절 선택/강조: 변화 없음 (4모서리 라운드 유지)
- 비연속 구간(예: `1-3,5`): 각 런이 독립적으로 라운드 유지
- 연속 구간(예: `24-25`, `1-5`): 양 끝 바깥쪽 모서리만 라운드, 인접 경계는 평평

## 테스트

- [ ] 절 선택 모드에서 24, 25를 연속 선택해 안쪽 경계가 이어지는지 확인
- [ ] 단일 절만 선택했을 때 4모서리가 모두 라운드인지 확인
- [ ] 검색 결과에서 `…/john/5/24-25` 같은 다중 절 딥링크 진입 시 한 덩어리로 보이는지 확인
- [ ] `…/john/5/1-3,5` 같은 비연속 구간이 두 덩어리로 분리돼 보이는지 확인

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk visual/UI-only change: adds a few CSS classes and lightweight DOM class toggling to adjust border radii for adjacent verses; main risk is minor styling regressions in verse rendering/selection states.
> 
> **Overview**
> Consecutive verse *highlights* (from search/deep links) and *selections* (bookmark verse-select mode) now visually render as a single continuous block by flattening the inner border-radius between adjacent verses.
> 
> This introduces `*-join-prev`/`*-join-next` helper classes for both `.verse-highlight` and `.verse-selected` (with special handling for `.verse-poetry` vertical stacking), adds a post-render pass to mark adjacent highlighted verses, and adds `updateVerseSelectionBoundaries()` to keep selection join classes in sync during long-press, drag-select, and tap toggles (and cleans them up on exit).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b030aa6136acc03e939d257aa742a78e44f747cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->