### PR TITLE
style: 북마크 드로어 툴바 버튼 크기 확대 및 행 높이 정렬

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2199,7 +2199,7 @@ body.verse-select-active .verse[data-vref]:hover {
 #bookmark-drawer-toolbar {
   display: flex;
   gap: 0.25rem;
-  padding: 0.4rem 0.75rem;
+  padding: 0.5rem 0.75rem max(0.75rem, env(safe-area-inset-bottom, 0px));
   flex-shrink: 0;
   justify-content: flex-end;
   align-items: center;
@@ -2238,8 +2238,8 @@ body.verse-select-active .verse[data-vref]:hover {
 }
 
 .bm-toolbar-btn {
-  width: 2.2rem;
-  height: 2.2rem;
+  width: 2.4rem;
+  height: 2.4rem;
   padding: 0;
   display: flex;
   align-items: center;

--- a/index.html
+++ b/index.html
@@ -167,23 +167,23 @@
     </div>
     <div id="bookmark-drawer-toolbar">
       <button id="bm-add-folder-btn" type="button" class="bm-toolbar-btn" aria-label="새 폴더" title="새 폴더">
-        <svg width="22" height="22" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M20 6h-8l-2-2H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2zm-1 8h-3v3h-2v-3h-3v-2h3V9h2v3h3v2z"/></svg>
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M20 6h-8l-2-2H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2zm-1 8h-3v3h-2v-3h-3v-2h3V9h2v3h3v2z"/></svg>
       </button>
       <button id="bm-save-chapter-btn" type="button" class="bm-toolbar-btn" aria-label="이 장 저장" title="이 장 저장">
-        <svg width="22" height="22" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M17 3H7c-1.1 0-2 .9-2 2v16l7-3 7 3V5c0-1.1-.9-2-2-2zm-2 10h-2v2h-2v-2H9v-2h2V9h2v2h2v2z"/></svg>
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M17 3H7c-1.1 0-2 .9-2 2v16l7-3 7 3V5c0-1.1-.9-2-2-2zm-2 10h-2v2h-2v-2H9v-2h2V9h2v2h2v2z"/></svg>
       </button>
       <button id="bm-select-verses-btn" type="button" class="bm-toolbar-btn" aria-label="절 선택" title="절 선택">
-        <svg width="22" height="22" viewBox="0 -960 960 960" fill="currentColor" aria-hidden="true"><path d="M440-120v-80h80v80h-80Zm0-640v-80h80v80h-80Zm160 640v-80h80v80h-80Zm0-640v-80h80v80h-80Zm160 640v-80h80v80h-80Zm0-640v-80h80v80h-80ZM120-120v-80h80v-560h-80v-80h240v80h-80v560h80v80H120Zm560-200-56-56 63-64H400v-80h287l-63-64 56-56 160 160-160 160Z"/></svg>
+        <svg width="24" height="24" viewBox="0 -960 960 960" fill="currentColor" aria-hidden="true"><path d="M440-120v-80h80v80h-80Zm0-640v-80h80v80h-80Zm160 640v-80h80v80h-80Zm0-640v-80h80v80h-80Zm160 640v-80h80v80h-80Zm0-640v-80h80v80h-80ZM120-120v-80h80v-560h-80v-80h240v80h-80v560h80v80H120Zm560-200-56-56 63-64H400v-80h287l-63-64 56-56 160 160-160 160Z"/></svg>
       </button>
       <button id="bm-overflow-btn" type="button" class="bm-toolbar-btn" aria-label="더 보기" title="더 보기" aria-expanded="false">
-        <svg width="22" height="22" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"/></svg>
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"/></svg>
       </button>
       <div id="bm-overflow-panel" hidden>
         <button id="bm-export-btn" type="button" class="bm-toolbar-btn" aria-label="내보내기" title="내보내기">
-          <svg width="22" height="22" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M9 16h6v-6h4l-7-7-7 7h4v6zm-4 2h14v2H5v-2z"/></svg>
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M9 16h6v-6h4l-7-7-7 7h4v6zm-4 2h14v2H5v-2z"/></svg>
         </button>
         <button id="bm-import-btn" type="button" class="bm-toolbar-btn" aria-label="가져오기" title="가져오기">
-          <svg width="22" height="22" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"/></svg>
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"/></svg>
         </button>
       </div>
       <input id="bm-import-input" type="file" accept=".json" hidden aria-hidden="true">


### PR DESCRIPTION
오디오 플레이어 행과 동일한 높이가 되도록 툴바 패딩을 조정하고,
버튼은 2.2rem → 2.4rem, 아이콘은 22 → 24로 키워 가독성 개선.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure UI/CSS tweaks to bookmark drawer toolbar sizing (padding/button/icon dimensions) with no logic changes; low risk aside from minor layout regressions on small screens/safe-area devices.
> 
> **Overview**
> Adjusts the bookmark drawer toolbar sizing to better align with the audio bar row height by updating `#bookmark-drawer-toolbar` padding (including safe-area bottom inset).
> 
> Increases bookmark toolbar button hit-targets (`.bm-toolbar-btn` 2.2rem → 2.4rem) and updates the toolbar SVG icon sizes in `index.html` from 22px to 24px for improved legibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfae26102f60b9b8e6df0572f87206b122e5af1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->