### PR TITLE
fix: 모바일 검색 드로어 열릴 때 입력창 자동 포커스 및 키보드 노출

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -2723,6 +2723,22 @@ function isMobile() {
   return window.matchMedia("(max-width: 768px)").matches;
 }
 
+// Lift the sheet above the on-screen keyboard. Default Android viewport
+// behavior (`resizes-visual`) leaves position:fixed elements anchored to the
+// layout viewport, so the bottom of the sheet would sit behind the keyboard.
+function adjustSheetForKeyboard() {
+  if (!window.visualViewport || $searchSheet.hidden) return;
+  const vv = window.visualViewport;
+  const keyboardOffset = Math.max(0, window.innerHeight - vv.height - vv.offsetTop);
+  if (keyboardOffset > 0) {
+    $searchSheet.style.bottom = `${keyboardOffset}px`;
+    $searchSheet.style.maxHeight = `${vv.height * 0.95}px`;
+  } else {
+    $searchSheet.style.bottom = "";
+    $searchSheet.style.maxHeight = "";
+  }
+}
+
 function openSearchSheet(query) {
   $searchScrim.hidden = false;
   $searchSheet.hidden = false;
@@ -2732,6 +2748,10 @@ function openSearchSheet(query) {
   // Focus synchronously so iOS Safari opens the on-screen keyboard.
   // requestAnimationFrame would defer past the user-gesture context.
   $searchSheetInput.focus({ preventScroll: true });
+  if (window.visualViewport) {
+    window.visualViewport.addEventListener("resize", adjustSheetForKeyboard);
+    window.visualViewport.addEventListener("scroll", adjustSheetForKeyboard);
+  }
   if (query) runSheetSearch(query, 1);
 }
 
@@ -2739,8 +2759,14 @@ function closeSearchSheet() {
   $searchScrim.hidden = true;
   $searchSheet.hidden = true;
   $searchSheet.style.height = "";
+  $searchSheet.style.bottom = "";
+  $searchSheet.style.maxHeight = "";
   $searchFab.hidden = false;
   clearNode($searchSheetResults);
+  if (window.visualViewport) {
+    window.visualViewport.removeEventListener("resize", adjustSheetForKeyboard);
+    window.visualViewport.removeEventListener("scroll", adjustSheetForKeyboard);
+  }
 }
 
 let sheetDebounceTimer = null;

--- a/js/app.js
+++ b/js/app.js
@@ -2729,7 +2729,9 @@ function openSearchSheet(query) {
   $searchSheetInput.value = query || "";
   $searchSheetClear.hidden = !query;
   $searchFab.hidden = true;
-  requestAnimationFrame(() => $searchSheetInput.focus());
+  // Focus synchronously so iOS Safari opens the on-screen keyboard.
+  // requestAnimationFrame would defer past the user-gesture context.
+  $searchSheetInput.focus({ preventScroll: true });
   if (query) runSheetSearch(query, 1);
 }
 


### PR DESCRIPTION
iOS Safari는 사용자 제스처 컨텍스트 안에서 동기적으로 호출된 .focus()만
on-screen 키보드를 띄운다. requestAnimationFrame으로 감싸면 제스처
컨텍스트가 끊겨 키보드가 올라오지 않는 문제를 해결.

https://claude.ai/code/session_01QM2sQY1e2VFYEnpPMA8jr9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: isolated to mobile search bottom-sheet focus/viewport handling, with minimal impact outside the overlay; main risk is device/browser-specific behavior differences around `visualViewport` events.
> 
> **Overview**
> Fixes mobile search bottom-sheet behavior so the on-screen keyboard reliably appears on iOS Safari by focusing the sheet input synchronously (instead of via `requestAnimationFrame`).
> 
> Adds `visualViewport`-based repositioning (`adjustSheetForKeyboard`) to lift the fixed-position sheet above the keyboard on resize/scroll, and cleans up the added styles and event listeners when the sheet closes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a3c94722a4223ab1bd5ad0876e0a6377296928c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->