### PR TITLE
fix: 검색 시트가 키보드 위 가시 영역을 가득 채우도록 수정

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -2782,6 +2782,7 @@ function adjustSheetForKeyboard() {
     $searchSheet.style.height = `${vv.height}px`;
     $searchSheet.style.maxHeight = `${vv.height}px`;
   } else {
+    $searchSheet.style.transition = "";
     $searchSheet.style.bottom = "";
     $searchSheet.style.height = "";
     $searchSheet.style.maxHeight = "";

--- a/js/app.js
+++ b/js/app.js
@@ -2772,6 +2772,9 @@ function adjustSheetForKeyboard() {
   if (!window.visualViewport || $searchSheet.hidden) return;
   const vv = window.visualViewport;
   const keyboardOffset = Math.max(0, window.innerHeight - vv.height - vv.offsetTop);
+  // Suppress the CSS height transition so viewport adjustments snap instantly
+  // rather than lagging 200ms behind rapid visualViewport resize/scroll events.
+  $searchSheet.style.transition = "none";
   if (keyboardOffset > 0) {
     // Fill the visible viewport so the page body cannot peek through
     // the gap between the sheet and the on-screen keyboard.
@@ -2804,6 +2807,7 @@ function openSearchSheet(query) {
 function closeSearchSheet() {
   $searchScrim.hidden = true;
   $searchSheet.hidden = true;
+  $searchSheet.style.transition = "";
   $searchSheet.style.height = "";
   $searchSheet.style.bottom = "";
   $searchSheet.style.maxHeight = "";

--- a/js/app.js
+++ b/js/app.js
@@ -2773,10 +2773,14 @@ function adjustSheetForKeyboard() {
   const vv = window.visualViewport;
   const keyboardOffset = Math.max(0, window.innerHeight - vv.height - vv.offsetTop);
   if (keyboardOffset > 0) {
+    // Fill the visible viewport so the page body cannot peek through
+    // the gap between the sheet and the on-screen keyboard.
     $searchSheet.style.bottom = `${keyboardOffset}px`;
-    $searchSheet.style.maxHeight = `${vv.height * 0.95}px`;
+    $searchSheet.style.height = `${vv.height}px`;
+    $searchSheet.style.maxHeight = `${vv.height}px`;
   } else {
     $searchSheet.style.bottom = "";
+    $searchSheet.style.height = "";
     $searchSheet.style.maxHeight = "";
   }
 }


### PR DESCRIPTION
iOS Safari에서 검색 바텀 시트를 열면 시트 하단과 키보드 사이로 본문이
비치는 문제가 있었음. visualViewport 기준으로 sheet의 height를 강제 지정해
가시 뷰포트를 가득 채우도록 변경.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change affecting mobile `visualViewport` resize/scroll handling; potential minor regressions in sheet sizing/animation on edge browsers.
> 
> **Overview**
> Fixes mobile search bottom-sheet positioning when the on-screen keyboard is open by **forcing the sheet to fill the `visualViewport` height** (preventing body content from showing through the gap).
> 
> Also **disables the sheet’s height transition during `visualViewport` resize/scroll updates** to avoid a delayed/laggy animation, and ensures the transition/style overrides are reset on close.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 814ea15c11616055d275764f63505075abecce1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->