### PR TITLE
style: 절 선택 모드에서 오디오 플레이어 숨기기

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1973,6 +1973,10 @@ body.verse-select-active {
   user-select: none;
 }
 
+body.verse-select-active #audio-bar {
+  display: none;
+}
+
 body.verse-select-active .verse[data-vref] {
   cursor: pointer;
   padding: 0.1em 0.15em;

--- a/css/style.css
+++ b/css/style.css
@@ -1977,6 +1977,10 @@ body.verse-select-active #audio-bar {
   display: none;
 }
 
+body.verse-select-active #audio-bar ~ #search-fab {
+  bottom: max(1.5rem, var(--fab-lift-nav, 0px));
+}
+
 body.verse-select-active .verse[data-vref] {
   cursor: pointer;
   padding: 0.1em 0.15em;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CSS-only change that conditionally hides `#audio-bar` and tweaks `#search-fab` positioning; low risk aside from potential layout regressions on small screens.
> 
> **Overview**
> When `body.verse-select-active` is enabled, the sticky `#audio-bar` is now hidden to reduce UI clutter during verse selection.
> 
> To avoid leaving the mobile search FAB unnecessarily elevated, the `#audio-bar ~ #search-fab` bottom offset is overridden in verse-select mode to use the normal lifted-by-nav positioning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 431511ec5e424bab3d11f991f26a73ba4b8989f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->