### PR TITLE
feat: Google Drive 동기화 기능 추가

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2476,6 +2476,19 @@ body.verse-select-active .verse.verse-poetry[data-vref] {
   transition: background 0.1s;
 }
 
+.bm-row-content {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  flex: 1;
+  min-width: 0;
+}
+
+/* Mobile-only swipe-to-reveal panel; shown on viewports ≤768px (see ADR-010). */
+.bm-row-actions-mobile {
+  display: none;
+}
+
 .bm-folder-row:hover,
 .bm-bookmark-row:hover {
   background: color-mix(in srgb, var(--accent) 8%, transparent);
@@ -3097,6 +3110,90 @@ body.verse-select-active .verse.verse-poetry[data-vref] {
   outline-offset: -2px;
 }
 
+/* ── Mobile: swipe-to-reveal bookmark actions (ADR-010, 2026-05-03) ──
+   On touch viewports, hover-revealed action buttons stick open after the first
+   tap (iOS Safari treats first tap as :hover), forcing a double-tap to reach
+   edit/delete. Replace with swipe-left or long-press to reveal a slide-out
+   action panel; single tap navigates as expected. */
+@media (max-width: 768px) {
+  .bm-folder-row .bm-item-actions,
+  .bm-bookmark-row .bm-item-actions {
+    display: none;
+  }
+
+  .bm-folder-row,
+  .bm-bookmark-row {
+    position: relative;
+    overflow: hidden;
+    padding: 0;
+  }
+
+  .bm-row-content {
+    padding: 0.3rem 0.75rem;
+    background: var(--bg);
+    transition: transform 0.2s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+    will-change: transform;
+    position: relative;
+    z-index: 1;
+  }
+
+  .bm-bookmark-row.bm-active {
+    background: transparent;
+    margin-right: 0;
+    border-radius: 0;
+  }
+
+  .bm-bookmark-row.bm-active .bm-row-content {
+    background: color-mix(in srgb, var(--accent) 12%, var(--bg));
+  }
+
+  .bm-folder-row:hover,
+  .bm-bookmark-row:hover {
+    background: transparent;
+  }
+
+  .bm-bookmark-row.bm-swiped .bm-row-content,
+  .bm-folder-row.bm-swiped .bm-row-content {
+    transform: translateX(-140px);
+  }
+
+  /* Disable the snap-back transition while the finger is dragging the row. */
+  .bm-bookmark-row.bm-swiping .bm-row-content,
+  .bm-folder-row.bm-swiping .bm-row-content {
+    transition: none;
+  }
+
+  .bm-row-actions-mobile {
+    display: flex;
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    width: 140px;
+    z-index: 0;
+  }
+
+  .bm-mobile-action-btn {
+    flex: 1;
+    border: none;
+    font-family: inherit;
+    font-size: 0.85rem;
+    color: #fff;
+    cursor: pointer;
+    padding: 0;
+    min-height: 44px;
+    touch-action: manipulation;
+  }
+
+  .bm-mobile-edit-btn {
+    background: var(--accent);
+  }
+
+  .bm-mobile-delete-btn {
+    background: #c0392b;
+  }
+}
+
 /* ── Reduced motion ── */
 
 @media (prefers-reduced-motion: reduce) {
@@ -3106,5 +3203,8 @@ body.verse-select-active .verse.verse-poetry[data-vref] {
   #bookmark-drawer:not([hidden]):not(.drawer-closing),
   #bookmark-drawer.drawer-closing {
     animation: none;
+  }
+  .bm-row-content {
+    transition: none;
   }
 }

--- a/docs/decisions/010-bookmark-feature.md
+++ b/docs/decisions/010-bookmark-feature.md
@@ -1,7 +1,7 @@
 # ADR-010: 즐겨찾기(북마크) 기능 설계
 
 - 일시: 2026-04-25
-- 개정: 2026-04-26 (UI 개선)
+- 개정: 2026-04-26 (UI 개선), 2026-05-03 (모바일 행 UX)
 - 상태: 승인됨
 
 ## 결정
@@ -225,3 +225,99 @@ WCAG 일관성 유지 (북마크 드로어와 동일 패턴).
 - ~~키보드 트리 탐색~~: WAI-ARIA Tree Pattern 키보드 스펙 구현
   (`↑↓` 포커스 이동, `→←` 폴더 열기/닫기·부모 이동, `Enter`/`Space` 활성화,
   `Home`/`End` 처음·끝. 버튼·링크에서는 트리 키 무시. roving tabindex 적용)
+
+
+## 개정 (2026-05-03): 모바일 북마크 행 UX
+
+### 맥락
+
+`.bm-item-actions`(수정/삭제 버튼)는 데스크톱에서 `:hover`/`:focus-within`으로
+노출되도록 설계되었다. iOS Safari가 첫 탭을 hover로 처리하기 때문에 모바일에서
+북마크 항목으로 이동하려면 **두 번 탭**이 필요한 문제가 발생했다.
+첫 탭은 액션 버튼을 노출만 시키고, 두 번째 탭에서야 링크로 이동.
+
+### 결정
+
+**모바일(`max-width: 768px`) 한정**으로 행 UX를 다음과 같이 변경:
+
+1. **단일 탭** = 즉시 이동 (또는 폴더 펼치기)
+2. **좌측 스와이프** = 행 콘텐츠 슬라이드 → 우측에 수정/삭제 액션 노출
+3. **롱프레스 (500ms)** = 동일 액션 노출 (Android 친화 + 발견성 보강)
+4. **수직 드래그** = 기존 reorder 동작 유지 (방향 우선 결정으로 분기)
+
+데스크톱은 변경 없음 (hover-reveal 그대로 유지).
+
+### 검토한 대안
+
+#### A. 케밥(⋯) 버튼 행마다 추가
+- 장점: 발견성 최고
+- 단점: 시각적 노이즈 큼, 모바일/데스크톱 패턴 분리 필요
+
+#### B. 스와이프-투-리빌만 (롱프레스 없음)
+- 장점: iOS 표준, 단순
+- 단점: Android는 보통 롱프레스 → 다중 선택 모드. 발견성 낮음
+
+#### C. 스와이프 + 롱프레스 (채택)
+- iOS·Android 양 플랫폼 사용자가 자기 OS 습관대로 발견·사용
+- 두 제스처가 같은 결과(액션 노출)를 만들어 모델이 단순
+
+### DOM 구조
+
+행 내부에 swipe wrapper 추가:
+
+```
+li.bm-bookmark
+  div.bm-bookmark-row              ← position: relative; overflow: hidden (모바일)
+    div.bm-row-content             ← translateX로 슬라이드, 기존 flex 레이아웃 보유
+      span.bm-bookmark-type-icon
+      a.bm-bookmark-link
+      div.bm-item-actions           ← 데스크톱 hover-reveal (모바일 display:none)
+    div.bm-row-actions-mobile      ← position: absolute; right: 0 (데스크톱 display:none)
+      button.bm-mobile-edit-btn
+      button.bm-mobile-delete-btn
+```
+
+폴더 행도 동일 구조 (`.bm-folder-row` > `.bm-row-content` + `.bm-row-actions-mobile`).
+
+### 제스처 분기 로직 (`_setupDragHandle`)
+
+기존 drag-to-reorder 핸들러를 확장하여 세 모드를 단일 핸들러로 처리:
+
+| 조건 | 모드 |
+|------|------|
+| 모바일 + 5px 미만 + 500ms 유지 | `longpress` → 액션 노출 |
+| 모바일 + `|Δx| > |Δy|` (5px 이상) | `swipe` → 실시간 transform |
+| 그 외 (데스크톱 또는 수직 우세) | `drag` → 기존 reorder |
+| 5px 미만에서 pointerup | 분류되지 않음 → 링크/토글 click 정상 처리 |
+
+스와이프 종료 임계값: `-SWIPE_REVEAL_PX / 2`(70px) 이상 좌측 이동 시 reveal 고정,
+미만이면 0으로 스냅 백.
+
+### 자동 닫기
+
+- 다른 행 스와이프/롱프레스 시 이전 행 close (`_swipedRow` 단일 추적)
+- 드로어 빈 영역 탭 시 close (`$bookmarkDrawerBody` pointerdown listener)
+- 드로어 닫힘, `renderBookmarkTree()` 재실행 시 close
+- 스와이프된 행의 link/folder 영역 탭 = 이동/펼치기 대신 close (iOS 메일과 동일)
+
+### 시각·접근성
+
+- 액션 버튼 최소 44×44 (WCAG AA 터치 타겟)
+- 수정 버튼: `var(--accent)`, 삭제 버튼: `#c0392b` (기존 `.bm-delete-btn:hover` 색상과 일관)
+- `prefers-reduced-motion`에서 transition 제거
+- 햅틱 피드백: 롱프레스 reveal 시 `navigator.vibrate(10)` (지원 시)
+- 모바일 액션 패널은 `aria-hidden="true"` (데스크톱 hover-reveal 액션이 SR-친화 경로)
+
+### 변경 파일
+
+- `js/app.js`:
+  - 신규: `closeSwipedRow()`, `_openSwipedRow()`, `_isMobileViewport()`,
+    상수 `SWIPE_REVEAL_PX = 140`, `LONG_PRESS_MS = 500`
+  - `_setupDragHandle()`: 3-mode 분기 (swipe/longpress/drag)
+  - `_buildBookmarkItem()`, `_buildFolderItem()`: `.bm-row-content` 래퍼 + `.bm-row-actions-mobile` 추가
+  - `closeBookmarkDrawer()`, `renderBookmarkTree()`: `closeSwipedRow(null)`/ref 초기화
+  - `$bookmarkDrawerBody` pointerdown: 빈 영역 탭 시 swipe close
+- `css/style.css`:
+  - 모바일 미디어 쿼리에서 `.bm-item-actions { display:none }`, swipe 슬라이드 스타일,
+    모바일 액션 버튼 스타일 추가
+  - `prefers-reduced-motion`에 `.bm-row-content { transition: none }` 추가

--- a/js/app.js
+++ b/js/app.js
@@ -1110,18 +1110,75 @@ function _updateDragIndicators(clientX, clientY) {
   }
 }
 
+// Mobile swipe-to-reveal + long-press: tracks the single revealed row so
+// opening a new one auto-closes the previous. See ADR-010 (2026-05-03).
+const SWIPE_REVEAL_PX = 140;
+const LONG_PRESS_MS = 500;
+let _swipedRow = null;
+
+function _isMobileViewport() {
+  return window.matchMedia("(max-width: 768px)").matches;
+}
+
+function closeSwipedRow(except) {
+  if (_swipedRow && _swipedRow !== except) {
+    _swipedRow.classList.remove("bm-swiped");
+    const prevContent = _swipedRow.querySelector(".bm-row-content");
+    if (prevContent) prevContent.style.transform = "";
+    _swipedRow = null;
+  }
+}
+
+function _openSwipedRow(row) {
+  closeSwipedRow(row);
+  row.classList.add("bm-swiped");
+  const content = row.querySelector(".bm-row-content");
+  if (content) content.style.transform = "";
+  _swipedRow = row;
+}
+
 function _setupDragHandle(li, row) {
   row.addEventListener("pointerdown", (e) => {
     if (e.pointerType === "mouse" && e.button !== 0) return;
     if (e.target.closest("button")) return;
+    // Buttons inside the mobile-only revealed actions live outside .bm-row-content
+    // but inside the row; the closest("button") check above already excludes them.
 
     const pointerId = e.pointerId;
     const startX = e.clientX;
     const startY = e.clientY;
     const origRect = li.getBoundingClientRect();
+    const isMobile = _isMobileViewport();
+    const swipeContent = row.querySelector(".bm-row-content");
+    const canSwipe = isMobile && !!swipeContent;
+    // null until the first significant move classifies the gesture.
+    // "drag" → reorder, "swipe" → reveal actions, "longpress" → reveal via hold
+    let mode = null;
     let dragStarted = false;
+    const startedSwiped = canSwipe && row.classList.contains("bm-swiped");
+    const baseOffset = startedSwiped ? -SWIPE_REVEAL_PX : 0;
+    let longPressTimer = null;
+
+    if (canSwipe && !startedSwiped) {
+      longPressTimer = setTimeout(() => {
+        if (mode !== null) return;
+        mode = "longpress";
+        _openSwipedRow(row);
+        if (navigator.vibrate) {
+          try { navigator.vibrate(10); } catch {}
+        }
+      }, LONG_PRESS_MS);
+    }
+
+    const clearLongPress = () => {
+      if (longPressTimer) {
+        clearTimeout(longPressTimer);
+        longPressTimer = null;
+      }
+    };
 
     const cleanupPointerHandlers = () => {
+      clearLongPress();
       document.removeEventListener("pointermove", onMove);
       document.removeEventListener("pointerup", finish);
       document.removeEventListener("pointercancel", cancel);
@@ -1132,8 +1189,37 @@ function _setupDragHandle(li, row) {
 
     function onMove(e) {
       if (e.pointerId !== pointerId) return;
+      const dx = e.clientX - startX;
+      const dy = e.clientY - startY;
+
+      if (mode === null) {
+        if (Math.hypot(dx, dy) < 5) return;
+        clearLongPress();
+        // Horizontal-dominant gesture on mobile → swipe; otherwise → drag-to-reorder.
+        if (canSwipe && Math.abs(dx) > Math.abs(dy)) {
+          mode = "swipe";
+          row.classList.add("bm-swiping");
+          row.setPointerCapture(pointerId);
+        } else {
+          mode = "drag";
+        }
+      }
+
+      if (mode === "swipe") {
+        let offset = baseOffset + dx;
+        if (offset > 0) offset = 0;
+        if (offset < -SWIPE_REVEAL_PX * 1.2) offset = -SWIPE_REVEAL_PX * 1.2;
+        if (swipeContent) swipeContent.style.transform = `translateX(${offset}px)`;
+        return;
+      }
+
+      if (mode === "longpress") {
+        // After long-press reveal, ignore further movement until pointerup.
+        return;
+      }
+
+      // mode === "drag"
       if (!dragStarted) {
-        if (Math.hypot(e.clientX - startX, e.clientY - startY) < 5) return;
         dragStarted = true;
         const ghost = document.createElement("li");
         ghost.className = "bm-drag-ghost";
@@ -1142,7 +1228,7 @@ function _setupDragHandle(li, row) {
         const rowClone = (li.querySelector(".bm-folder-row, .bm-bookmark-row") || li.firstElementChild).cloneNode(true);
         ghost.appendChild(rowClone);
         document.body.appendChild(ghost);
-        row.setPointerCapture(e.pointerId);
+        row.setPointerCapture(pointerId);
         li.classList.add("bm-dragging");
         _dragState = { id: li.dataset.id, ghost, origLi: li, startY, origTop: origRect.top };
       }
@@ -1154,6 +1240,22 @@ function _setupDragHandle(li, row) {
     function finish(e) {
       if (e.pointerId !== pointerId) return;
       cleanupPointerHandlers();
+
+      if (mode === "swipe") {
+        row.classList.remove("bm-swiping");
+        const finalOffset = baseOffset + (e.clientX - startX);
+        if (finalOffset < -SWIPE_REVEAL_PX / 2) {
+          _openSwipedRow(row);
+        } else {
+          row.classList.remove("bm-swiped");
+          if (swipeContent) swipeContent.style.transform = "";
+          if (_swipedRow === row) _swipedRow = null;
+        }
+        return;
+      }
+
+      if (mode === "longpress") return;
+
       if (!_dragState) return;
       const ds = _dragState;
       _dragState = null;
@@ -1171,6 +1273,20 @@ function _setupDragHandle(li, row) {
     function cancel(e) {
       if (e.pointerId !== pointerId) return;
       cleanupPointerHandlers();
+
+      if (mode === "swipe") {
+        row.classList.remove("bm-swiping");
+        // Snap back to the pre-gesture state on cancel.
+        if (startedSwiped) {
+          _openSwipedRow(row);
+        } else {
+          row.classList.remove("bm-swiped");
+          if (swipeContent) swipeContent.style.transform = "";
+          if (_swipedRow === row) _swipedRow = null;
+        }
+        return;
+      }
+
       if (!_dragState) return;
       _dragState.ghost.remove();
       _dragState.origLi.classList.remove("bm-dragging");
@@ -3687,6 +3803,7 @@ function openBookmarkDrawer(bookId, chapter) {
 
 function closeBookmarkDrawer() {
   if ($bookmarkDrawer.hidden || $bookmarkDrawer.classList.contains("drawer-closing")) return;
+  closeSwipedRow(null);
   $bmOverflowPanel.hidden = true;
   $bmOverflowBtn.setAttribute("aria-expanded", "false");
   const closeSeq = ++_bookmarkDrawerCloseSeq;
@@ -3739,6 +3856,7 @@ function _buildBookmarkItem(bm, depth) {
   const isActive = _isActiveBookmark(bm);
   const row = el("div", { className: "bm-bookmark-row" + (isActive ? " bm-active" : "") });
   _setupDragHandle(li, row);
+  const content = el("div", { className: "bm-row-content" });
   const typeIcon = el("span", { className: "bm-bookmark-type-icon" });
   typeIcon.appendChild(_buildBookmarkTypeIcon(isActive));
   const link = el("a", { className: "bm-bookmark-link", href: _bookmarkHref(bm), draggable: "false" });
@@ -3748,26 +3866,59 @@ function _buildBookmarkItem(bm, depth) {
   }
   link.addEventListener("click", (e) => {
     e.preventDefault();
+    if (row.classList.contains("bm-swiped")) {
+      closeSwipedRow(null);
+      return;
+    }
     closeBookmarkDrawer();
     navigate(_bookmarkHref(bm));
   });
-  const actions = el("div", { className: "bm-item-actions" });
-  const editBtn = el("button", { className: "bm-action-btn bm-edit-btn", type: "button" }, "수정");
-  editBtn.addEventListener("click", () => openSaveModal("edit", { existingId: bm.id }));
-  const delBtn = el("button", { className: "bm-action-btn bm-delete-btn", type: "button" }, "삭제");
-  delBtn.addEventListener("click", () => {
+
+  const editAction = () => {
+    closeSwipedRow(null);
+    openSaveModal("edit", { existingId: bm.id });
+  };
+  const deleteAction = () => {
     if (!window.confirm(`"${bm.label}" 북마크를 삭제할까요?`)) return;
+    closeSwipedRow(null);
     const store = loadBookmarks();
     removeItemById(store, bm.id);
     saveBookmarks(store);
     renderBookmarkTree();
     refreshBookmarkHeaderBtn();
-  });
+  };
+
+  const actions = el("div", { className: "bm-item-actions" });
+  const editBtn = el("button", { className: "bm-action-btn bm-edit-btn", type: "button" }, "수정");
+  editBtn.addEventListener("click", editAction);
+  const delBtn = el("button", { className: "bm-action-btn bm-delete-btn", type: "button" }, "삭제");
+  delBtn.addEventListener("click", deleteAction);
   actions.appendChild(editBtn);
   actions.appendChild(delBtn);
-  row.appendChild(typeIcon);
-  row.appendChild(link);
-  row.appendChild(actions);
+
+  // Mobile swipe-to-reveal actions panel (hidden on desktop via CSS).
+  // Sits behind the sliding row content; revealed when row.bm-swiped translates left.
+  const mobileActions = el("div", { className: "bm-row-actions-mobile", "aria-hidden": "true" });
+  const mEditBtn = el("button", {
+    className: "bm-mobile-action-btn bm-mobile-edit-btn",
+    type: "button",
+    "aria-label": `${bm.label} 수정`,
+  }, "수정");
+  mEditBtn.addEventListener("click", editAction);
+  const mDelBtn = el("button", {
+    className: "bm-mobile-action-btn bm-mobile-delete-btn",
+    type: "button",
+    "aria-label": `${bm.label} 삭제`,
+  }, "삭제");
+  mDelBtn.addEventListener("click", deleteAction);
+  mobileActions.appendChild(mEditBtn);
+  mobileActions.appendChild(mDelBtn);
+
+  content.appendChild(typeIcon);
+  content.appendChild(link);
+  content.appendChild(actions);
+  row.appendChild(content);
+  row.appendChild(mobileActions);
   li.appendChild(row);
   return li;
 }
@@ -3978,18 +4129,23 @@ function _buildFolderItem(folder, depth) {
   if (depth > 0) li.setAttribute("aria-level", String(depth + 1));
   const row = el("div", { className: "bm-folder-row" });
   _setupDragHandle(li, row);
+  const content = el("div", { className: "bm-row-content" });
   const toggle = el("span", { className: "bm-folder-toggle", "aria-hidden": "true" });
   toggle.appendChild(_buildFolderToggleIcon(expanded));
   const name = el("span", { className: "bm-folder-name" }, folder.name);
   row.addEventListener("click", (e) => {
-    if (e.target.closest(".bm-item-actions")) return;
+    if (e.target.closest(".bm-item-actions, .bm-row-actions-mobile")) return;
+    if (row.classList.contains("bm-swiped")) {
+      closeSwipedRow(null);
+      return;
+    }
     const newExpanded = li.getAttribute("aria-expanded") !== "true";
     li.setAttribute("aria-expanded", String(newExpanded));
     toggle.replaceChildren(_buildFolderToggleIcon(newExpanded));
   });
-  const actions = el("div", { className: "bm-item-actions" });
-  const renameBtn = el("button", { className: "bm-action-btn", type: "button" }, "수정");
-  renameBtn.addEventListener("click", () => {
+
+  const renameAction = () => {
+    closeSwipedRow(null);
     const newName = window.prompt("폴더 이름:", folder.name);
     if (!newName || !newName.trim()) return;
     const store = loadBookmarks();
@@ -3997,24 +4153,49 @@ function _buildFolderItem(folder, depth) {
     if (found) found.item.name = newName.trim();
     saveBookmarks(store);
     renderBookmarkTree();
-  });
-  const delBtn = el("button", { className: "bm-action-btn bm-delete-btn", type: "button" }, "삭제");
-  delBtn.addEventListener("click", () => {
+  };
+  const deleteAction = () => {
     const childCount = folder.children ? folder.children.length : 0;
     const msg = childCount > 0
       ? `"${folder.name}" 폴더와 안의 항목 ${childCount}개를 모두 삭제할까요?`
       : `"${folder.name}" 폴더를 삭제할까요?`;
     if (!window.confirm(msg)) return;
+    closeSwipedRow(null);
     const store = loadBookmarks();
     removeItemById(store, folder.id);
     saveBookmarks(store);
     renderBookmarkTree();
-  });
+  };
+
+  const actions = el("div", { className: "bm-item-actions" });
+  const renameBtn = el("button", { className: "bm-action-btn", type: "button" }, "수정");
+  renameBtn.addEventListener("click", renameAction);
+  const delBtn = el("button", { className: "bm-action-btn bm-delete-btn", type: "button" }, "삭제");
+  delBtn.addEventListener("click", deleteAction);
   actions.appendChild(renameBtn);
   actions.appendChild(delBtn);
-  row.appendChild(toggle);
-  row.appendChild(name);
-  row.appendChild(actions);
+
+  const mobileActions = el("div", { className: "bm-row-actions-mobile", "aria-hidden": "true" });
+  const mRenameBtn = el("button", {
+    className: "bm-mobile-action-btn bm-mobile-edit-btn",
+    type: "button",
+    "aria-label": `${folder.name} 수정`,
+  }, "수정");
+  mRenameBtn.addEventListener("click", renameAction);
+  const mDelBtn = el("button", {
+    className: "bm-mobile-action-btn bm-mobile-delete-btn",
+    type: "button",
+    "aria-label": `${folder.name} 삭제`,
+  }, "삭제");
+  mDelBtn.addEventListener("click", deleteAction);
+  mobileActions.appendChild(mRenameBtn);
+  mobileActions.appendChild(mDelBtn);
+
+  content.appendChild(toggle);
+  content.appendChild(name);
+  content.appendChild(actions);
+  row.appendChild(content);
+  row.appendChild(mobileActions);
   li.appendChild(row);
   const children = el("ul", { role: "group", className: "bm-folder-children" });
   for (const child of (folder.children || [])) {
@@ -4028,6 +4209,8 @@ function _buildFolderItem(folder, depth) {
 
 function renderBookmarkTree() {
   _renderPathname = window.location.pathname;
+  // The previously swiped row may be replaced when we re-render; drop the stale reference.
+  _swipedRow = null;
   clearNode($bookmarkDrawerBody);
   const store = loadBookmarks();
   if (!store.length) {
@@ -4073,6 +4256,13 @@ function _toggleFolder(li) {
   li.setAttribute("aria-expanded", String(newExpanded));
   if (toggle) toggle.replaceChildren(_buildFolderToggleIcon(newExpanded));
 }
+
+// Tap on empty drawer area closes any revealed mobile-swipe actions.
+$bookmarkDrawerBody.addEventListener("pointerdown", (e) => {
+  if (!_swipedRow) return;
+  if (_swipedRow.contains(e.target)) return;
+  closeSwipedRow(null);
+});
 
 $bookmarkDrawerBody.addEventListener("keydown", (e) => {
   // Ignore keypresses originating from interactive controls inside the row (buttons, inputs)

--- a/js/app.js
+++ b/js/app.js
@@ -1254,7 +1254,12 @@ function _setupDragHandle(li, row) {
         return;
       }
 
-      if (mode === "longpress") return;
+      if (mode === "longpress") {
+        // Suppress the click that the browser fires after pointerup so it doesn't
+        // immediately re-close the just-revealed action row.
+        document.addEventListener("click", (ce) => { ce.stopPropagation(); ce.preventDefault(); }, { capture: true, once: true });
+        return;
+      }
 
       if (!_dragState) return;
       const ds = _dragState;

--- a/js/drive-sync.js
+++ b/js/drive-sync.js
@@ -67,7 +67,8 @@ async function _findSyncFileId() {
 
 async function _upload() {
   if (!_accessToken) return;
-  const body = JSON.stringify(_buildSyncPayload());
+  const payload = _buildSyncPayload();
+  const body = JSON.stringify(payload);
   const fileId = await _findSyncFileId();
 
   let ok = false;
@@ -95,7 +96,7 @@ async function _upload() {
     });
     ok = res.ok;
   }
-  if (ok) localStorage.setItem(SYNC_UPDATED_KEY, String(Date.now()));
+  if (ok) localStorage.setItem(SYNC_UPDATED_KEY, String(payload.updatedAt));
 }
 
 async function _downloadAndMerge() {
@@ -120,6 +121,7 @@ async function _downloadAndMerge() {
   }
 
   // Remote is newer — apply to local
+  if (!_validateRemote(remote)) return;
   _applyRemote(remote);
   localStorage.setItem(SYNC_UPDATED_KEY, String(remote.updatedAt));
   _showSnackbar("다른 기기에서 변경된 데이터를 불러왔습니다.");

--- a/js/drive-sync.js
+++ b/js/drive-sync.js
@@ -239,7 +239,7 @@ function signOut() {
 function scheduleUpload() {
   if (!_accessToken) return;
   clearTimeout(_uploadTimer);
-  _uploadTimer = setTimeout(_upload, 300);
+  _uploadTimer = setTimeout(() => _upload().catch(() => {}), 300);
 }
 
 function isEnabled() {

--- a/js/drive-sync.js
+++ b/js/drive-sync.js
@@ -18,7 +18,7 @@ let _isRefreshing = false;
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
 function _buildSyncPayload() {
-  const get = (k) => { try { return JSON.parse(localStorage.getItem(k)); } catch { return null; } };
+  const get = (k) => { const v = localStorage.getItem(k); try { return JSON.parse(v); } catch { return v; } };
   return {
     version: 1,
     updatedAt: Date.now(),
@@ -70,9 +70,10 @@ async function _upload() {
   const body = JSON.stringify(_buildSyncPayload());
   const fileId = await _findSyncFileId();
 
+  let ok = false;
   if (fileId) {
     // Update existing file
-    await fetch(`${DRIVE_UPLOAD_API}/files/${fileId}?uploadType=media`, {
+    const res = await fetch(`${DRIVE_UPLOAD_API}/files/${fileId}?uploadType=media`, {
       method: "PATCH",
       headers: {
         Authorization: `Bearer ${_accessToken}`,
@@ -80,19 +81,21 @@ async function _upload() {
       },
       body,
     });
+    ok = res.ok;
   } else {
     // Create new file in appDataFolder
     const meta = JSON.stringify({ name: "sync.json", parents: ["appDataFolder"] });
     const form = new FormData();
     form.append("metadata", new Blob([meta], { type: "application/json" }));
     form.append("file", new Blob([body], { type: "application/json" }));
-    await fetch(`${DRIVE_UPLOAD_API}/files?uploadType=multipart`, {
+    const res = await fetch(`${DRIVE_UPLOAD_API}/files?uploadType=multipart`, {
       method: "POST",
       headers: { Authorization: `Bearer ${_accessToken}` },
       body: form,
     });
+    ok = res.ok;
   }
-  localStorage.setItem(SYNC_UPDATED_KEY, String(Date.now()));
+  if (ok) localStorage.setItem(SYNC_UPDATED_KEY, String(Date.now()));
 }
 
 async function _downloadAndMerge() {

--- a/js/drive-sync.js
+++ b/js/drive-sync.js
@@ -184,7 +184,7 @@ async function _onTokenResponse(resp) {
     _userEmail = null;
   }
   _updateSettingsUI();
-  _downloadAndMerge();
+  _downloadAndMerge().catch((err) => console.warn("[drive-sync] merge failed:", err));
 }
 
 function _initTokenClient() {
@@ -206,7 +206,7 @@ function _silentSignIn() {
 // ── Public API ────────────────────────────────────────────────────────────────
 
 function initDriveSync() {
-  if (!window.google) {
+  if (!window.google?.accounts?.oauth2) {
     // GIS not loaded yet — retry up to 20 times (10 s) then give up silently.
     if (_initRetryCount++ < 20) setTimeout(initDriveSync, 500);
     return;

--- a/sw.js
+++ b/sw.js
@@ -80,7 +80,8 @@ self.addEventListener("fetch", (event) => {
   const { hostname } = new URL(event.request.url);
 
   // Bypass cache for Google OAuth and Drive API — always network-only.
-  if (hostname.endsWith("googleapis.com") || hostname.endsWith("accounts.google.com")) {
+  const DRIVE_HOSTNAMES = ["www.googleapis.com", "content.googleapis.com", "oauth2.googleapis.com", "accounts.google.com"];
+  if (DRIVE_HOSTNAMES.includes(hostname)) {
     return;
   }
 


### PR DESCRIPTION
북마크·설정·마지막 읽기 위치를 Google Drive appDataFolder에 저장해
여러 기기 간 자동 동기화를 지원한다.

- drive-sync.js: GIS token flow 기반 인증, 업로드/다운로드/머지 구현
- 토큰 만료 시 silent re-auth 자동 시도, 실패 시 스낵바 알림
- initDriveSync 무한 재시도 방지 (최대 20회)
- hostname 기반 dev/prod Client ID 자동 분기
- 설정 팝오버에 연결·해제·계정 정보 UI 추가
- CSP에 Google OAuth·Drive API 출처 추가
- SW에서 googleapis.com 요청 캐시 바이패스
- 캐시 초기화 시 폰트 캐시 보존

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Introduces new Google OAuth token handling and Drive read/write flows plus CSP/SW policy changes; bugs here could break auth, overwrite user data, or affect offline caching behavior.
> 
> **Overview**
> Adds optional **Google Drive 동기화** to persist bookmarks, user settings, and last-read position to a `sync.json` file in Drive `appDataFolder`, including silent re-auth and conflict resolution based on `updatedAt`.
> 
> Updates the UI to manage sync (connect/disconnect + connected account info) and triggers background uploads whenever local state changes.
> 
> Adjusts security and offline behavior: expands `Content-Security-Policy` to allow Google Identity/Drive endpoints, adds `drive-sync.js` to the SW precache while bypassing SW caching for OAuth/Drive hosts, preserves font caches on “clear cache”, and improves mobile bookmark row UX with swipe/long-press action reveal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cd8ecc518b1a2789c0a4ad94390ebc7cc17b7bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->