### PR TITLE
feat: 모바일 북마크 행 스와이프·롱프레스 UX (drive-sync 분리)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2415,6 +2415,19 @@ body.verse-select-active .verse.verse-poetry[data-vref] {
   transition: background 0.1s;
 }
 
+.bm-row-content {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  flex: 1;
+  min-width: 0;
+}
+
+/* Mobile-only swipe-to-reveal panel; shown on viewports ≤768px (see ADR-010). */
+.bm-row-actions-mobile {
+  display: none;
+}
+
 .bm-folder-row:hover,
 .bm-bookmark-row:hover {
   background: color-mix(in srgb, var(--accent) 8%, transparent);
@@ -3036,6 +3049,90 @@ body.verse-select-active .verse.verse-poetry[data-vref] {
   outline-offset: -2px;
 }
 
+/* ── Mobile: swipe-to-reveal bookmark actions (ADR-010, 2026-05-03) ──
+   On touch viewports, hover-revealed action buttons stick open after the first
+   tap (iOS Safari treats first tap as :hover), forcing a double-tap to reach
+   edit/delete. Replace with swipe-left or long-press to reveal a slide-out
+   action panel; single tap navigates as expected. */
+@media (max-width: 768px) {
+  .bm-folder-row .bm-item-actions,
+  .bm-bookmark-row .bm-item-actions {
+    display: none;
+  }
+
+  .bm-folder-row,
+  .bm-bookmark-row {
+    position: relative;
+    overflow: hidden;
+    padding: 0;
+  }
+
+  .bm-row-content {
+    padding: 0.3rem 0.75rem;
+    background: var(--bg);
+    transition: transform 0.2s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+    will-change: transform;
+    position: relative;
+    z-index: 1;
+  }
+
+  .bm-bookmark-row.bm-active {
+    background: transparent;
+    margin-right: 0;
+    border-radius: 0;
+  }
+
+  .bm-bookmark-row.bm-active .bm-row-content {
+    background: color-mix(in srgb, var(--accent) 12%, var(--bg));
+  }
+
+  .bm-folder-row:hover,
+  .bm-bookmark-row:hover {
+    background: transparent;
+  }
+
+  .bm-bookmark-row.bm-swiped .bm-row-content,
+  .bm-folder-row.bm-swiped .bm-row-content {
+    transform: translateX(-140px);
+  }
+
+  /* Disable the snap-back transition while the finger is dragging the row. */
+  .bm-bookmark-row.bm-swiping .bm-row-content,
+  .bm-folder-row.bm-swiping .bm-row-content {
+    transition: none;
+  }
+
+  .bm-row-actions-mobile {
+    display: flex;
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    width: 140px;
+    z-index: 0;
+  }
+
+  .bm-mobile-action-btn {
+    flex: 1;
+    border: none;
+    font-family: inherit;
+    font-size: 0.85rem;
+    color: #fff;
+    cursor: pointer;
+    padding: 0;
+    min-height: 44px;
+    touch-action: manipulation;
+  }
+
+  .bm-mobile-edit-btn {
+    background: var(--accent);
+  }
+
+  .bm-mobile-delete-btn {
+    background: #c0392b;
+  }
+}
+
 /* ── Reduced motion ── */
 
 @media (prefers-reduced-motion: reduce) {
@@ -3045,5 +3142,8 @@ body.verse-select-active .verse.verse-poetry[data-vref] {
   #bookmark-drawer:not([hidden]):not(.drawer-closing),
   #bookmark-drawer.drawer-closing {
     animation: none;
+  }
+  .bm-row-content {
+    transition: none;
   }
 }

--- a/js/app.js
+++ b/js/app.js
@@ -1015,18 +1015,75 @@ function _updateDragIndicators(clientX, clientY) {
   }
 }
 
+// Mobile swipe-to-reveal + long-press: tracks the single revealed row so
+// opening a new one auto-closes the previous. See ADR-010 (2026-05-03).
+const SWIPE_REVEAL_PX = 140;
+const LONG_PRESS_MS = 500;
+let _swipedRow = null;
+
+function _isMobileViewport() {
+  return window.matchMedia("(max-width: 768px)").matches;
+}
+
+function closeSwipedRow(except) {
+  if (_swipedRow && _swipedRow !== except) {
+    _swipedRow.classList.remove("bm-swiped");
+    const prevContent = _swipedRow.querySelector(".bm-row-content");
+    if (prevContent) prevContent.style.transform = "";
+    _swipedRow = null;
+  }
+}
+
+function _openSwipedRow(row) {
+  closeSwipedRow(row);
+  row.classList.add("bm-swiped");
+  const content = row.querySelector(".bm-row-content");
+  if (content) content.style.transform = "";
+  _swipedRow = row;
+}
+
 function _setupDragHandle(li, row) {
   row.addEventListener("pointerdown", (e) => {
     if (e.pointerType === "mouse" && e.button !== 0) return;
     if (e.target.closest("button")) return;
+    // Buttons inside the mobile-only revealed actions live outside .bm-row-content
+    // but inside the row; the closest("button") check above already excludes them.
 
     const pointerId = e.pointerId;
     const startX = e.clientX;
     const startY = e.clientY;
     const origRect = li.getBoundingClientRect();
+    const isMobile = _isMobileViewport();
+    const swipeContent = row.querySelector(".bm-row-content");
+    const canSwipe = isMobile && !!swipeContent;
+    // null until the first significant move classifies the gesture.
+    // "drag" → reorder, "swipe" → reveal actions, "longpress" → reveal via hold
+    let mode = null;
     let dragStarted = false;
+    const startedSwiped = canSwipe && row.classList.contains("bm-swiped");
+    const baseOffset = startedSwiped ? -SWIPE_REVEAL_PX : 0;
+    let longPressTimer = null;
+
+    if (canSwipe && !startedSwiped) {
+      longPressTimer = setTimeout(() => {
+        if (mode !== null) return;
+        mode = "longpress";
+        _openSwipedRow(row);
+        if (navigator.vibrate) {
+          try { navigator.vibrate(10); } catch {}
+        }
+      }, LONG_PRESS_MS);
+    }
+
+    const clearLongPress = () => {
+      if (longPressTimer) {
+        clearTimeout(longPressTimer);
+        longPressTimer = null;
+      }
+    };
 
     const cleanupPointerHandlers = () => {
+      clearLongPress();
       document.removeEventListener("pointermove", onMove);
       document.removeEventListener("pointerup", finish);
       document.removeEventListener("pointercancel", cancel);
@@ -1037,8 +1094,37 @@ function _setupDragHandle(li, row) {
 
     function onMove(e) {
       if (e.pointerId !== pointerId) return;
+      const dx = e.clientX - startX;
+      const dy = e.clientY - startY;
+
+      if (mode === null) {
+        if (Math.hypot(dx, dy) < 5) return;
+        clearLongPress();
+        // Horizontal-dominant gesture on mobile → swipe; otherwise → drag-to-reorder.
+        if (canSwipe && Math.abs(dx) > Math.abs(dy)) {
+          mode = "swipe";
+          row.classList.add("bm-swiping");
+          row.setPointerCapture(pointerId);
+        } else {
+          mode = "drag";
+        }
+      }
+
+      if (mode === "swipe") {
+        let offset = baseOffset + dx;
+        if (offset > 0) offset = 0;
+        if (offset < -SWIPE_REVEAL_PX * 1.2) offset = -SWIPE_REVEAL_PX * 1.2;
+        if (swipeContent) swipeContent.style.transform = `translateX(${offset}px)`;
+        return;
+      }
+
+      if (mode === "longpress") {
+        // After long-press reveal, ignore further movement until pointerup.
+        return;
+      }
+
+      // mode === "drag"
       if (!dragStarted) {
-        if (Math.hypot(e.clientX - startX, e.clientY - startY) < 5) return;
         dragStarted = true;
         const ghost = document.createElement("li");
         ghost.className = "bm-drag-ghost";
@@ -1047,7 +1133,7 @@ function _setupDragHandle(li, row) {
         const rowClone = (li.querySelector(".bm-folder-row, .bm-bookmark-row") || li.firstElementChild).cloneNode(true);
         ghost.appendChild(rowClone);
         document.body.appendChild(ghost);
-        row.setPointerCapture(e.pointerId);
+        row.setPointerCapture(pointerId);
         li.classList.add("bm-dragging");
         _dragState = { id: li.dataset.id, ghost, origLi: li, startY, origTop: origRect.top };
       }
@@ -1059,6 +1145,22 @@ function _setupDragHandle(li, row) {
     function finish(e) {
       if (e.pointerId !== pointerId) return;
       cleanupPointerHandlers();
+
+      if (mode === "swipe") {
+        row.classList.remove("bm-swiping");
+        const finalOffset = baseOffset + (e.clientX - startX);
+        if (finalOffset < -SWIPE_REVEAL_PX / 2) {
+          _openSwipedRow(row);
+        } else {
+          row.classList.remove("bm-swiped");
+          if (swipeContent) swipeContent.style.transform = "";
+          if (_swipedRow === row) _swipedRow = null;
+        }
+        return;
+      }
+
+      if (mode === "longpress") return;
+
       if (!_dragState) return;
       const ds = _dragState;
       _dragState = null;
@@ -1076,6 +1178,20 @@ function _setupDragHandle(li, row) {
     function cancel(e) {
       if (e.pointerId !== pointerId) return;
       cleanupPointerHandlers();
+
+      if (mode === "swipe") {
+        row.classList.remove("bm-swiping");
+        // Snap back to the pre-gesture state on cancel.
+        if (startedSwiped) {
+          _openSwipedRow(row);
+        } else {
+          row.classList.remove("bm-swiped");
+          if (swipeContent) swipeContent.style.transform = "";
+          if (_swipedRow === row) _swipedRow = null;
+        }
+        return;
+      }
+
       if (!_dragState) return;
       _dragState.ghost.remove();
       _dragState.origLi.classList.remove("bm-dragging");
@@ -3600,6 +3716,7 @@ function openBookmarkDrawer(bookId, chapter) {
 
 function closeBookmarkDrawer() {
   if ($bookmarkDrawer.hidden || $bookmarkDrawer.classList.contains("drawer-closing")) return;
+  closeSwipedRow(null);
   $bmOverflowPanel.hidden = true;
   $bmOverflowBtn.setAttribute("aria-expanded", "false");
   const closeSeq = ++_bookmarkDrawerCloseSeq;
@@ -3652,6 +3769,7 @@ function _buildBookmarkItem(bm, depth) {
   const isActive = _isActiveBookmark(bm);
   const row = el("div", { className: "bm-bookmark-row" + (isActive ? " bm-active" : "") });
   _setupDragHandle(li, row);
+  const content = el("div", { className: "bm-row-content" });
   const typeIcon = el("span", { className: "bm-bookmark-type-icon" });
   typeIcon.appendChild(_buildBookmarkTypeIcon(isActive));
   const link = el("a", { className: "bm-bookmark-link", href: _bookmarkHref(bm), draggable: "false" });
@@ -3661,26 +3779,59 @@ function _buildBookmarkItem(bm, depth) {
   }
   link.addEventListener("click", (e) => {
     e.preventDefault();
+    if (row.classList.contains("bm-swiped")) {
+      closeSwipedRow(null);
+      return;
+    }
     closeBookmarkDrawer();
     navigate(_bookmarkHref(bm));
   });
-  const actions = el("div", { className: "bm-item-actions" });
-  const editBtn = el("button", { className: "bm-action-btn bm-edit-btn", type: "button" }, "수정");
-  editBtn.addEventListener("click", () => openSaveModal("edit", { existingId: bm.id }));
-  const delBtn = el("button", { className: "bm-action-btn bm-delete-btn", type: "button" }, "삭제");
-  delBtn.addEventListener("click", () => {
+
+  const editAction = () => {
+    closeSwipedRow(null);
+    openSaveModal("edit", { existingId: bm.id });
+  };
+  const deleteAction = () => {
     if (!window.confirm(`"${bm.label}" 북마크를 삭제할까요?`)) return;
+    closeSwipedRow(null);
     const store = loadBookmarks();
     removeItemById(store, bm.id);
     saveBookmarks(store);
     renderBookmarkTree();
     refreshBookmarkHeaderBtn();
-  });
+  };
+
+  const actions = el("div", { className: "bm-item-actions" });
+  const editBtn = el("button", { className: "bm-action-btn bm-edit-btn", type: "button" }, "수정");
+  editBtn.addEventListener("click", editAction);
+  const delBtn = el("button", { className: "bm-action-btn bm-delete-btn", type: "button" }, "삭제");
+  delBtn.addEventListener("click", deleteAction);
   actions.appendChild(editBtn);
   actions.appendChild(delBtn);
-  row.appendChild(typeIcon);
-  row.appendChild(link);
-  row.appendChild(actions);
+
+  // Mobile swipe-to-reveal actions panel (hidden on desktop via CSS).
+  // Sits behind the sliding row content; revealed when row.bm-swiped translates left.
+  const mobileActions = el("div", { className: "bm-row-actions-mobile", "aria-hidden": "true" });
+  const mEditBtn = el("button", {
+    className: "bm-mobile-action-btn bm-mobile-edit-btn",
+    type: "button",
+    "aria-label": `${bm.label} 수정`,
+  }, "수정");
+  mEditBtn.addEventListener("click", editAction);
+  const mDelBtn = el("button", {
+    className: "bm-mobile-action-btn bm-mobile-delete-btn",
+    type: "button",
+    "aria-label": `${bm.label} 삭제`,
+  }, "삭제");
+  mDelBtn.addEventListener("click", deleteAction);
+  mobileActions.appendChild(mEditBtn);
+  mobileActions.appendChild(mDelBtn);
+
+  content.appendChild(typeIcon);
+  content.appendChild(link);
+  content.appendChild(actions);
+  row.appendChild(content);
+  row.appendChild(mobileActions);
   li.appendChild(row);
   return li;
 }
@@ -3891,18 +4042,23 @@ function _buildFolderItem(folder, depth) {
   if (depth > 0) li.setAttribute("aria-level", String(depth + 1));
   const row = el("div", { className: "bm-folder-row" });
   _setupDragHandle(li, row);
+  const content = el("div", { className: "bm-row-content" });
   const toggle = el("span", { className: "bm-folder-toggle", "aria-hidden": "true" });
   toggle.appendChild(_buildFolderToggleIcon(expanded));
   const name = el("span", { className: "bm-folder-name" }, folder.name);
   row.addEventListener("click", (e) => {
-    if (e.target.closest(".bm-item-actions")) return;
+    if (e.target.closest(".bm-item-actions, .bm-row-actions-mobile")) return;
+    if (row.classList.contains("bm-swiped")) {
+      closeSwipedRow(null);
+      return;
+    }
     const newExpanded = li.getAttribute("aria-expanded") !== "true";
     li.setAttribute("aria-expanded", String(newExpanded));
     toggle.replaceChildren(_buildFolderToggleIcon(newExpanded));
   });
-  const actions = el("div", { className: "bm-item-actions" });
-  const renameBtn = el("button", { className: "bm-action-btn", type: "button" }, "수정");
-  renameBtn.addEventListener("click", () => {
+
+  const renameAction = () => {
+    closeSwipedRow(null);
     const newName = window.prompt("폴더 이름:", folder.name);
     if (!newName || !newName.trim()) return;
     const store = loadBookmarks();
@@ -3910,24 +4066,49 @@ function _buildFolderItem(folder, depth) {
     if (found) found.item.name = newName.trim();
     saveBookmarks(store);
     renderBookmarkTree();
-  });
-  const delBtn = el("button", { className: "bm-action-btn bm-delete-btn", type: "button" }, "삭제");
-  delBtn.addEventListener("click", () => {
+  };
+  const deleteAction = () => {
     const childCount = folder.children ? folder.children.length : 0;
     const msg = childCount > 0
       ? `"${folder.name}" 폴더와 안의 항목 ${childCount}개를 모두 삭제할까요?`
       : `"${folder.name}" 폴더를 삭제할까요?`;
     if (!window.confirm(msg)) return;
+    closeSwipedRow(null);
     const store = loadBookmarks();
     removeItemById(store, folder.id);
     saveBookmarks(store);
     renderBookmarkTree();
-  });
+  };
+
+  const actions = el("div", { className: "bm-item-actions" });
+  const renameBtn = el("button", { className: "bm-action-btn", type: "button" }, "수정");
+  renameBtn.addEventListener("click", renameAction);
+  const delBtn = el("button", { className: "bm-action-btn bm-delete-btn", type: "button" }, "삭제");
+  delBtn.addEventListener("click", deleteAction);
   actions.appendChild(renameBtn);
   actions.appendChild(delBtn);
-  row.appendChild(toggle);
-  row.appendChild(name);
-  row.appendChild(actions);
+
+  const mobileActions = el("div", { className: "bm-row-actions-mobile", "aria-hidden": "true" });
+  const mRenameBtn = el("button", {
+    className: "bm-mobile-action-btn bm-mobile-edit-btn",
+    type: "button",
+    "aria-label": `${folder.name} 수정`,
+  }, "수정");
+  mRenameBtn.addEventListener("click", renameAction);
+  const mDelBtn = el("button", {
+    className: "bm-mobile-action-btn bm-mobile-delete-btn",
+    type: "button",
+    "aria-label": `${folder.name} 삭제`,
+  }, "삭제");
+  mDelBtn.addEventListener("click", deleteAction);
+  mobileActions.appendChild(mRenameBtn);
+  mobileActions.appendChild(mDelBtn);
+
+  content.appendChild(toggle);
+  content.appendChild(name);
+  content.appendChild(actions);
+  row.appendChild(content);
+  row.appendChild(mobileActions);
   li.appendChild(row);
   const children = el("ul", { role: "group", className: "bm-folder-children" });
   for (const child of (folder.children || [])) {
@@ -3941,6 +4122,8 @@ function _buildFolderItem(folder, depth) {
 
 function renderBookmarkTree() {
   _renderPathname = window.location.pathname;
+  // The previously swiped row may be replaced when we re-render; drop the stale reference.
+  _swipedRow = null;
   clearNode($bookmarkDrawerBody);
   const store = loadBookmarks();
   if (!store.length) {
@@ -3986,6 +4169,13 @@ function _toggleFolder(li) {
   li.setAttribute("aria-expanded", String(newExpanded));
   if (toggle) toggle.replaceChildren(_buildFolderToggleIcon(newExpanded));
 }
+
+// Tap on empty drawer area closes any revealed mobile-swipe actions.
+$bookmarkDrawerBody.addEventListener("pointerdown", (e) => {
+  if (!_swipedRow) return;
+  if (_swipedRow.contains(e.target)) return;
+  closeSwipedRow(null);
+});
 
 $bookmarkDrawerBody.addEventListener("keydown", (e) => {
   // Ignore keypresses originating from interactive controls inside the row (buttons, inputs)

--- a/js/app.js
+++ b/js/app.js
@@ -1159,7 +1159,12 @@ function _setupDragHandle(li, row) {
         return;
       }
 
-      if (mode === "longpress") return;
+      if (mode === "longpress") {
+        // Suppress the click that the browser fires after pointerup so it doesn't
+        // immediately re-close the just-revealed action row.
+        document.addEventListener("click", (ce) => { ce.stopPropagation(); ce.preventDefault(); }, { capture: true, once: true });
+        return;
+      }
 
       if (!_dragState) return;
       const ds = _dragState;


### PR DESCRIPTION
## Summary

- **모바일 북마크 행 swipe/longpress UX 살리기**: 기존 `feat/drive-sync` PR #20에서 drive-sync 코드와 함께 묶여 있던 비-sync 변경 2개를 분리해 main에 반영
- **drive-sync는 폐기 예정**: PR #20의 [`js/drive-sync.js`](https://github.com/anglican-kr/common-bible/blob/feat/drive-sync/js/drive-sync.js) 및 18개 fix 커밋은 ADR-011 재설계(별도 PR 1~4)로 대체하기 위해 통째로 폐기하기로 결정 (`docs/decisions/011-bookmark-sync.md` 재작성 예정)

## 포함된 커밋

| 원본 | 내용 |
|------|------|
| `7139d9b` | `css/style.css` + `js/app.js` — iOS Safari `:hover` 첫 탭 문제 해소를 위한 모바일 행 swipe·longpress·single-tap 분기 |
| `931f47` | `js/app.js` — 롱프레스 후 발생하는 `click` 이벤트가 노출된 액션 패널을 즉시 닫는 버그 수정 (capture·once로 직후 1회 click 흡수) |

원본 커밋들이 drive-sync와 한 브랜치에 섞여 있었으나, 두 커밋의 변경 내용에는 drive-sync 의존이 없음. 본 PR은 `main` 기준으로 cherry-pick·conflict 해소(드라이브 디스컨넥트 모달 css 제외)를 거친 결과.

ADR-010의 모바일 행 UX 개정 블록은 PR #21에서 이미 main에 반영됨.

## Test plan

- [ ] 모바일 뷰포트(≤768px)에서 북마크 행 단일 탭 = 즉시 이동
- [ ] 좌측 스와이프 = 우측에 수정/삭제 액션 슬라이드 노출
- [ ] 롱프레스(500ms) = 동일 액션 노출, 손 떼고 외부 탭 시 정상 닫힘
- [ ] 롱프레스로 액션 노출 후 액션 버튼 클릭이 정상 동작 (즉시 닫히지 않음)
- [ ] 데스크톱 hover-reveal UX 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk: changes pointer/gesture handling for bookmark rows and modifies the DOM structure/CSS for those rows, which could introduce regressions in drag-to-reorder or tap navigation on mobile/desktop.
> 
> **Overview**
> Improves mobile bookmark-drawer UX by replacing hover-revealed row actions with a **swipe-left or 500ms long-press** slide-out action panel, avoiding iOS Safari’s first-tap-creates-`:hover` double-tap issue.
> 
> Updates bookmark/folder row markup to wrap content in `bm-row-content` and adds a hidden `bm-row-actions-mobile` panel (edit/delete) that is revealed via `bm-swiped`/`bm-swiping` classes; adds logic to ensure only one row is revealed at a time and to auto-close the panel when tapping elsewhere or closing the drawer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 399585af226a90126b6b04dbfb1973d620339f9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->