### PR TITLE
feat: Drive 동기화 v2 스키마 — per-record LWW + 마이그레이션 (PR 2/4)

### DIFF
--- a/index.html
+++ b/index.html
@@ -250,6 +250,7 @@
   <!-- Drive sync modules (load order matters: debug-log → transport → state-machine → facade) -->
   <script defer src="/js/sync/debug-log.js"></script>
   <script defer src="/js/sync/transport.js"></script>
+  <script defer src="/js/sync/store-v2.js"></script>
   <script defer src="/js/sync/state-machine.js"></script>
   <script defer src="/js/drive-sync.js"></script>
   <script defer src="/js/gtag-init.js"></script>

--- a/js/app.js
+++ b/js/app.js
@@ -114,7 +114,9 @@ let _dragState = null; // { id, ghost, origLi, startY, origTop }
 
 function saveReadingPosition(bookId, chapter, verse = null) {
   try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify({ bookId, chapter, verse }));
+    const val = { bookId, chapter, verse };
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(val));
+    window.syncStoreV2?.saveLastRead(val);
     if (window.driveSync) window.driveSync.scheduleUpload();
   } catch (_) {}
 }
@@ -180,6 +182,7 @@ function loadStartupBehavior() {
 
 function saveStartupBehavior(val) {
   localStorage.setItem(STARTUP_BEHAVIOR_KEY, val);
+  window.syncStoreV2?.saveSetting("startupBehavior", val);
   if (window.driveSync) window.driveSync.scheduleUpload();
 }
 
@@ -195,7 +198,7 @@ function loadFontSize() {
 }
 
 function saveFontSize(size) {
-  try { localStorage.setItem(FONT_SIZE_KEY, String(size)); if (window.driveSync) window.driveSync.scheduleUpload(); } catch (_) {}
+  try { localStorage.setItem(FONT_SIZE_KEY, String(size)); window.syncStoreV2?.saveSetting("fontSize", size); if (window.driveSync) window.driveSync.scheduleUpload(); } catch (_) {}
 }
 
 function applyFontSize(size) {
@@ -655,7 +658,7 @@ function loadColorScheme() {
 }
 
 function saveColorScheme(scheme) {
-  try { localStorage.setItem(COLOR_SCHEME_KEY, scheme); if (window.driveSync) window.driveSync.scheduleUpload(); } catch (_) {}
+  try { localStorage.setItem(COLOR_SCHEME_KEY, scheme); window.syncStoreV2?.saveSetting("colorScheme", scheme); if (window.driveSync) window.driveSync.scheduleUpload(); } catch (_) {}
 }
 
 // Default favicon/apple-touch-icon URLs as shipped in index.html.
@@ -700,7 +703,7 @@ function loadTheme() {
 }
 
 function saveTheme(theme) {
-  try { localStorage.setItem(THEME_KEY, theme); if (window.driveSync) window.driveSync.scheduleUpload(); } catch (_) {}
+  try { localStorage.setItem(THEME_KEY, theme); window.syncStoreV2?.saveSetting("theme", theme); if (window.driveSync) window.driveSync.scheduleUpload(); } catch (_) {}
 }
 
 let _systemThemeListener = null;
@@ -742,10 +745,11 @@ function loadBookOrder() {
 }
 
 function saveBookOrder(order) {
-  try { localStorage.setItem(BOOK_ORDER_KEY, order); if (window.driveSync) window.driveSync.scheduleUpload(); } catch (_) {}
+  try { localStorage.setItem(BOOK_ORDER_KEY, order); window.syncStoreV2?.saveSetting("bookOrder", order); if (window.driveSync) window.driveSync.scheduleUpload(); } catch (_) {}
 }
 
 // Apply saved settings on load
+window.syncStoreV2?.migrateLegacyIfNeeded();
 applyFontSize(loadFontSize());
 applyTheme(loadTheme());
 applyColorScheme(loadColorScheme());
@@ -824,6 +828,7 @@ function generateId() {
 }
 
 function loadBookmarks() {
+  if (window.syncStoreV2) return window.syncStoreV2.loadBookmarks();
   try {
     const raw = localStorage.getItem(BOOKMARK_KEY);
     return raw ? JSON.parse(raw) : [];
@@ -833,6 +838,7 @@ function loadBookmarks() {
 function saveBookmarks(store) {
   try {
     localStorage.setItem(BOOKMARK_KEY, JSON.stringify(store));
+    window.syncStoreV2?.saveBookmarks(store);
     if (window.driveSync) window.driveSync.scheduleUpload();
   } catch (_) {}
 }

--- a/js/sync/state-machine.js
+++ b/js/sync/state-machine.js
@@ -39,17 +39,9 @@ const SILENT_FAIL_REASONS = new Set([
 // ── Factory ───────────────────────────────────────────────────────────────────
 
 function createSyncMachine({ onStateChange } = {}) {
-  // Storage keys — kept inside closure to avoid colliding with app.js globals.
-  const SYNC_ENABLED_KEY  = "bible-drive-sync";
-  const SYNC_UPDATED_KEY  = "bible-drive-sync-updated";
-  const SYNC_EMAIL_KEY    = "bible-drive-sync-email";
-  const BM_KEY            = "bible-bookmarks";
-  const FS_KEY            = "bible-font-size";
-  const CS_KEY            = "bible-color-scheme";
-  const TH_KEY            = "bible-theme";
-  const BO_KEY            = "bible-book-order";
-  const SU_KEY            = "bible-startup";
-  const LR_KEY            = "bible-last-read";
+  // Storage keys
+  const SYNC_ENABLED_KEY = "bible-drive-sync";
+  const SYNC_EMAIL_KEY   = "bible-drive-sync-email";
   const T = window.syncTransport;
   const L = window.syncDebugLog;
 
@@ -74,51 +66,22 @@ function createSyncMachine({ onStateChange } = {}) {
     if (typeof window._showSyncSnackbar === "function") window._showSyncSnackbar(msg);
   }
 
-  // ── v1 data operations ────────────────────────────────────────────────────
+  // ── v2 data operations (via syncStoreV2) ─────────────────────────────────────
 
-  function _buildPayload() {
-    const get = (k) => {
-      const v = localStorage.getItem(k);
-      try { return JSON.parse(v); } catch { return v; }
-    };
-    const rawBm = get(BM_KEY);
-    const bookmarks = Array.isArray(rawBm)
-      ? rawBm
-      : (rawBm?._version === 1 && Array.isArray(rawBm.items) ? rawBm.items : []);
-    return {
-      version: 1,
-      updatedAt: Date.now(),
-      bookmarks,
-      settings: {
-        fontSize:        get(FS_KEY),
-        colorScheme:     get(CS_KEY),
-        theme:           get(TH_KEY),
-        bookOrder:       get(BO_KEY),
-        startupBehavior: get(SU_KEY),
-      },
-      lastRead: get(LR_KEY),
-    };
-  }
+  const V2 = window.syncStoreV2;
+  const _deviceId = V2.getDeviceId();
 
-  function _validateRemote(data) {
-    return (
-      typeof data === "object" && data !== null &&
-      data.version === 1 &&
-      Array.isArray(data.bookmarks)
-    );
-  }
-
-  function _applyRemote(data) {
-    if (!_validateRemote(data)) return;
-    localStorage.setItem(BM_KEY, JSON.stringify(data.bookmarks));
+  function _applyMergedDoc(merged, hadRemoteChanges) {
+    V2.saveLocal(merged);
+    V2.applyToLegacyKeys(merged);
     if (typeof window.renderBookmarkTree === "function") window.renderBookmarkTree();
-    const s = data.settings ?? {};
-    if (s.fontSize        != null) { localStorage.setItem(FS_KEY, s.fontSize);        if (typeof window.applyFontSize    === "function") window.applyFontSize(s.fontSize); }
-    if (s.colorScheme     != null) { localStorage.setItem(CS_KEY, s.colorScheme);     if (typeof window.applyColorScheme === "function") window.applyColorScheme(s.colorScheme); }
-    if (s.theme           != null) { localStorage.setItem(TH_KEY, s.theme);           if (typeof window.applyTheme       === "function") window.applyTheme(s.theme); }
-    if (s.bookOrder       != null)   localStorage.setItem(BO_KEY, s.bookOrder);
-    if (s.startupBehavior != null)   localStorage.setItem(SU_KEY, s.startupBehavior);
-    if (data.lastRead     != null)   localStorage.setItem(LR_KEY, JSON.stringify(data.lastRead));
+    if (hadRemoteChanges) {
+      const s = merged.settings ?? {};
+      if (s.fontSize?.v        != null && typeof window.applyFontSize    === "function") window.applyFontSize(s.fontSize.v);
+      if (s.colorScheme?.v     != null && typeof window.applyColorScheme === "function") window.applyColorScheme(s.colorScheme.v);
+      if (s.theme?.v           != null && typeof window.applyTheme       === "function") window.applyTheme(s.theme.v);
+      _snackbar("다른 기기에서 변경된 데이터를 불러왔습니다.");
+    }
   }
 
   async function _syncCycle() {
@@ -129,13 +92,14 @@ function createSyncMachine({ onStateChange } = {}) {
       const fileId = await T.findSyncFileId(_token);
       L.log({ kind: "NETWORK", event: "FIND_FILE", fileId: L.mask("fileId", fileId) });
 
+      const local = V2.loadLocal();
+      const localMaxU = V2.maxU(local);
+
       if (!fileId) {
-        // No remote file — upload current local state.
-        const payload = _buildPayload();
+        const payload = V2.buildSyncPayload(_deviceId);
         const { ok, status } = await T.uploadSyncFile(_token, payload);
         L.log({ kind: "NETWORK", event: "UPLOAD_NEW", ok, status });
         if (status === 401) { dispatch({ type: "SYNC_FAIL", reason: "401" }); return; }
-        if (ok) localStorage.setItem(SYNC_UPDATED_KEY, String(payload.updatedAt));
         dispatch({ type: "SYNC_DONE" });
         return;
       }
@@ -145,22 +109,33 @@ function createSyncMachine({ onStateChange } = {}) {
       if (dlStatus === 401) { dispatch({ type: "SYNC_FAIL", reason: "401" }); return; }
       if (!remote) { dispatch({ type: "SYNC_DONE" }); return; }
 
-      const localUpdatedAt = Number(localStorage.getItem(SYNC_UPDATED_KEY) ?? 0) || 0;
-      const remoteUpdatedAt = Number(remote.updatedAt) || 0;
-
-      if (remoteUpdatedAt > localUpdatedAt) {
-        if (!_validateRemote(remote)) { dispatch({ type: "SYNC_DONE" }); return; }
-        _applyRemote(remote);
-        localStorage.setItem(SYNC_UPDATED_KEY, String(remoteUpdatedAt));
-        _snackbar("다른 기기에서 변경된 데이터를 불러왔습니다.");
-        L.log({ kind: "ACTION", event: "APPLIED_REMOTE", remoteUpdatedAt, localUpdatedAt });
-      } else if (remoteUpdatedAt < localUpdatedAt) {
-        const payload = _buildPayload();
+      // Remote v2: merge per-record. Remote v1 (legacy): treat as no remote data.
+      if (!V2.validateRemote(remote)) {
+        L.log({ kind: "ACTION", event: "REMOTE_SCHEMA_MISMATCH", schema: remote?.schemaVersion });
+        const payload = V2.buildSyncPayload(_deviceId);
         const { ok, status } = await T.uploadSyncFile(_token, payload, { fileId });
         L.log({ kind: "NETWORK", event: "UPLOAD_UPDATE", ok, status });
         if (status === 401) { dispatch({ type: "SYNC_FAIL", reason: "401" }); return; }
-        if (ok) localStorage.setItem(SYNC_UPDATED_KEY, String(payload.updatedAt));
+        dispatch({ type: "SYNC_DONE" });
+        return;
       }
+
+      const remoteMaxU = V2.maxU(remote);
+      const merged = V2.mergeDocs(local, remote, _deviceId);
+      const mergedMaxU = V2.maxU(merged);
+      const hadRemoteChanges = remoteMaxU > localMaxU;
+
+      L.log({ kind: "ACTION", event: "MERGE", localMaxU, remoteMaxU, mergedMaxU });
+      _applyMergedDoc(merged, hadRemoteChanges);
+
+      // Upload if merged has data remote didn't have.
+      if (mergedMaxU > remoteMaxU) {
+        const payload = V2.buildSyncPayload(_deviceId);
+        const { ok, status } = await T.uploadSyncFile(_token, payload, { fileId });
+        L.log({ kind: "NETWORK", event: "UPLOAD_UPDATE", ok, status });
+        if (status === 401) { dispatch({ type: "SYNC_FAIL", reason: "401" }); return; }
+      }
+
       dispatch({ type: "SYNC_DONE" });
     } catch (err) {
       L.log({ kind: "ERROR", event: "SYNC_EXCEPTION", reason: err.message });

--- a/js/sync/state-machine.js
+++ b/js/sync/state-machine.js
@@ -123,13 +123,31 @@ function createSyncMachine({ onStateChange } = {}) {
       const remoteMaxU = V2.maxU(remote);
       const merged = V2.mergeDocs(local, remote, _deviceId);
       const mergedMaxU = V2.maxU(merged);
-      const hadRemoteChanges = remoteMaxU > localMaxU;
 
-      L.log({ kind: "ACTION", event: "MERGE", localMaxU, remoteMaxU, mergedMaxU });
+      // Per-record comparison: did any merged record come from remote?
+      const hadRemoteChanges = (
+        Object.keys(merged.settings ?? {}).some(k =>
+          (merged.settings[k]?._u ?? 0) > (local.settings?.[k]?._u ?? 0)
+        ) ||
+        (merged.lastRead?._u ?? 0) > (local.lastRead?._u ?? 0) ||
+        Object.keys(merged.bookmarks?.items ?? {}).some(id =>
+          (merged.bookmarks.items[id]?._u ?? 0) > (local.bookmarks?.items?.[id]?._u ?? 0)
+        ) ||
+        Object.keys(merged.bookmarks?.tombstones ?? {}).some(id =>
+          (merged.bookmarks.tombstones[id] ?? 0) > (local.bookmarks?.tombstones?.[id] ?? 0)
+        )
+      );
+
+      L.log({ kind: "ACTION", event: "MERGE", localMaxU, remoteMaxU, mergedMaxU, hadRemoteChanges });
       _applyMergedDoc(merged, hadRemoteChanges);
 
-      // Upload if merged has data remote didn't have.
-      if (mergedMaxU > remoteMaxU) {
+      // Upload if merged has newer data OR more records than remote
+      // (local-only records with _u < remoteMaxU are caught by count check).
+      const remoteRecordCount = Object.keys(remote.bookmarks?.items ?? {}).length
+                              + Object.keys(remote.bookmarks?.tombstones ?? {}).length;
+      const mergedRecordCount = Object.keys(merged.bookmarks?.items ?? {}).length
+                              + Object.keys(merged.bookmarks?.tombstones ?? {}).length;
+      if (mergedMaxU > remoteMaxU || mergedRecordCount > remoteRecordCount) {
         const payload = V2.buildSyncPayload(_deviceId);
         const { ok, status } = await T.uploadSyncFile(_token, payload, { fileId });
         L.log({ kind: "NETWORK", event: "UPLOAD_UPDATE", ok, status });

--- a/js/sync/store-v2.js
+++ b/js/sync/store-v2.js
@@ -1,0 +1,309 @@
+// ── Sync Store v2 ─────────────────────────────────────────────────────────────
+// Per-record mtime (_u) + tombstones + flat-map bookmark storage.
+// Provides: loadLocal, saveLocal, loadBookmarks, saveBookmarks, save*/lastRead,
+//           migrateLegacyIfNeeded, mergeDocs, buildSyncPayload, applyToLegacyKeys.
+//
+// v2 layout in localStorage:
+//   "bible-sync-meta"       { schemaVersion: 2, deviceId }
+//   "bible-bookmarks-v2"    { bookmarks: {items, tombstones}, settings, lastRead }
+
+const _META_KEY  = "bible-sync-meta";
+const _STORE_KEY = "bible-bookmarks-v2";
+
+const _SETTING_LS_KEYS = {
+  fontSize:        "bible-font-size",
+  colorScheme:     "bible-color-scheme",
+  theme:           "bible-theme",
+  bookOrder:       "bible-book-order",
+  startupBehavior: "bible-startup",
+};
+const _LR_KEY = "bible-last-read";
+
+// ── Device ID ─────────────────────────────────────────────────────────────────
+
+function _uuid() {
+  return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (c) => {
+    const r = Math.random() * 16 | 0;
+    return (c === "x" ? r : (r & 0x3 | 0x8)).toString(16);
+  });
+}
+
+function _getOrCreateMeta() {
+  try {
+    const m = JSON.parse(localStorage.getItem(_META_KEY) ?? "null");
+    if (m?.schemaVersion === 2 && m.deviceId) return m;
+  } catch {}
+  const meta = { schemaVersion: 2, deviceId: _uuid() };
+  localStorage.setItem(_META_KEY, JSON.stringify(meta));
+  return meta;
+}
+
+function getDeviceId() { return _getOrCreateMeta().deviceId; }
+
+// ── Flat-map helpers ──────────────────────────────────────────────────────────
+
+// Recursively walk a bookmark tree and produce a flat {[id]: node} map.
+// Each node gets parentId and _order; _u is preserved if already set.
+function _flattenTree(nodes, parentId, out, now) {
+  nodes.forEach((node, idx) => {
+    const { children, ...rest } = node;
+    out[node.id] = {
+      ...rest,
+      parentId: parentId ?? null,
+      _order:   idx,
+      _u:       rest._u ?? now,
+    };
+    if (Array.isArray(children) && children.length) {
+      _flattenTree(children, node.id, out, now);
+    }
+  });
+  return out;
+}
+
+// Reconstruct a bookmark tree from a flat map.
+// Tombstoned items must already be filtered out before calling.
+function bookmarkTreeFromFlat(items) {
+  const byParent = {};
+  for (const node of Object.values(items)) {
+    const p = node.parentId ?? null;
+    (byParent[p] ??= []).push(node);
+  }
+  function build(parentId) {
+    return (byParent[parentId] ?? [])
+      .sort((a, b) => (a._order ?? 0) - (b._order ?? 0))
+      .map(({ parentId: _p, _order: _o, _u: _t, ...rest }) => {
+        const kids = build(rest.id);
+        if (kids.length)                   return { ...rest, children: kids };
+        if (rest.type === "folder")        return { ...rest, children: [] };
+        return rest;
+      });
+  }
+  return build(null);
+}
+
+// ── Empty document ────────────────────────────────────────────────────────────
+
+function _emptyDoc() {
+  return {
+    bookmarks: { items: {}, tombstones: {} },
+    settings: {
+      fontSize:        { v: null, _u: 0 },
+      colorScheme:     { v: null, _u: 0 },
+      theme:           { v: null, _u: 0 },
+      bookOrder:       { v: null, _u: 0 },
+      startupBehavior: { v: null, _u: 0 },
+    },
+    lastRead: { v: null, _u: 0 },
+  };
+}
+
+// ── Load / Save ───────────────────────────────────────────────────────────────
+
+function loadLocal() {
+  try {
+    const raw = localStorage.getItem(_STORE_KEY);
+    if (raw) return JSON.parse(raw);
+  } catch {}
+  return _emptyDoc();
+}
+
+function saveLocal(doc) {
+  try { localStorage.setItem(_STORE_KEY, JSON.stringify(doc)); } catch {}
+}
+
+// ── Bookmark CRUD (tree ↔ flat-map) ──────────────────────────────────────────
+
+// Stable content fingerprint for conflict detection (excludes positional fields).
+function _contentKey(node) {
+  const { id, type, name, vref, verseSpec, color } = node;
+  return JSON.stringify({ id, type, name, vref, verseSpec, color });
+}
+
+// Save a bookmark tree into v2 flat-map, preserving _u for unchanged items
+// and adding tombstones for removed items.
+function saveBookmarks(tree) {
+  const now = Date.now();
+  const doc = loadLocal();
+  const oldItems = doc.bookmarks.items;
+  const newFlat  = _flattenTree(tree, null, {}, now);
+
+  const nextItems = {};
+  for (const [id, node] of Object.entries(newFlat)) {
+    const old = oldItems[id];
+    const sameContent  = old && _contentKey(old)  === _contentKey(node);
+    const samePosition = old && old._order         === node._order
+                              && old.parentId       === node.parentId;
+    nextItems[id] = { ...node, _u: (sameContent && samePosition) ? (old._u ?? now) : now };
+  }
+
+  // Items removed → tombstone (only if not already tombstoned with a newer time).
+  for (const id of Object.keys(oldItems)) {
+    if (!nextItems[id] && !(doc.bookmarks.tombstones[id] > now)) {
+      doc.bookmarks.tombstones[id] = now;
+    }
+  }
+
+  doc.bookmarks.items = nextItems;
+  saveLocal(doc);
+}
+
+// Load and reconstruct the bookmark tree, filtering out tombstoned items.
+function loadBookmarks() {
+  const doc = loadLocal();
+  const { items, tombstones } = doc.bookmarks;
+  const alive = {};
+  for (const [id, node] of Object.entries(items)) {
+    if (!(tombstones[id] > node._u)) alive[id] = node;
+  }
+  return bookmarkTreeFromFlat(alive);
+}
+
+// ── Settings / lastRead ───────────────────────────────────────────────────────
+
+function saveSetting(key, value) {
+  const doc = loadLocal();
+  doc.settings[key] = { v: value, _u: Date.now() };
+  saveLocal(doc);
+}
+
+function saveLastRead(value) {
+  const doc = loadLocal();
+  doc.lastRead = { v: value, _u: Date.now() };
+  saveLocal(doc);
+}
+
+// ── Migration v0/v1 → v2 ─────────────────────────────────────────────────────
+
+function migrateLegacyIfNeeded() {
+  if (localStorage.getItem(_STORE_KEY)) return; // already migrated
+
+  const now = Date.now();
+  const doc = _emptyDoc();
+
+  // Bookmarks: detect v0 (bare array) or v1 ({ _version:1, items:[...] }).
+  try {
+    const raw = localStorage.getItem("bible-bookmarks");
+    if (raw) {
+      const parsed = JSON.parse(raw);
+      const tree = Array.isArray(parsed)
+        ? parsed
+        : (parsed?._version === 1 && Array.isArray(parsed.items) ? parsed.items : []);
+      _flattenTree(tree, null, doc.bookmarks.items, now);
+    }
+  } catch {}
+
+  // Settings: _u = 0 so that any remote data wins on first sync.
+  for (const [key, lsKey] of Object.entries(_SETTING_LS_KEYS)) {
+    const raw = localStorage.getItem(lsKey);
+    if (raw !== null) {
+      let v; try { v = JSON.parse(raw); } catch { v = raw; }
+      doc.settings[key] = { v, _u: 0 };
+    }
+  }
+
+  // lastRead
+  try {
+    const raw = localStorage.getItem(_LR_KEY);
+    if (raw) doc.lastRead = { v: JSON.parse(raw), _u: 0 };
+  } catch {}
+
+  saveLocal(doc);
+  _getOrCreateMeta();
+}
+
+// ── Merge ─────────────────────────────────────────────────────────────────────
+
+// Returns the maximum _u across all records in a doc (for quick staleness check).
+function maxU(doc) {
+  let m = 0;
+  for (const n of Object.values(doc.bookmarks?.items    ?? {})) m = Math.max(m, n._u ?? 0);
+  for (const t of Object.values(doc.bookmarks?.tombstones ?? {})) m = Math.max(m, t);
+  for (const s of Object.values(doc.settings ?? {})) m = Math.max(m, s._u ?? 0);
+  if (doc.lastRead?._u) m = Math.max(m, doc.lastRead._u);
+  return m;
+}
+
+// Per-record LWW merge. Conflict policy: higher _u wins; tie → deviceId sort.
+function mergeDocs(local, remote, deviceId) {
+  const merged = _emptyDoc();
+  const remoteDeviceId = remote.deviceId ?? "";
+
+  // Bookmarks
+  const allIds = new Set([
+    ...Object.keys(local.bookmarks?.items    ?? {}),
+    ...Object.keys(remote.bookmarks?.items   ?? {}),
+    ...Object.keys(local.bookmarks?.tombstones  ?? {}),
+    ...Object.keys(remote.bookmarks?.tombstones ?? {}),
+  ]);
+
+  for (const id of allIds) {
+    const L  = local.bookmarks?.items?.[id];
+    const R  = remote.bookmarks?.items?.[id];
+    const LT = local.bookmarks?.tombstones?.[id]  ?? -Infinity;
+    const RT = remote.bookmarks?.tombstones?.[id] ?? -Infinity;
+    const death = Math.max(LT, RT);
+    const aliveL = L && L._u > death;
+    const aliveR = R && R._u > death;
+
+    if (!aliveL && !aliveR) {
+      if (isFinite(death)) merged.bookmarks.tombstones[id] = death;
+    } else if (aliveL && aliveR) {
+      if (L._u !== R._u)         merged.bookmarks.items[id] = L._u > R._u ? L : R;
+      else                       merged.bookmarks.items[id] = deviceId <= remoteDeviceId ? L : R;
+    } else {
+      merged.bookmarks.items[id] = aliveL ? L : R;
+    }
+  }
+
+  // Settings: per-key LWW
+  for (const key of Object.keys(merged.settings)) {
+    const lv = local.settings?.[key]  ?? { v: null, _u: 0 };
+    const rv = remote.settings?.[key] ?? { v: null, _u: 0 };
+    merged.settings[key] = rv._u >= lv._u ? rv : lv;
+  }
+
+  // lastRead: LWW
+  const ll = local.lastRead  ?? { v: null, _u: 0 };
+  const rl = remote.lastRead ?? { v: null, _u: 0 };
+  merged.lastRead = rl._u >= ll._u ? rl : ll;
+
+  return merged;
+}
+
+// ── Sync payload (for upload) ─────────────────────────────────────────────────
+
+function buildSyncPayload(deviceId) {
+  const doc = loadLocal();
+  return { schemaVersion: 2, deviceId, ...doc };
+}
+
+// Validate a remote doc is v2.
+function validateRemote(data) {
+  return (
+    typeof data === "object" && data !== null &&
+    data.schemaVersion === 2 &&
+    typeof data.bookmarks?.items === "object"
+  );
+}
+
+// ── Apply remote doc to localStorage legacy keys ──────────────────────────────
+// Keeps existing app.js helpers (loadFontSize, loadTheme, etc.) working.
+
+function applyToLegacyKeys(doc) {
+  for (const [key, lsKey] of Object.entries(_SETTING_LS_KEYS)) {
+    const s = doc.settings?.[key];
+    if (s?.v != null) localStorage.setItem(lsKey, typeof s.v === "string" ? s.v : JSON.stringify(s.v));
+  }
+  if (doc.lastRead?.v != null) localStorage.setItem(_LR_KEY, JSON.stringify(doc.lastRead.v));
+}
+
+window.syncStoreV2 = {
+  getDeviceId,
+  loadLocal, saveLocal,
+  loadBookmarks, saveBookmarks,
+  saveSetting, saveLastRead,
+  migrateLegacyIfNeeded,
+  mergeDocs, maxU,
+  buildSyncPayload, validateRemote,
+  bookmarkTreeFromFlat, applyToLegacyKeys,
+};

--- a/js/sync/store-v2.js
+++ b/js/sync/store-v2.js
@@ -115,8 +115,8 @@ function saveLocal(doc) {
 
 // Stable content fingerprint for conflict detection (excludes positional fields).
 function _contentKey(node) {
-  const { id, type, name, vref, verseSpec, color } = node;
-  return JSON.stringify({ id, type, name, vref, verseSpec, color });
+  const { id, type, name, bookId, chapter, vref, verseSpec, color, label, note } = node;
+  return JSON.stringify({ id, type, name, bookId, chapter, vref, verseSpec, color, label, note });
 }
 
 // Save a bookmark tree into v2 flat-map, preserving _u for unchanged items
@@ -295,6 +295,13 @@ function applyToLegacyKeys(doc) {
     if (s?.v != null) localStorage.setItem(lsKey, typeof s.v === "string" ? s.v : JSON.stringify(s.v));
   }
   if (doc.lastRead?.v != null) localStorage.setItem(_LR_KEY, JSON.stringify(doc.lastRead.v));
+  const { items, tombstones } = doc.bookmarks ?? { items: {}, tombstones: {} };
+  const alive = {};
+  for (const [id, node] of Object.entries(items)) {
+    if (!(tombstones?.[id] > node._u)) alive[id] = node;
+  }
+  const tree = bookmarkTreeFromFlat(alive);
+  localStorage.setItem("bible-bookmarks", JSON.stringify(tree));
 }
 
 window.syncStoreV2 = {

--- a/js/sync/transport.js
+++ b/js/sync/transport.js
@@ -98,8 +98,8 @@ async function downloadSyncFile(token, fileId) {
     if (!ok) return { doc: null, etag: null, status: res.status };
     let doc;
     try { doc = await res.json(); } catch { return { doc: null, etag: null }; }
-    return { doc, etag };
-  } catch { return { doc: null, etag: null }; }
+    return { doc, etag, status: res.status };
+  } catch { return { doc: null, etag: null, status: 0 }; }
 }
 
 // Returns { ok, status, etag }. Never throws.

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Bump this version on every release. Activating a new CACHE_NAME clears all
 // prior caches (shell + data), ensuring bible/search updates reach clients.
-const CACHE_NAME = "rev-40";
+const CACHE_NAME = "rev-41";
 
 // Separate cache for Google Font files (fonts.gstatic.com).
 // Never cleared on CACHE_NAME bump — font files are content-addressed and immutable.
@@ -11,6 +11,11 @@ const SHELL_FILES = [
   "/index.html",
   "/privacy.html",
   "/js/app.js",
+  "/js/drive-sync.js",
+  "/js/sync/debug-log.js",
+  "/js/sync/transport.js",
+  "/js/sync/store-v2.js",
+  "/js/sync/state-machine.js",
   "/js/pre-fetch.js",
   "/js/gtag-init.js",
   "/js/search-worker.js",


### PR DESCRIPTION
## Summary

PR 1의 FSM 위에 **항목 단위 데이터 모델(v2)** 을 도입합니다.

### 핵심 변경

| 파일 | 내용 |
|------|------|
| `js/sync/store-v2.js` (신규) | flat-map 북마크 + per-record `_u` + tombstone + `mergeDocs` + 마이그레이션 |
| `js/sync/state-machine.js` | v1 인라인 로직 제거, syncStoreV2 기반 `_syncCycle` |
| `js/app.js` | `loadBookmarks`/`saveBookmarks`/`save*` → v2 store 동시 기록, 시작 시 마이그레이션 |
| `index.html` | `store-v2.js` 스크립트 태그 추가 |
| `sw.js` | sync 모듈 4개 SHELL_FILES 추가, rev-41 |
| `js/sync/transport.js` | `downloadSyncFile` 성공 경로 `status` 누락 수정 |

### 데이터 모델 변경

- **v1**: 문서 단위 `updatedAt` LWW → 동시 편집 시 한쪽 손실
- **v2**: 항목 단위 `_u` (mtime) + tombstone → 양쪽 변경 모두 보존

### 마이그레이션

기존 사용자(v0 bare array / v1 래퍼) → 앱 시작 시 `migrateLegacyIfNeeded()` 자동 실행. 기존 `bible-bookmarks` 키는 하위 호환용으로 유지.

### PR #24 bugbot 3건 해소

| 버그 | 해소 방법 |
|------|----------|
| 초기 동기화 후 로컬 변경 미업로드 | `maxU` 비교로 업로드 필요 여부 결정 — `else if` 구조적 제거 |
| `downloadSyncFile` `status` 누락 | 성공 경로에 `status: res.status` 추가 |
| SW 프리캐시 sync 모듈 누락 | `SHELL_FILES`에 4개 추가 |

## Test plan

- [ ] Hard refresh → 기존 북마크가 그대로 표시됨 (v0→v2 마이그레이션)
- [ ] `localStorage.getItem("bible-bookmarks-v2")` 콘솔 확인 — flat-map 구조
- [ ] 북마크 추가 → Drive 업로드 (`[sync] UPLOAD_UPDATE` 로그)
- [ ] 다른 기기에서 다른 북마크 추가 → 두 기기 모두 두 북마크 보존
- [ ] 한 기기 삭제 + 다른 기기 수정 → tombstone 우선 (삭제 시각 > 수정 시각)
- [ ] 오프라인 변경 → Drive 재연결 시 업로드

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches bookmark/settings persistence and Drive sync merge/upload logic, including automatic localStorage migration, so mistakes could cause data loss or inconsistent cross-device state despite being scoped to client-side storage.
> 
> **Overview**
> Introduces a new Drive sync **v2 data model** (`syncStoreV2`) that stores bookmarks/settings/last-read as per-record LWW entries with `_u` timestamps plus tombstones, and auto-migrates legacy `localStorage` data on startup.
> 
> Reworks the sync FSM `_syncCycle` to use v2 merge semantics (merge local+remote, apply merged doc back to legacy keys/UI, and decide uploads based on merged max `_u`/record counts) and fixes `downloadSyncFile` to always return `status`.
> 
> Wires app writes (`saveBookmarks`, `save*` settings, `saveReadingPosition`) to also persist into `syncStoreV2`, adds `store-v2.js` to `index.html`, and updates the service worker precache/revision to ship the new sync modules offline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6b81e546fb69bb8e2a9e57ff4710457519ea69c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->