### PR TITLE
feat: ETag 낙관적 동시성 + backoff + OFFLINE 상태 (PR 3/4)

### DIFF
--- a/js/drive-sync.js
+++ b/js/drive-sync.js
@@ -22,6 +22,12 @@ const _machine = window.createSyncMachine({
   },
 });
 
+// ── Network recovery ──────────────────────────────────────────────────────────
+window.addEventListener("online", () => {
+  window.syncDebugLog?.log({ kind: "ACTION", event: "NET_RECOVERED" });
+  if (_machine.isEnabled()) _machine.dispatch({ type: "NET_RECOVERED" });
+});
+
 // ── Snackbar (UI notification, called by state machine) ────────────────────────
 window._showSyncSnackbar = function (msg) {
   const el = document.createElement("div");

--- a/js/sync/state-machine.js
+++ b/js/sync/state-machine.js
@@ -253,6 +253,8 @@ function createSyncMachine({ onStateChange } = {}) {
 
       case S.IDLE:
         if (event.type === "SYNC_REQUEST") {
+          clearTimeout(_backoffTimer);
+          _backoffTimer = null;
           _setState(S.SYNCING, event);
           _syncCycle();
         } else if (event.type === "DISABLE") {
@@ -266,6 +268,8 @@ function createSyncMachine({ onStateChange } = {}) {
 
       case S.SYNCING:
         if (event.type === "SYNC_DONE") {
+          clearTimeout(_backoffTimer);
+          _backoffTimer = null;
           _netFailCount = 0;
           _conflictCount = 0;
           _setState(S.IDLE, event);

--- a/js/sync/state-machine.js
+++ b/js/sync/state-machine.js
@@ -55,6 +55,7 @@ function createSyncMachine({ onStateChange } = {}) {
   let _netFailCount = 0;    // consecutive network/5xx failures
   let _conflictCount = 0;   // consecutive 412 conflicts
   let _backoffTimer = null; // pending retry setTimeout
+  const MAX_NET_RETRIES = 5; // delays: 1s/2s/4s/8s/16s; OFFLINE after 6th failure
 
   // ── Internal helpers ───────────────────────────────────────────────────────
 
@@ -255,6 +256,8 @@ function createSyncMachine({ onStateChange } = {}) {
           _setState(S.SYNCING, event);
           _syncCycle();
         } else if (event.type === "DISABLE") {
+          clearTimeout(_backoffTimer);
+          _backoffTimer = null;
           _token = null;
           _setState(S.DISABLED, event);
           if (typeof window.rebuildDriveSyncSection === "function") window.rebuildDriveSyncSection();
@@ -292,7 +295,7 @@ function createSyncMachine({ onStateChange } = {}) {
           } else {
             // Network / 5xx — backoff retry, then OFFLINE after 5 failures.
             _netFailCount++;
-            if (_netFailCount >= 5 || !navigator.onLine) {
+            if (_netFailCount > MAX_NET_RETRIES || !navigator.onLine) {
               _setState(S.OFFLINE, event);
               if (typeof window.rebuildDriveSyncSection === "function") window.rebuildDriveSyncSection();
             } else {

--- a/js/sync/state-machine.js
+++ b/js/sync/state-machine.js
@@ -133,9 +133,10 @@ function createSyncMachine({ onStateChange } = {}) {
       if (!V2.validateRemote(remote)) {
         L.log({ kind: "ACTION", event: "REMOTE_SCHEMA_MISMATCH", schema: remote?.schemaVersion });
         const payload = V2.buildSyncPayload(_deviceId);
-        const { ok, status } = await T.uploadSyncFile(_token, payload, { fileId });
+        const { ok, status } = await T.uploadSyncFile(_token, payload, { fileId, ifMatch: etag });
         L.log({ kind: "NETWORK", event: "UPLOAD_UPDATE", ok, status });
         if (status === 401) { dispatch({ type: "SYNC_FAIL", reason: "401" }); return; }
+        if (status === 412) { dispatch({ type: "SYNC_FAIL", reason: "412" }); return; }
         dispatch({ type: "SYNC_DONE" });
         return;
       }
@@ -179,7 +180,8 @@ function createSyncMachine({ onStateChange } = {}) {
       dispatch({ type: "SYNC_DONE" });
     } catch (err) {
       L.log({ kind: "ERROR", event: "SYNC_EXCEPTION", reason: err.message });
-      dispatch({ type: "SYNC_FAIL", reason: "network" });
+      const reason = err.message === "no_token" ? "no_token" : "exception";
+      dispatch({ type: "SYNC_FAIL", reason });
     } finally {
       _syncPending = false;
     }
@@ -296,6 +298,12 @@ function createSyncMachine({ onStateChange } = {}) {
               _snackbar("동기화 충돌이 반복됩니다. 잠시 후 다시 시도해 주세요.");
               _setState(S.IDLE, event);
             }
+          } else if (event.reason === "no_token" || event.reason === "exception") {
+            // Deterministic non-network failure — retrying won't help.
+            _token = null;
+            _snackbar("동기화 중 오류가 발생했습니다. 설정에서 재연결해 주세요.");
+            _setState(S.ERROR, event);
+            if (typeof window.rebuildDriveSyncSection === "function") window.rebuildDriveSyncSection();
           } else {
             // Network / 5xx — backoff retry, then OFFLINE after 5 failures.
             _netFailCount++;

--- a/js/sync/state-machine.js
+++ b/js/sync/state-machine.js
@@ -28,6 +28,7 @@ const S = Object.freeze({
   AUTHENTICATING: "AUTHENTICATING",
   IDLE:           "IDLE",
   SYNCING:        "SYNCING",
+  OFFLINE:        "OFFLINE",
   ERROR:          "ERROR",
 });
 
@@ -49,8 +50,11 @@ function createSyncMachine({ onStateChange } = {}) {
   let _token = null;
   let _email = null;
   let _tokenClient = null;
-  let _reAuthCount = 0;   // consecutive re-auth attempts since last TOKEN_OK
-  let _syncPending = false; // true when a sync cycle is in flight
+  let _reAuthCount = 0;
+  let _syncPending = false;
+  let _netFailCount = 0;    // consecutive network/5xx failures
+  let _conflictCount = 0;   // consecutive 412 conflicts
+  let _backoffTimer = null; // pending retry setTimeout
 
   // ── Internal helpers ───────────────────────────────────────────────────────
 
@@ -64,6 +68,19 @@ function createSyncMachine({ onStateChange } = {}) {
 
   function _snackbar(msg) {
     if (typeof window._showSyncSnackbar === "function") window._showSyncSnackbar(msg);
+  }
+
+  // Exponential backoff: 1s/2s/4s/8s/16s with ±250ms jitter.
+  function _scheduleRetry() {
+    const delays = [1000, 2000, 4000, 8000, 16000];
+    const base = delays[Math.min(_netFailCount - 1, delays.length - 1)];
+    const delay = base + Math.random() * 500 - 250;
+    clearTimeout(_backoffTimer);
+    L.log({ kind: "ACTION", event: "RETRY_SCHEDULED", attempt: _netFailCount, delayMs: Math.round(delay) });
+    _backoffTimer = setTimeout(() => {
+      _backoffTimer = null;
+      if (_state === S.IDLE) dispatch({ type: "SYNC_REQUEST" });
+    }, delay);
   }
 
   // ── v2 data operations (via syncStoreV2) ─────────────────────────────────────
@@ -100,6 +117,7 @@ function createSyncMachine({ onStateChange } = {}) {
         const { ok, status } = await T.uploadSyncFile(_token, payload);
         L.log({ kind: "NETWORK", event: "UPLOAD_NEW", ok, status });
         if (status === 401) { dispatch({ type: "SYNC_FAIL", reason: "401" }); return; }
+        if (!ok) { dispatch({ type: "SYNC_FAIL", reason: `http_${status}` }); return; }
         dispatch({ type: "SYNC_DONE" });
         return;
       }
@@ -107,6 +125,7 @@ function createSyncMachine({ onStateChange } = {}) {
       const { doc: remote, etag, status: dlStatus } = await T.downloadSyncFile(_token, fileId);
       L.log({ kind: "NETWORK", event: "DOWNLOAD", status: dlStatus, etag: L.mask("etag", etag) });
       if (dlStatus === 401) { dispatch({ type: "SYNC_FAIL", reason: "401" }); return; }
+      if (dlStatus >= 500) { dispatch({ type: "SYNC_FAIL", reason: `http_${dlStatus}` }); return; }
       if (!remote) { dispatch({ type: "SYNC_DONE" }); return; }
 
       // Remote v2: merge per-record. Remote v1 (legacy): treat as no remote data.
@@ -149,15 +168,17 @@ function createSyncMachine({ onStateChange } = {}) {
                               + Object.keys(merged.bookmarks?.tombstones ?? {}).length;
       if (mergedMaxU > remoteMaxU || mergedRecordCount > remoteRecordCount) {
         const payload = V2.buildSyncPayload(_deviceId);
-        const { ok, status } = await T.uploadSyncFile(_token, payload, { fileId });
+        const { ok, status } = await T.uploadSyncFile(_token, payload, { fileId, ifMatch: etag });
         L.log({ kind: "NETWORK", event: "UPLOAD_UPDATE", ok, status });
         if (status === 401) { dispatch({ type: "SYNC_FAIL", reason: "401" }); return; }
+        if (status === 412) { dispatch({ type: "SYNC_FAIL", reason: "412" }); return; }
+        if (!ok) { dispatch({ type: "SYNC_FAIL", reason: `http_${status}` }); return; }
       }
 
       dispatch({ type: "SYNC_DONE" });
     } catch (err) {
       L.log({ kind: "ERROR", event: "SYNC_EXCEPTION", reason: err.message });
-      dispatch({ type: "SYNC_FAIL", reason: err.message });
+      dispatch({ type: "SYNC_FAIL", reason: "network" });
     } finally {
       _syncPending = false;
     }
@@ -242,6 +263,8 @@ function createSyncMachine({ onStateChange } = {}) {
 
       case S.SYNCING:
         if (event.type === "SYNC_DONE") {
+          _netFailCount = 0;
+          _conflictCount = 0;
           _setState(S.IDLE, event);
         } else if (event.type === "SYNC_FAIL") {
           if (event.reason === "401" && _reAuthCount < 3) {
@@ -255,11 +278,43 @@ function createSyncMachine({ onStateChange } = {}) {
             _snackbar("Google Drive 동기화 세션이 만료됐습니다. 설정에서 재연결해 주세요.");
             _setState(S.ERROR, event);
             if (typeof window.rebuildDriveSyncSection === "function") window.rebuildDriveSyncSection();
+          } else if (event.reason === "412") {
+            // ETag mismatch — another device uploaded concurrently. Retry sync.
+            _conflictCount++;
+            if (_conflictCount <= 3) {
+              _setState(S.IDLE, event);
+              setTimeout(() => { if (_state === S.IDLE) dispatch({ type: "SYNC_REQUEST" }); }, 200);
+            } else {
+              _conflictCount = 0;
+              _snackbar("동기화 충돌이 반복됩니다. 잠시 후 다시 시도해 주세요.");
+              _setState(S.IDLE, event);
+            }
           } else {
-            // Network / other error — return to IDLE silently (PR 3 adds backoff).
-            _setState(S.IDLE, event);
+            // Network / 5xx — backoff retry, then OFFLINE after 5 failures.
+            _netFailCount++;
+            if (_netFailCount >= 5 || !navigator.onLine) {
+              _setState(S.OFFLINE, event);
+              if (typeof window.rebuildDriveSyncSection === "function") window.rebuildDriveSyncSection();
+            } else {
+              _setState(S.IDLE, event);
+              _scheduleRetry();
+            }
           }
         } else if (event.type === "DISABLE") {
+          clearTimeout(_backoffTimer);
+          _token = null;
+          _setState(S.DISABLED, event);
+          if (typeof window.rebuildDriveSyncSection === "function") window.rebuildDriveSyncSection();
+        }
+        break;
+
+      case S.OFFLINE:
+        if (event.type === "NET_RECOVERED") {
+          _netFailCount = 0;
+          _setState(S.AUTHENTICATING, event);
+          T.requestSilentToken(_tokenClient, localStorage.getItem(SYNC_EMAIL_KEY));
+        } else if (event.type === "DISABLE") {
+          clearTimeout(_backoffTimer);
           _token = null;
           _setState(S.DISABLED, event);
           if (typeof window.rebuildDriveSyncSection === "function") window.rebuildDriveSyncSection();
@@ -268,7 +323,6 @@ function createSyncMachine({ onStateChange } = {}) {
 
       case S.ERROR:
         if (event.type === "ENABLE") {
-          // User manually retries connection.
           _reAuthCount = 0;
           _setState(S.AUTHENTICATING, event);
           T.requestConsentToken(_tokenClient);

--- a/js/sync/state-machine.js
+++ b/js/sync/state-machine.js
@@ -318,6 +318,7 @@ function createSyncMachine({ onStateChange } = {}) {
       case S.OFFLINE:
         if (event.type === "NET_RECOVERED") {
           _netFailCount = 0;
+          _conflictCount = 0;
           _setState(S.AUTHENTICATING, event);
           T.requestSilentToken(_tokenClient, localStorage.getItem(SYNC_EMAIL_KEY));
         } else if (event.type === "DISABLE") {

--- a/js/sync/state-machine.js
+++ b/js/sync/state-machine.js
@@ -126,7 +126,7 @@ function createSyncMachine({ onStateChange } = {}) {
       const { doc: remote, etag, status: dlStatus } = await T.downloadSyncFile(_token, fileId);
       L.log({ kind: "NETWORK", event: "DOWNLOAD", status: dlStatus, etag: L.mask("etag", etag) });
       if (dlStatus === 401) { dispatch({ type: "SYNC_FAIL", reason: "401" }); return; }
-      if (dlStatus >= 500) { dispatch({ type: "SYNC_FAIL", reason: `http_${dlStatus}` }); return; }
+      if (dlStatus === 0 || dlStatus >= 500) { dispatch({ type: "SYNC_FAIL", reason: `http_${dlStatus}` }); return; }
       if (!remote) { dispatch({ type: "SYNC_DONE" }); return; }
 
       // Remote v2: merge per-record. Remote v1 (legacy): treat as no remote data.

--- a/js/sync/transport.js
+++ b/js/sync/transport.js
@@ -103,17 +103,20 @@ async function downloadSyncFile(token, fileId) {
 }
 
 // Returns { ok, status, etag }. Never throws.
-async function uploadSyncFile(token, body, { fileId } = {}) {
+// Pass ifMatch to send If-Match header; Drive returns 412 if ETag mismatches.
+async function uploadSyncFile(token, body, { fileId, ifMatch } = {}) {
   const bodyStr = JSON.stringify(body);
   try {
     let res, etag;
     if (fileId) {
+      const headers = {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      };
+      if (ifMatch) headers["If-Match"] = ifMatch;
       res = await fetch(`${DRIVE_UPLOAD_API}/files/${fileId}?uploadType=media`, {
         method: "PATCH",
-        headers: {
-          Authorization: `Bearer ${token}`,
-          "Content-Type": "application/json",
-        },
+        headers,
         body: bodyStr,
       });
       etag = res.headers.get("ETag");

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Bump this version on every release. Activating a new CACHE_NAME clears all
 // prior caches (shell + data), ensuring bible/search updates reach clients.
-const CACHE_NAME = "rev-41";
+const CACHE_NAME = "rev-42";
 
 // Separate cache for Google Font files (fonts.gstatic.com).
 // Never cleared on CACHE_NAME bump — font files are content-addressed and immutable.


### PR DESCRIPTION
## Summary

PR 2의 per-record LWW 위에 **동시성 보호 + 네트워크 복원력**을 추가합니다.

### 변경 내용

| 파일 | 내용 |
|------|------|
| `js/sync/transport.js` | `uploadSyncFile`에 `ifMatch` 파라미터 — PATCH 시 `If-Match` 헤더 전송 |
| `js/sync/state-machine.js` | OFFLINE 상태, 412/5xx/network 처리, backoff retry, NET_RECOVERED |
| `js/drive-sync.js` | `window.addEventListener('online')` → dispatch NET_RECOVERED |
| `sw.js` | rev-42 캐시 버전 bump |

### ETag / If-Match

- 다운로드 시 `ETag` 저장 → 업로드 시 `If-Match` 첨부
- Drive가 ETag 불일치(다른 기기 동시 업로드) 감지 시 **412** 반환
- 412 수신 → 재다운로드 → 재머지 → 재업로드 (최대 3회)

### Exponential Backoff

- 5xx / 네트워크 오류 → 1s / 2s / 4s / 8s / 16s + ±250ms jitter
- 5회 연속 실패 또는 `navigator.onLine=false` → **OFFLINE** 상태 전환

### OFFLINE 상태

- OFFLINE 진입 시 재시도 타이머 중지
- `window 'online'` 이벤트 수신 → **NET_RECOVERED** → silent re-auth → 재동기화

## Test plan

- [ ] 두 기기에서 동시 업로드 → 412 후 재머지, 두 변경 모두 보존
- [ ] DevTools Network throttle "Offline" → `[sync] RETRY_SCHEDULED` 로그, OFFLINE 상태
- [ ] Offline 복귀 → `[sync] NET_RECOVERED` → 자동 재동기화
- [ ] backoff 로그: `delayMs` 값이 1000→2000→4000 순서로 증가
- [ ] SYNC_DONE 후 `_netFailCount` 리셋 확인 (다음 실패가 1s부터 시작)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sync error-handling and retry behavior (ETag `If-Match`, 412 conflict retries, exponential backoff, new `OFFLINE` state), which can affect data freshness and user-visible sync reliability if edge cases are missed.
> 
> **Overview**
> Adds **optimistic concurrency control** to Drive sync by passing downloaded `ETag` via `If-Match` on uploads and handling `412` conflicts with limited automatic re-sync retries.
> 
> Improves **network resilience** by classifying 0/5xx/network failures, adding exponential backoff retries, and introducing an `OFFLINE` state that recovers on the browser `online` event via a `NET_RECOVERED` dispatch and silent re-auth. Also bumps the service worker cache version to `rev-42`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0601bd083e29b2af56e896e2412639a9f9240ee2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->