### PR TITLE
refactor: Drive sync statechart 패턴 재작성 + e2e 테스트 (PR 5/5)

### DIFF
--- a/js/sync/state-machine.js
+++ b/js/sync/state-machine.js
@@ -281,7 +281,13 @@ function createSyncMachine({ onStateChange } = {}) {
 
       case S.IDLE:
         if (event.type === "SYNC_REQUEST") {
-          _transition(S.SYNCING, {}, event); // timer cleared here
+          // Carry failure counts forward — they must accumulate across retry cycles.
+          // backoffTimer is NOT carried (cleared by _transition default).
+          _transition(S.SYNCING, {
+            netFails:     _ctx.netFails,
+            conflictFails: _ctx.conflictFails,
+            reAuthFails:  _ctx.reAuthFails,
+          }, event);
           _syncCycle();
         } else if (event.type === "DISABLE") {
           _token = null;

--- a/js/sync/state-machine.js
+++ b/js/sync/state-machine.js
@@ -1,26 +1,25 @@
-// ── Sync State Machine ────────────────────────────────────────────────────────
-// Single dispatch() entry point. All GIS callbacks and fetch responses route
-// through dispatch() — never mutate state directly.
+// ── Sync State Machine (statechart) ───────────────────────────────────────────
+// Explicit context object eliminates "hidden state" bugs:
+//   _ctx = { netFails, conflictFails, reAuthFails, backoffTimer }
 //
-// States
-//   DISABLED      — sync off; token null, no ops running
-//   INITIALIZING  — waiting for GIS library to finish loading
-//   AUTHENTICATING — token request in flight (silent re-auth or consent)
-//   IDLE          — authenticated, no sync in progress
-//   SYNCING       — download/upload in progress
-//   ERROR         — persistent failure; user must reconnect manually
+// All state changes go through _transition(nextState, ctxPatch).
+// By default every transition resets all counts and clears the backoff timer.
+// To carry a value forward, pass it explicitly in ctxPatch:
+//   _transition(S.IDLE, { netFails: _ctx.netFails + 1, backoffTimer: timer })
 //
-// Events
-//   ENABLE / DISABLE
-//   GIS_READY
-//   TOKEN_OK  { token, email }
-//   TOKEN_FAIL { reason }   — reason from GIS error string
-//   SYNC_REQUEST
-//   SYNC_DONE
-//   SYNC_FAIL { reason }   — "401" | "network" | other
+// This inverts the bug pattern: "forget to reset" is impossible — you have to
+// actively opt in to preserving a value across a transition.
 //
-// PR 1 scope: v1 data logic (document-level last-write-wins, document-level
-// updatedAt). Per-record merge (v2) is added in PR 2.
+// States:  DISABLED | INITIALIZING | AUTHENTICATING | IDLE | SYNCING | OFFLINE | ERROR
+// Events:  ENABLE | DISABLE | GIS_READY | TOKEN_OK | TOKEN_FAIL | SYNC_REQUEST |
+//          SYNC_DONE | SYNC_FAIL { reason } | NET_RECOVERED
+//
+// SYNC_FAIL reasons:
+//   "401"       — token expired  → re-auth
+//   "412"       — ETag mismatch  → re-merge retry (max 3)
+//   "no_token"  — guard tripped  → ERROR (deterministic)
+//   "exception" — JS error       → ERROR (deterministic)
+//   other       — network/5xx    → backoff (max 5), then OFFLINE
 
 const S = Object.freeze({
   DISABLED:       "DISABLED",
@@ -32,62 +31,106 @@ const S = Object.freeze({
   ERROR:          "ERROR",
 });
 
-// GIS error reasons that mean "user declined" — no snackbar, no ERROR state.
 const SILENT_FAIL_REASONS = new Set([
   "user_cancel", "access_denied", "popup_closed_by_user",
 ]);
 
+const MAX_REAUTH    = 3;
+const MAX_CONFLICTS = 3;
+const MAX_NET_RETRIES = 5; // 5 retries → delays 1s/2s/4s/8s/16s; OFFLINE on 6th failure
+
 // ── Factory ───────────────────────────────────────────────────────────────────
 
 function createSyncMachine({ onStateChange } = {}) {
-  // Storage keys
   const SYNC_ENABLED_KEY = "bible-drive-sync";
   const SYNC_EMAIL_KEY   = "bible-drive-sync-email";
-  const T = window.syncTransport;
-  const L = window.syncDebugLog;
+  const T  = window.syncTransport;
+  const L  = window.syncDebugLog;
+  const V2 = window.syncStoreV2;
+  const _deviceId = V2.getDeviceId();
 
   let _state = S.DISABLED;
   let _token = null;
   let _email = null;
   let _tokenClient = null;
-  let _reAuthCount = 0;
   let _syncPending = false;
-  let _netFailCount = 0;    // consecutive network/5xx failures
-  let _conflictCount = 0;   // consecutive 412 conflicts
-  let _backoffTimer = null; // pending retry setTimeout
-  const MAX_NET_RETRIES = 5; // delays: 1s/2s/4s/8s/16s; OFFLINE after 6th failure
 
-  // ── Internal helpers ───────────────────────────────────────────────────────
+  // ── Context (all "hidden state" in one place) ─────────────────────────────
+  // Mutated only by _transition().
 
-  function _setState(next, event) {
+  let _ctx = _emptyCtx();
+
+  function _emptyCtx() {
+    return { netFails: 0, conflictFails: 0, reAuthFails: 0, backoffTimer: null };
+  }
+
+  // ── _transition: the ONLY place that changes state + context ─────────────
+  // 1. Clear pending backoff timer (always safe).
+  // 2. Reset all counts to zero.
+  // 3. Apply ctxPatch to selectively carry values forward.
+  // 4. Persist enabled flag; fire onStateChange.
+
+  function _transition(next, ctxPatch = {}, event) {
+    clearTimeout(_ctx.backoffTimer);
+    _ctx = { ..._emptyCtx(), ...ctxPatch };
+
     if (next === _state) return;
-    L.log({ kind: "TRANSITION", event: event?.type, from: _state, to: next });
+    L.log({ kind: "TRANSITION", event: event?.type ?? "—", from: _state, to: next });
     _state = next;
-    localStorage.setItem(SYNC_ENABLED_KEY, next === S.DISABLED || next === S.ERROR ? "0" : "1");
+    const enabled = next !== S.DISABLED && next !== S.ERROR;
+    localStorage.setItem(SYNC_ENABLED_KEY, enabled ? "1" : "0");
     if (onStateChange) onStateChange(next);
+  }
+
+  // ── Side-effect helpers ───────────────────────────────────────────────────
+
+  function _refreshUI() {
+    if (typeof window.rebuildDriveSyncSection === "function") window.rebuildDriveSyncSection();
   }
 
   function _snackbar(msg) {
     if (typeof window._showSyncSnackbar === "function") window._showSyncSnackbar(msg);
   }
 
-  // Exponential backoff: 1s/2s/4s/8s/16s with ±250ms jitter.
-  function _scheduleRetry() {
+  function _emailHint() { return localStorage.getItem(SYNC_EMAIL_KEY); }
+
+  // Backoff timer that fires a SYNC_REQUEST if still IDLE.
+  // Stored in ctxPatch so _transition will clear it on next transition.
+  function _makeBackoffTimer(failCount) {
     const delays = [1000, 2000, 4000, 8000, 16000];
-    const base = delays[Math.min(_netFailCount - 1, delays.length - 1)];
-    const delay = base + Math.random() * 500 - 250;
-    clearTimeout(_backoffTimer);
-    L.log({ kind: "ACTION", event: "RETRY_SCHEDULED", attempt: _netFailCount, delayMs: Math.round(delay) });
-    _backoffTimer = setTimeout(() => {
-      _backoffTimer = null;
+    const base   = delays[Math.min(failCount - 1, delays.length - 1)];
+    const delay  = base + Math.random() * 500 - 250;
+    L.log({ kind: "ACTION", event: "RETRY_SCHEDULED", attempt: failCount, delayMs: Math.round(delay) });
+    return setTimeout(() => {
       if (_state === S.IDLE) dispatch({ type: "SYNC_REQUEST" });
     }, delay);
   }
 
-  // ── v2 data operations (via syncStoreV2) ─────────────────────────────────────
+  // Short timer for 412 re-sync (waits for _syncPending to clear).
+  function _makeConflictTimer() {
+    return setTimeout(() => {
+      if (_state === S.IDLE) dispatch({ type: "SYNC_REQUEST" });
+    }, 200);
+  }
 
-  const V2 = window.syncStoreV2;
-  const _deviceId = V2.getDeviceId();
+  function _reqSilentToken() {
+    T.requestSilentToken(_tokenClient, _emailHint());
+  }
+
+  function _storeToken(token) {
+    _token = token;
+    L.log({ kind: "ACTION", event: "TOKEN_STORED", token: L.mask("token", token) });
+    T.fetchUserInfo(token).then(({ email }) => {
+      _email = email;
+      localStorage.setItem(SYNC_EMAIL_KEY, email ?? "");
+      L.log({ kind: "ACTION", event: "EMAIL_FETCHED", email: L.mask("email", email) });
+      if (email) _refreshUI();
+    }).catch((err) => {
+      L.log({ kind: "ERROR", event: "EMAIL_FETCH_FAILED", reason: err.message });
+    });
+  }
+
+  // ── v2 data operations ────────────────────────────────────────────────────
 
   function _applyMergedDoc(merged, hadRemoteChanges) {
     V2.saveLocal(merged);
@@ -95,9 +138,9 @@ function createSyncMachine({ onStateChange } = {}) {
     if (typeof window.renderBookmarkTree === "function") window.renderBookmarkTree();
     if (hadRemoteChanges) {
       const s = merged.settings ?? {};
-      if (s.fontSize?.v        != null && typeof window.applyFontSize    === "function") window.applyFontSize(s.fontSize.v);
-      if (s.colorScheme?.v     != null && typeof window.applyColorScheme === "function") window.applyColorScheme(s.colorScheme.v);
-      if (s.theme?.v           != null && typeof window.applyTheme       === "function") window.applyTheme(s.theme.v);
+      if (s.fontSize?.v    != null && typeof window.applyFontSize    === "function") window.applyFontSize(s.fontSize.v);
+      if (s.colorScheme?.v != null && typeof window.applyColorScheme === "function") window.applyColorScheme(s.colorScheme.v);
+      if (s.theme?.v       != null && typeof window.applyTheme       === "function") window.applyTheme(s.theme.v);
       _snackbar("다른 기기에서 변경된 데이터를 불러왔습니다.");
     }
   }
@@ -107,81 +150,76 @@ function createSyncMachine({ onStateChange } = {}) {
     _syncPending = true;
     try {
       if (!_token) throw new Error("no_token");
+
       const fileId = await T.findSyncFileId(_token);
       L.log({ kind: "NETWORK", event: "FIND_FILE", fileId: L.mask("fileId", fileId) });
 
-      const local = V2.loadLocal();
-      const localMaxU = V2.maxU(local);
+      const local      = V2.loadLocal();
+      const localMaxU  = V2.maxU(local);
 
+      // ── No remote file yet: upload local state ──
       if (!fileId) {
-        const payload = V2.buildSyncPayload(_deviceId);
-        const { ok, status } = await T.uploadSyncFile(_token, payload);
+        const { ok, status } = await T.uploadSyncFile(_token, V2.buildSyncPayload(_deviceId));
         L.log({ kind: "NETWORK", event: "UPLOAD_NEW", ok, status });
-        if (status === 401) { dispatch({ type: "SYNC_FAIL", reason: "401" }); return; }
-        if (!ok) { dispatch({ type: "SYNC_FAIL", reason: `http_${status}` }); return; }
+        if (status === 401)             { dispatch({ type: "SYNC_FAIL", reason: "401" });              return; }
+        if (!ok)                        { dispatch({ type: "SYNC_FAIL", reason: `http_${status}` });   return; }
         dispatch({ type: "SYNC_DONE" });
         return;
       }
 
+      // ── Download remote ──
       const { doc: remote, etag, status: dlStatus } = await T.downloadSyncFile(_token, fileId);
       L.log({ kind: "NETWORK", event: "DOWNLOAD", status: dlStatus, etag: L.mask("etag", etag) });
-      if (dlStatus === 401) { dispatch({ type: "SYNC_FAIL", reason: "401" }); return; }
+      if (dlStatus === 401)             { dispatch({ type: "SYNC_FAIL", reason: "401" });              return; }
       if (dlStatus === 0 || dlStatus >= 500) { dispatch({ type: "SYNC_FAIL", reason: `http_${dlStatus}` }); return; }
-      if (!remote) { dispatch({ type: "SYNC_DONE" }); return; }
+      if (!remote)                      { dispatch({ type: "SYNC_DONE" });                             return; }
 
-      // Remote v2: merge per-record. Remote v1 (legacy): treat as no remote data.
+      // ── Remote is legacy v1: upgrade Drive to v2 ──
       if (!V2.validateRemote(remote)) {
         L.log({ kind: "ACTION", event: "REMOTE_SCHEMA_MISMATCH", schema: remote?.schemaVersion });
-        const payload = V2.buildSyncPayload(_deviceId);
-        const { ok, status } = await T.uploadSyncFile(_token, payload, { fileId, ifMatch: etag });
+        const { ok, status } = await T.uploadSyncFile(_token, V2.buildSyncPayload(_deviceId), { fileId, ifMatch: etag });
         L.log({ kind: "NETWORK", event: "UPLOAD_UPDATE", ok, status });
-        if (status === 401) { dispatch({ type: "SYNC_FAIL", reason: "401" }); return; }
-        if (status === 412) { dispatch({ type: "SYNC_FAIL", reason: "412" }); return; }
+        if (status === 401)             { dispatch({ type: "SYNC_FAIL", reason: "401" });              return; }
+        if (status === 412)             { dispatch({ type: "SYNC_FAIL", reason: "412" });              return; }
         dispatch({ type: "SYNC_DONE" });
         return;
       }
 
+      // ── Merge and conditionally upload ──
       const remoteMaxU = V2.maxU(remote);
-      const merged = V2.mergeDocs(local, remote, _deviceId);
+      const merged     = V2.mergeDocs(local, remote, _deviceId);
       const mergedMaxU = V2.maxU(merged);
 
-      // Per-record comparison: did any merged record come from remote?
       const hadRemoteChanges = (
         Object.keys(merged.settings ?? {}).some(k =>
-          (merged.settings[k]?._u ?? 0) > (local.settings?.[k]?._u ?? 0)
-        ) ||
+          (merged.settings[k]?._u ?? 0) > (local.settings?.[k]?._u ?? 0)) ||
         (merged.lastRead?._u ?? 0) > (local.lastRead?._u ?? 0) ||
         Object.keys(merged.bookmarks?.items ?? {}).some(id =>
-          (merged.bookmarks.items[id]?._u ?? 0) > (local.bookmarks?.items?.[id]?._u ?? 0)
-        ) ||
+          (merged.bookmarks.items[id]?._u ?? 0) > (local.bookmarks?.items?.[id]?._u ?? 0)) ||
         Object.keys(merged.bookmarks?.tombstones ?? {}).some(id =>
-          (merged.bookmarks.tombstones[id] ?? 0) > (local.bookmarks?.tombstones?.[id] ?? 0)
-        )
+          (merged.bookmarks.tombstones[id] ?? 0) > (local.bookmarks?.tombstones?.[id] ?? 0))
       );
 
       L.log({ kind: "ACTION", event: "MERGE", localMaxU, remoteMaxU, mergedMaxU, hadRemoteChanges });
       _applyMergedDoc(merged, hadRemoteChanges);
 
-      // Upload if merged has newer data OR more records than remote
-      // (local-only records with _u < remoteMaxU are caught by count check).
-      const remoteRecordCount = Object.keys(remote.bookmarks?.items ?? {}).length
-                              + Object.keys(remote.bookmarks?.tombstones ?? {}).length;
-      const mergedRecordCount = Object.keys(merged.bookmarks?.items ?? {}).length
-                              + Object.keys(merged.bookmarks?.tombstones ?? {}).length;
-      if (mergedMaxU > remoteMaxU || mergedRecordCount > remoteRecordCount) {
-        const payload = V2.buildSyncPayload(_deviceId);
-        const { ok, status } = await T.uploadSyncFile(_token, payload, { fileId, ifMatch: etag });
+      const remoteCount = Object.keys(remote.bookmarks?.items ?? {}).length
+                        + Object.keys(remote.bookmarks?.tombstones ?? {}).length;
+      const mergedCount = Object.keys(merged.bookmarks?.items ?? {}).length
+                        + Object.keys(merged.bookmarks?.tombstones ?? {}).length;
+
+      if (mergedMaxU > remoteMaxU || mergedCount > remoteCount) {
+        const { ok, status } = await T.uploadSyncFile(_token, V2.buildSyncPayload(_deviceId), { fileId, ifMatch: etag });
         L.log({ kind: "NETWORK", event: "UPLOAD_UPDATE", ok, status });
-        if (status === 401) { dispatch({ type: "SYNC_FAIL", reason: "401" }); return; }
-        if (status === 412) { dispatch({ type: "SYNC_FAIL", reason: "412" }); return; }
-        if (!ok) { dispatch({ type: "SYNC_FAIL", reason: `http_${status}` }); return; }
+        if (status === 401)             { dispatch({ type: "SYNC_FAIL", reason: "401" });              return; }
+        if (status === 412)             { dispatch({ type: "SYNC_FAIL", reason: "412" });              return; }
+        if (!ok)                        { dispatch({ type: "SYNC_FAIL", reason: `http_${status}` });   return; }
       }
 
       dispatch({ type: "SYNC_DONE" });
     } catch (err) {
       L.log({ kind: "ERROR", event: "SYNC_EXCEPTION", reason: err.message });
-      const reason = err.message === "no_token" ? "no_token" : "exception";
-      dispatch({ type: "SYNC_FAIL", reason });
+      dispatch({ type: "SYNC_FAIL", reason: err.message === "no_token" ? "no_token" : "exception" });
     } finally {
       _syncPending = false;
     }
@@ -190,17 +228,17 @@ function createSyncMachine({ onStateChange } = {}) {
   // ── dispatch ──────────────────────────────────────────────────────────────
 
   function dispatch(event) {
-    L.log({ kind: "ACTION", event: event.type, state: _state });
+    L.log({ kind: "ACTION", event: event.type, state: _state, ctx: { ..._ctx, backoffTimer: !!_ctx.backoffTimer } });
 
     switch (_state) {
 
       case S.DISABLED:
         if (event.type === "ENABLE") {
           if (window.google?.accounts?.oauth2 && _tokenClient) {
-            _setState(S.AUTHENTICATING, event);
-            T.requestSilentToken(_tokenClient, localStorage.getItem(SYNC_EMAIL_KEY));
+            _transition(S.AUTHENTICATING, {}, event);
+            _reqSilentToken();
           } else {
-            _setState(S.INITIALIZING, event);
+            _transition(S.INITIALIZING, {}, event);
           }
         }
         break;
@@ -212,167 +250,139 @@ function createSyncMachine({ onStateChange } = {}) {
             "https://www.googleapis.com/auth/drive.appdata email",
             (resp) => dispatch({ type: resp.error ? "TOKEN_FAIL" : "TOKEN_OK", ...resp, reason: resp.error })
           );
-          _setState(S.AUTHENTICATING, event);
-          T.requestSilentToken(_tokenClient, localStorage.getItem(SYNC_EMAIL_KEY));
+          _transition(S.AUTHENTICATING, {}, event);
+          _reqSilentToken();
         } else if (event.type === "DISABLE") {
-          _setState(S.DISABLED, event);
+          _transition(S.DISABLED, {}, event);
         }
         break;
 
       case S.AUTHENTICATING:
         if (event.type === "TOKEN_OK") {
-          _reAuthCount = 0;
-          _token = event.access_token;
-          L.log({ kind: "ACTION", event: "TOKEN_STORED", token: L.mask("token", _token) });
-          _setState(S.IDLE, event);
-          if (typeof window.rebuildDriveSyncSection === "function") window.rebuildDriveSyncSection();
-          // Fetch email asynchronously — GIS token callback doesn't include it.
-          T.fetchUserInfo(_token).then(({ email }) => {
-            _email = email;
-            localStorage.setItem(SYNC_EMAIL_KEY, email ?? "");
-            L.log({ kind: "ACTION", event: "EMAIL_FETCHED", email: L.mask("email", email) });
-            if (email && typeof window.rebuildDriveSyncSection === "function") window.rebuildDriveSyncSection();
-          }).catch((err) => {
-            L.log({ kind: "ERROR", event: "EMAIL_FETCH_FAILED", reason: err.message });
-          });
-          // Trigger initial sync immediately after authentication.
+          _storeToken(event.access_token);
+          _transition(S.IDLE, {}, event);
+          _refreshUI();
           dispatch({ type: "SYNC_REQUEST" });
         } else if (event.type === "TOKEN_FAIL") {
           L.log({ kind: "ERROR", event: "TOKEN_FAIL", reason: event.reason });
           if (SILENT_FAIL_REASONS.has(event.reason)) {
-            _setState(S.DISABLED, event);
+            _transition(S.DISABLED, {}, event);
           } else {
             _snackbar("Google Drive 동기화 세션이 만료됐습니다. 설정에서 재연결해 주세요.");
-            _setState(S.ERROR, event);
+            _transition(S.ERROR, {}, event);
           }
-          if (typeof window.rebuildDriveSyncSection === "function") window.rebuildDriveSyncSection();
+          _refreshUI();
         } else if (event.type === "DISABLE") {
           _token = null;
-          _setState(S.DISABLED, event);
-          if (typeof window.rebuildDriveSyncSection === "function") window.rebuildDriveSyncSection();
+          _transition(S.DISABLED, {}, event);
+          _refreshUI();
         }
         break;
 
       case S.IDLE:
         if (event.type === "SYNC_REQUEST") {
-          clearTimeout(_backoffTimer);
-          _backoffTimer = null;
-          _setState(S.SYNCING, event);
+          _transition(S.SYNCING, {}, event); // timer cleared here
           _syncCycle();
         } else if (event.type === "DISABLE") {
-          clearTimeout(_backoffTimer);
-          _backoffTimer = null;
           _token = null;
-          _setState(S.DISABLED, event);
-          if (typeof window.rebuildDriveSyncSection === "function") window.rebuildDriveSyncSection();
+          _transition(S.DISABLED, {}, event); // timer cleared here
+          _refreshUI();
         }
         break;
 
       case S.SYNCING:
         if (event.type === "SYNC_DONE") {
-          clearTimeout(_backoffTimer);
-          _backoffTimer = null;
-          _netFailCount = 0;
-          _conflictCount = 0;
-          _setState(S.IDLE, event);
+          _transition(S.IDLE, {}, event); // all counts reset, timer cleared
         } else if (event.type === "SYNC_FAIL") {
-          if (event.reason === "401" && _reAuthCount < 3) {
-            _reAuthCount++;
-            L.log({ kind: "ACTION", event: "REAUTH", attempt: _reAuthCount });
-            _token = null;
-            _setState(S.AUTHENTICATING, event);
-            T.requestSilentToken(_tokenClient, localStorage.getItem(SYNC_EMAIL_KEY));
-          } else if (event.reason === "401") {
-            _token = null;
-            _snackbar("Google Drive 동기화 세션이 만료됐습니다. 설정에서 재연결해 주세요.");
-            _setState(S.ERROR, event);
-            if (typeof window.rebuildDriveSyncSection === "function") window.rebuildDriveSyncSection();
-          } else if (event.reason === "412") {
-            // ETag mismatch — another device uploaded concurrently. Retry sync.
-            _conflictCount++;
-            if (_conflictCount <= 3) {
-              _setState(S.IDLE, event);
-              setTimeout(() => { if (_state === S.IDLE) dispatch({ type: "SYNC_REQUEST" }); }, 200);
-            } else {
-              _conflictCount = 0;
-              _snackbar("동기화 충돌이 반복됩니다. 잠시 후 다시 시도해 주세요.");
-              _setState(S.IDLE, event);
-            }
-          } else if (event.reason === "no_token" || event.reason === "exception") {
-            // Deterministic non-network failure — retrying won't help.
-            _token = null;
-            _snackbar("동기화 중 오류가 발생했습니다. 설정에서 재연결해 주세요.");
-            _setState(S.ERROR, event);
-            if (typeof window.rebuildDriveSyncSection === "function") window.rebuildDriveSyncSection();
-          } else {
-            // Network / 5xx — backoff retry, then OFFLINE after 5 failures.
-            _netFailCount++;
-            if (_netFailCount > MAX_NET_RETRIES || !navigator.onLine) {
-              _setState(S.OFFLINE, event);
-              if (typeof window.rebuildDriveSyncSection === "function") window.rebuildDriveSyncSection();
-            } else {
-              _setState(S.IDLE, event);
-              _scheduleRetry();
-            }
-          }
+          _handleSyncFail(event);
         } else if (event.type === "DISABLE") {
-          clearTimeout(_backoffTimer);
           _token = null;
-          _setState(S.DISABLED, event);
-          if (typeof window.rebuildDriveSyncSection === "function") window.rebuildDriveSyncSection();
+          _transition(S.DISABLED, {}, event); // timer cleared
+          _refreshUI();
         }
         break;
 
       case S.OFFLINE:
         if (event.type === "NET_RECOVERED") {
-          _netFailCount = 0;
-          _conflictCount = 0;
-          _setState(S.AUTHENTICATING, event);
-          T.requestSilentToken(_tokenClient, localStorage.getItem(SYNC_EMAIL_KEY));
+          _transition(S.AUTHENTICATING, {}, event); // all counts reset
+          _reqSilentToken();
         } else if (event.type === "DISABLE") {
-          clearTimeout(_backoffTimer);
           _token = null;
-          _setState(S.DISABLED, event);
-          if (typeof window.rebuildDriveSyncSection === "function") window.rebuildDriveSyncSection();
+          _transition(S.DISABLED, {}, event);
+          _refreshUI();
         }
         break;
 
       case S.ERROR:
         if (event.type === "ENABLE") {
-          _reAuthCount = 0;
-          _setState(S.AUTHENTICATING, event);
+          _transition(S.AUTHENTICATING, {}, event);
           T.requestConsentToken(_tokenClient);
         } else if (event.type === "DISABLE") {
           _token = null;
-          _setState(S.DISABLED, event);
-          if (typeof window.rebuildDriveSyncSection === "function") window.rebuildDriveSyncSection();
+          _transition(S.DISABLED, {}, event);
+          _refreshUI();
         }
         break;
     }
   }
 
-  // ── Public API (consumed by drive-sync.js facade) ─────────────────────────
+  // ── SYNC_FAIL handler (extracted for readability) ─────────────────────────
+  // All branches use _transition() with explicit ctxPatch — no implicit resets.
 
-  function enable() {
-    dispatch({ type: "ENABLE" });
+  function _handleSyncFail(event) {
+    const { reason } = event;
+
+    if (reason === "401") {
+      _token = null;
+      if (_ctx.reAuthFails < MAX_REAUTH) {
+        L.log({ kind: "ACTION", event: "REAUTH", attempt: _ctx.reAuthFails + 1 });
+        _transition(S.AUTHENTICATING, { reAuthFails: _ctx.reAuthFails + 1 }, event);
+        _reqSilentToken();
+      } else {
+        _snackbar("Google Drive 동기화 세션이 만료됐습니다. 설정에서 재연결해 주세요.");
+        _transition(S.ERROR, {}, event);
+        _refreshUI();
+      }
+
+    } else if (reason === "412") {
+      if (_ctx.conflictFails < MAX_CONFLICTS) {
+        const timer = _makeConflictTimer();
+        _transition(S.IDLE, { conflictFails: _ctx.conflictFails + 1, backoffTimer: timer }, event);
+      } else {
+        _snackbar("동기화 충돌이 반복됩니다. 잠시 후 다시 시도해 주세요.");
+        _transition(S.IDLE, {}, event); // conflictFails reset
+      }
+
+    } else if (reason === "no_token" || reason === "exception") {
+      _token = null;
+      _snackbar("동기화 중 오류가 발생했습니다. 설정에서 재연결해 주세요.");
+      _transition(S.ERROR, {}, event);
+      _refreshUI();
+
+    } else {
+      // Network / 5xx — exponential backoff, then OFFLINE.
+      const n = _ctx.netFails + 1;
+      if (n > MAX_NET_RETRIES || !navigator.onLine) {
+        _transition(S.OFFLINE, {}, event);
+        _refreshUI();
+      } else {
+        const timer = _makeBackoffTimer(n);
+        _transition(S.IDLE, { netFails: n, backoffTimer: timer }, event);
+      }
+    }
   }
 
-  function disable() {
-    dispatch({ type: "DISABLE" });
-  }
+  // ── Public API ────────────────────────────────────────────────────────────
 
-  function onGisReady() {
-    if (_state === S.INITIALIZING) dispatch({ type: "GIS_READY" });
-  }
+  function enable()      { dispatch({ type: "ENABLE" }); }
+  function disable()     { dispatch({ type: "DISABLE" }); }
+  function onGisReady()  { if (_state === S.INITIALIZING) dispatch({ type: "GIS_READY" }); }
+  function requestSync() { if (_state === S.IDLE) dispatch({ type: "SYNC_REQUEST" }); }
 
-  function requestSync() {
-    if (_state === S.IDLE) dispatch({ type: "SYNC_REQUEST" });
-  }
-
-  function getState()  { return _state; }
-  function getToken()  { return _token; }
-  function getEmail()  { return _email ?? localStorage.getItem(SYNC_EMAIL_KEY); }
-  function isEnabled() { return _state !== S.DISABLED && _state !== S.ERROR; }
+  function getState()        { return _state; }
+  function getToken()        { return _token; }
+  function getEmail()        { return _email ?? localStorage.getItem(SYNC_EMAIL_KEY); }
+  function isEnabled()       { return _state !== S.DISABLED && _state !== S.ERROR; }
   function isAuthenticated() { return !!_token; }
 
   async function deleteRemoteFile() {
@@ -385,7 +395,8 @@ function createSyncMachine({ onStateChange } = {}) {
     }
   }
 
-  return { enable, disable, onGisReady, requestSync, getState, getToken, getEmail, isEnabled, isAuthenticated, deleteRemoteFile, dispatch };
+  return { enable, disable, onGisReady, requestSync, dispatch,
+           getState, getToken, getEmail, isEnabled, isAuthenticated, deleteRemoteFile };
 }
 
 window.createSyncMachine = createSyncMachine;

--- a/tests/e2e/test_drive_sync.py
+++ b/tests/e2e/test_drive_sync.py
@@ -79,7 +79,7 @@ class FakeDrive:
             # Multipart body — extract JSON part (second part after boundary)
             raw = req.post_data_buffer
             parts = raw.split(b"\r\n\r\n")
-            doc_part = parts[-1].rsplit(b"\r\n", 1)[0] if len(parts) > 1 else parts[-1]
+            doc_part = parts[-1].split(b"\r\n--")[0] if len(parts) > 1 else parts[-1]
             with self._lock:
                 try:
                     self._file = json.loads(doc_part)

--- a/tests/e2e/test_drive_sync.py
+++ b/tests/e2e/test_drive_sync.py
@@ -1,0 +1,357 @@
+"""Drive sync e2e tests.
+
+Uses an in-memory fake Drive server (page.route) so no real OAuth or Drive
+calls are made. GIS is replaced by a window-level stub that grants tokens
+immediately. Two independent BrowserContext instances simulate two devices.
+
+Run with the dev server active:
+    python3 scripts/serve.py 8080
+    pytest tests/e2e/test_drive_sync.py -v
+"""
+
+import json
+import threading
+import pytest
+from playwright.sync_api import Page, BrowserContext, Route
+
+
+BASE_URL = "http://localhost:8080"
+
+
+# ── Fake Drive server ─────────────────────────────────────────────────────────
+
+class FakeDrive:
+    """Thread-safe in-memory Drive appDataFolder with ETag support."""
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._file: dict | None = None
+        self._etag = "etag-0"
+        self._etag_n = 0
+
+    def reset(self):
+        with self._lock:
+            self._file = None
+            self._etag = "etag-0"
+            self._etag_n = 0
+
+    def handle(self, route: Route):
+        req = route.request
+        url = req.url
+
+        # List files
+        if "spaces=appDataFolder" in url and "fields=files" in url:
+            with self._lock:
+                files = [{"id": "sync-file-id"}] if self._file is not None else []
+            route.fulfill(status=200, content_type="application/json",
+                          body=json.dumps({"files": files}))
+            return
+
+        # Download file
+        if "sync-file-id?alt=media" in url:
+            with self._lock:
+                if self._file is None:
+                    route.fulfill(status=404)
+                    return
+                route.fulfill(
+                    status=200,
+                    content_type="application/json",
+                    headers={"ETag": self._etag},
+                    body=json.dumps(self._file),
+                )
+            return
+
+        # Upload (PATCH — update)
+        if "uploadType=media" in url and "sync-file-id" in url:
+            if_match = req.headers.get("if-match")
+            with self._lock:
+                if if_match and if_match != self._etag:
+                    route.fulfill(status=412)
+                    return
+                self._etag_n += 1
+                self._etag = f"etag-{self._etag_n}"
+                self._file = json.loads(req.post_data)
+                route.fulfill(status=200, headers={"ETag": self._etag})
+            return
+
+        # Upload (POST — create)
+        if "uploadType=multipart" in url:
+            # Multipart body — extract JSON part (second part after boundary)
+            raw = req.post_data_buffer
+            parts = raw.split(b"\r\n\r\n")
+            doc_part = parts[-1].rsplit(b"\r\n", 1)[0] if len(parts) > 1 else parts[-1]
+            with self._lock:
+                try:
+                    self._file = json.loads(doc_part)
+                except Exception:
+                    self._file = {}
+                self._etag_n += 1
+                self._etag = f"etag-{self._etag_n}"
+                route.fulfill(status=200, headers={"ETag": self._etag})
+            return
+
+        # Delete file
+        if "sync-file-id" in url and req.method == "DELETE":
+            with self._lock:
+                self._file = None
+                self._etag = "etag-0"
+                self._etag_n = 0
+            route.fulfill(status=204)
+            return
+
+        # userinfo
+        if "userinfo" in url:
+            route.fulfill(status=200, content_type="application/json",
+                          body=json.dumps({"email": "test@example.com"}))
+            return
+
+        route.continue_()
+
+
+# ── GIS stub injected into every page ────────────────────────────────────────
+
+GIS_STUB = """
+window.__gisCallbacks = {};
+window.google = {
+  accounts: {
+    id: { initialize: () => {}, prompt: () => {} },
+    oauth2: {
+      initTokenClient: (cfg) => {
+        window.__gisCallbacks[cfg.client_id] = cfg.callback;
+        return {
+          requestAccessToken: (opts) => {
+            // Always grant immediately unless window.__gisForceError is set.
+            const error = window.__gisForceError;
+            if (error) {
+              window.__gisForceError = null;
+              cfg.callback({ error });
+              return;
+            }
+            cfg.callback({ access_token: "mock-token-abc123" });
+          }
+        };
+      },
+      revoke: (token, cb) => { if (cb) cb(); }
+    }
+  }
+};
+"""
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+@pytest.fixture(scope="module")
+def fake_drive():
+    drive = FakeDrive()
+    yield drive
+    drive.reset()
+
+
+def _make_page(browser, fake_drive) -> Page:
+    """Create a fresh BrowserContext + Page with GIS stub and Drive mock."""
+    ctx: BrowserContext = browser.new_context()
+    page = ctx.new_page()
+    page.add_init_script(GIS_STUB)
+    page.route("**/*googleapis.com/**", fake_drive.handle)
+    page.route("**/accounts.google.com/**", fake_drive.handle)
+    return page
+
+
+def _load(page: Page):
+    page.goto(BASE_URL)
+    page.wait_for_selector("#search-input", timeout=10_000)
+
+
+def _enable_sync(page: Page):
+    """Enable Drive sync and wait for IDLE state."""
+    page.evaluate("window.driveSync.signIn()")
+    page.wait_for_function(
+        "() => window.driveSync?.getStatus() === 'IDLE'",
+        timeout=5_000,
+    )
+
+
+def _add_bookmark(page: Page, name: str) -> str:
+    """Add a bookmark via the store and return its id."""
+    return page.evaluate(f"""
+        (() => {{
+            const id = 'bm-' + Math.random().toString(36).slice(2);
+            const store = window.loadBookmarks ? window.loadBookmarks() : [];
+            store.push({{ id, type: 'bookmark', name: {json.dumps(name)},
+                          bookId: 'gen', chapter: 1, vref: 'gen 1:1',
+                          verseSpec: '1' }});
+            if (window.saveBookmarks) window.saveBookmarks(store);
+            return id;
+        }})()
+    """)
+
+
+def _bookmark_names(page: Page) -> list[str]:
+    return page.evaluate("""
+        (() => {
+            const bms = window.loadBookmarks ? window.loadBookmarks() : [];
+            const names = [];
+            function walk(items) {
+                for (const it of items) {
+                    if (it.type === 'bookmark') names.push(it.name);
+                    if (it.children) walk(it.children);
+                }
+            }
+            walk(bms);
+            return names;
+        })()
+    """)
+
+
+def _wait_idle(page: Page, timeout=5_000):
+    page.wait_for_function(
+        "() => window.driveSync?.getStatus() === 'IDLE'",
+        timeout=timeout,
+    )
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+def test_upload_then_download(browser, fake_drive):
+    """Device A uploads a bookmark; Device B downloads it."""
+    fake_drive.reset()
+
+    page_a = _make_page(browser, fake_drive)
+    page_b = _make_page(browser, fake_drive)
+    try:
+        _load(page_a)
+        _enable_sync(page_a)
+        _add_bookmark(page_a, "Genesis 1")
+        page_a.evaluate("window.driveSync.scheduleUpload()")
+        _wait_idle(page_a)
+
+        _load(page_b)
+        _enable_sync(page_b)
+        _wait_idle(page_b)
+
+        names = _bookmark_names(page_b)
+        assert "Genesis 1" in names, f"Expected bookmark on device B, got: {names}"
+    finally:
+        page_a.context.close()
+        page_b.context.close()
+
+
+def test_concurrent_adds_both_preserved(browser, fake_drive):
+    """Devices A and B each add a different bookmark; both survive after sync."""
+    fake_drive.reset()
+
+    page_a = _make_page(browser, fake_drive)
+    page_b = _make_page(browser, fake_drive)
+    try:
+        # A syncs first (uploads its bookmark)
+        _load(page_a)
+        _enable_sync(page_a)
+        _add_bookmark(page_a, "Bookmark-A")
+        page_a.evaluate("window.driveSync.scheduleUpload()")
+        _wait_idle(page_a)
+
+        # B starts with a clean slate, adds its own bookmark and syncs
+        _load(page_b)
+        _enable_sync(page_b)
+        _wait_idle(page_b)  # initial download
+        _add_bookmark(page_b, "Bookmark-B")
+        page_b.evaluate("window.driveSync.scheduleUpload()")
+        _wait_idle(page_b)
+
+        # A re-syncs to pick up B's addition
+        page_a.evaluate("window.driveSync.scheduleUpload()")
+        _wait_idle(page_a)
+
+        names_a = _bookmark_names(page_a)
+        names_b = _bookmark_names(page_b)
+        assert "Bookmark-A" in names_a and "Bookmark-B" in names_a, \
+            f"Device A missing bookmarks: {names_a}"
+        assert "Bookmark-A" in names_b and "Bookmark-B" in names_b, \
+            f"Device B missing bookmarks: {names_b}"
+    finally:
+        page_a.context.close()
+        page_b.context.close()
+
+
+def test_412_triggers_remerge(browser, fake_drive):
+    """A 412 response causes the machine to re-download, re-merge, and retry."""
+    fake_drive.reset()
+
+    page = _make_page(browser, fake_drive)
+    try:
+        _load(page)
+        _enable_sync(page)
+
+        # Force the next upload to get a 412 by advancing the Drive etag externally.
+        with fake_drive._lock:
+            fake_drive._etag_n += 1
+            fake_drive._etag = f"etag-{fake_drive._etag_n}"
+
+        _add_bookmark(page, "After-412")
+        page.evaluate("window.driveSync.scheduleUpload()")
+
+        # Machine should retry after 412 and eventually reach IDLE again.
+        _wait_idle(page, timeout=8_000)
+
+        # Sync state should be healthy (not ERROR/OFFLINE).
+        status = page.evaluate("window.driveSync.getStatus()")
+        assert status == "IDLE", f"Expected IDLE after 412 recovery, got {status}"
+    finally:
+        page.context.close()
+
+
+def test_sign_out_clears_sync(browser, fake_drive):
+    """Signing out disables sync; subsequent changes don't upload."""
+    fake_drive.reset()
+
+    page = _make_page(browser, fake_drive)
+    try:
+        _load(page)
+        _enable_sync(page)
+        page.evaluate("window.driveSync.signOut()")
+
+        status = page.evaluate("window.driveSync.getStatus()")
+        assert status == "DISABLED", f"Expected DISABLED after sign-out, got {status}"
+
+        _add_bookmark(page, "After-Sign-Out")
+        page.evaluate("window.driveSync.scheduleUpload()")
+        page.wait_for_timeout(500)
+
+        # Drive should still have no file (or only the pre-signout content).
+        with fake_drive._lock:
+            file = fake_drive._file
+        if file:
+            items = list(file.get("bookmarks", {}).get("items", {}).values())
+            names = [it.get("name") for it in items]
+            assert "After-Sign-Out" not in names, "Bookmark uploaded after sign-out"
+    finally:
+        page.context.close()
+
+
+def test_v0_migration_syncs_correctly(browser, fake_drive):
+    """Legacy v0 (bare array) localStorage is migrated and synced to Drive."""
+    fake_drive.reset()
+
+    page = _make_page(browser, fake_drive)
+    try:
+        # Inject legacy v0 bookmark data before app loads.
+        page.add_init_script("""
+            const bms = [{ id: 'legacy-1', type: 'bookmark', name: 'Legacy BM',
+                           bookId: 'gen', chapter: 1, vref: 'gen 1:1', verseSpec: '1' }];
+            localStorage.setItem('bible-bookmarks', JSON.stringify(bms));
+        """)
+        _load(page)
+        _enable_sync(page)
+        _wait_idle(page)
+
+        names = _bookmark_names(page)
+        assert "Legacy BM" in names, f"Legacy bookmark missing after migration: {names}"
+
+        # Drive should have received the migrated data.
+        with fake_drive._lock:
+            assert fake_drive._file is not None, "Nothing uploaded to Drive"
+            items = fake_drive._file.get("bookmarks", {}).get("items", {})
+            drive_names = [v.get("name") for v in items.values()]
+        assert "Legacy BM" in drive_names, f"Legacy bookmark not on Drive: {drive_names}"
+    finally:
+        page.context.close()


### PR DESCRIPTION
## Summary

PR 3에서 버그봇이 6건을 연속 발견한 근본 원인을 해소합니다.

### 문제

`_netFailCount`, `_conflictCount`, `_reAuthCount`, `_backoffTimer` 4개 변수가 FSM 상태 전이 표 밖에서 클로저 변수로 분산 관리됨. "어떤 전이에서 어떤 카운터/타이머를 리셋해야 하는가"가 명시되지 않아 버그가 반복 발생.

### 해결: `_transition(nextState, ctxPatch, event)`

모든 상태 + 컨텍스트 변경이 단일 함수를 통해서만 발생:

```js
// 기본: 모든 카운터 0, 타이머 clear
_transition(S.IDLE, {}, event);

// 유지가 필요한 값만 명시적 opt-in
_transition(S.IDLE, { netFails: _ctx.netFails + 1, backoffTimer: timer }, event);
_transition(S.AUTHENTICATING, { reAuthFails: _ctx.reAuthFails + 1 }, event);
```

`_emptyCtx()` 가 기본값이므로 **"리셋 누락"이 구조적으로 불가능**. 명시한 것만 살아남습니다.

### e2e 테스트 (`tests/e2e/test_drive_sync.py`)

| 시나리오 | 검증 |
|----------|------|
| A 업로드 → B 다운로드 | 기본 동기화 흐름 |
| A·B 동시 추가 | per-record LWW — 양쪽 북마크 모두 보존 |
| 412 발생 | 재머지 후 IDLE 복귀, ERROR/OFFLINE 아님 |
| 로그아웃 후 변경 | Drive에 업로드되지 않음 |
| v0 레거시 마이그레이션 | 북마크 보존 + Drive 업로드 |

**FakeDrive**: `page.route`로 가로채는 인메모리 Drive 서버 (ETag, 412 시뮬레이션 포함)
**GIS 스텁**: 실제 OAuth 없이 즉시 토큰 부여

## Test plan

```bash
python3 scripts/serve.py 8080
pytest tests/e2e/test_drive_sync.py -v
```

- [ ] 5개 시나리오 모두 PASS
- [ ] 기존 e2e 테스트 회귀 없음 (`pytest tests/e2e/ -v`)
- [ ] Hard refresh 후 Drive 연결 → 동기화 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors core Drive sync/auth retry logic (state transitions, backoff, conflict handling), which can affect reliability and user sessions; added e2e tests reduce regression risk but behavior changes are non-trivial.
> 
> **Overview**
> Refactors `js/sync/state-machine.js` into a stricter *statechart* pattern by introducing a single `_transition(next, ctxPatch, event)` that **owns all state changes and retry/backoff counters**, clearing timers/counters by default and requiring explicit opt-in to carry them across transitions.
> 
> Extracts token handling and `SYNC_FAIL` branching into helpers (`_storeToken`, `_reqSilentToken`, `_handleSyncFail`), tightening behavior for **401 re-auth retries**, **412 conflict re-merge retries**, deterministic failures (`no_token`/`exception`) to `ERROR`, and network/5xx exponential backoff to `OFFLINE`.
> 
> Adds `tests/e2e/test_drive_sync.py` Playwright tests with an in-memory `FakeDrive` (ETag/412 support) and GIS stub to cover upload→download across devices, concurrent merges, 412 recovery, sign-out behavior, and legacy localStorage migration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7985354cb510e808d454cab11f8e459be2a90d05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->