### PR TITLE
fix: iOS 검색 바텀시트 키보드 영역 다듬기

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -136,7 +136,7 @@ body {
 /* ── Header ── */
 #sticky-group {
   position: sticky;
-  top: 0;
+  top: env(safe-area-inset-top);
   z-index: 20;
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -993,12 +993,27 @@ body {
   right: 0;
   z-index: 50;
   background: var(--bg);
+  background-clip: padding-box;
   border-radius: 16px 16px 0 0;
   box-shadow: 0 -4px 24px rgba(0, 0, 0, 0.15);
   flex-direction: column;
   height: 55vh;
   max-height: 80vh;
+  padding-bottom: env(safe-area-inset-bottom);
   transition: height 0.2s ease;
+}
+
+/* Sliver below the sheet so iOS's translucent form-accessory bar shows the
+   sheet's background instead of the dimmed page body bleeding through. */
+#search-sheet::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 100%;
+  height: 60px;
+  background: var(--bg);
+  pointer-events: none;
 }
 
 #search-sheet:not([hidden]) {

--- a/css/style.css
+++ b/css/style.css
@@ -757,12 +757,12 @@ body {
 
 /* Lift FAB above chapter-nav when it scrolls into view */
 #search-fab {
-  bottom: max(1.5rem, var(--fab-lift-nav, 0px));
+  bottom: max(calc(1.5rem + env(safe-area-inset-bottom)), var(--fab-lift-nav, 0px));
 }
 
 /* Lift FAB when audio bar is visible */
 #audio-bar:not([hidden]) ~ #search-fab {
-  bottom: max(5rem, calc(var(--fab-lift-nav, 0px) + 3.5rem));
+  bottom: max(calc(5rem + env(safe-area-inset-bottom)), calc(var(--fab-lift-nav, 0px) + 3.5rem));
 }
 
 /* ── Install guide modal ── */
@@ -2131,13 +2131,11 @@ body.verse-select-active #audio-bar {
   display: none;
 }
 
-<<<<<<< HEAD
 body.verse-select-active #audio-bar ~ #search-fab {
-  bottom: max(1.5rem, var(--fab-lift-nav, 0px));
+  bottom: max(calc(1.5rem + env(safe-area-inset-bottom)), var(--fab-lift-nav, 0px));
 }
 
-=======
->>>>>>> fa785bd (style: 절 선택 모드에서 오디오 플레이어 숨기기)
+
 body.verse-select-active .verse[data-vref] {
   cursor: pointer;
   padding: 0.1em 0.15em;

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' 'sha256-Ql/uJ1Ou2PlS6wibdLtHlsS2PAC1PERYjRj85nr6NqU=' 'sha256-f4HQaD+NpkjxARuDdQGRxOo2ppAliUcSVMnYbNcYEJ0=' https://fonts.googleapis.com https://accounts.google.com; font-src https://fonts.gstatic.com; script-src 'self' 'sha256-H8hoBBbQZLyCV/84gnOouMYd5d07yzGzrwAXB4enAh0=' 'unsafe-hashes' 'sha256-MhtPZXr7+LpJUY5qtMutB+qWfQtMaPccfe7QXtCcEYc=' https://www.googletagmanager.com https://accounts.google.com; worker-src 'self'; connect-src 'self' https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://accounts.google.com https://oauth2.googleapis.com https://www.googleapis.com https://content.googleapis.com; media-src 'self'; img-src 'self' data: https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.g.doubleclick.net https://*.google.com; frame-src https://accounts.google.com; object-src 'none'; base-uri 'self'">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="description" content="공동번역성서 — 대한성공회">
   <meta name="naver-site-verification" content="515b6ea4e37d17bb779ea6f6b525bafdc23b4151">
   <meta name="theme-color" content="#faf8f5" media="(prefers-color-scheme: light)">
@@ -147,7 +147,7 @@
     <div id="search-sheet-handle" aria-hidden="true"><span></span></div>
     <div id="search-sheet-bar">
       <div id="search-sheet-input-wrap">
-        <input id="search-sheet-input" type="search" placeholder="검색 (예: 사랑, 창세 1:3)" aria-label="성경 검색" autocomplete="off">
+        <input id="search-sheet-input" type="search" inputmode="search" enterkeyhint="search" autocorrect="off" autocapitalize="off" spellcheck="false" placeholder="검색 (예: 사랑, 창세 1:3)" aria-label="성경 검색" autocomplete="off">
         <button id="search-sheet-clear" type="button" aria-label="검색 초기화" hidden>&times;</button>
       </div>
       <button id="search-sheet-close" type="button" aria-label="닫기">

--- a/js/app.js
+++ b/js/app.js
@@ -2971,7 +2971,12 @@ function isMobile() {
 function adjustSheetForKeyboard() {
   if (!window.visualViewport || $searchSheet.hidden) return;
   const vv = window.visualViewport;
-  const keyboardOffset = Math.max(0, window.innerHeight - vv.height - vv.offsetTop);
+  // For position:fixed elements anchored to the layout viewport, ignore
+  // vv.offsetTop — it represents in-page scroll within the visual viewport
+  // (e.g. pinch-zoom pan) and would incorrectly shift the sheet.
+  const keyboardOffset = Math.max(0, window.innerHeight - vv.height);
+  const prevOffset = parseFloat($searchSheet.style.bottom) || 0;
+  if (keyboardOffset > 0 && Math.abs(keyboardOffset - prevOffset) < 1) return;
   // Suppress the CSS height transition so viewport adjustments snap instantly
   // rather than lagging 200ms behind rapid visualViewport resize/scroll events.
   $searchSheet.style.transition = "none";


### PR DESCRIPTION
## Summary

iOS Safari/PWA에서 검색 바텀시트가 열렸을 때 키보드와 시트 사이의 영역이 어색해 보이던 문제를 다듬는다.

근본 원인: WebKit의 native form accessory bar(`^/v ✓`)는 표준 `<input>`을 쓰는 한 웹 페이지에서 제거할 수 없다. 따라서 "바를 자연스럽게 보이도록" 처리하는 방향으로 정리.

### 변경 내역

- `index.html`
  - viewport meta에 `viewport-fit=cover` 추가 (노치/Dynamic Island 안전 영역 대응)
  - `#search-sheet-input`에 `inputmode="search"`, `enterkeyhint="search"`, `autocorrect="off"`, `autocapitalize="off"`, `spellcheck="false"` 추가 (모바일 키보드/Return 키 최적화)
- `css/style.css`
  - `#search-sheet`에 `padding-bottom: env(safe-area-inset-bottom)` + `background-clip: padding-box`
  - `#search-sheet::after`로 시트 하단 60px 슬라이버 추가 — iOS 반투명 accessory bar 뒤로 페이지 본문 대신 시트 배경색이 비치도록
- `js/app.js`
  - `adjustSheetForKeyboard()`에서 `vv.offsetTop` 차감 제거 — `position: fixed` 요소에 부적절(pinch-zoom/pan 시 sheet bottom이 잘못 계산됨)
  - 1px 미만 offset 변화는 무시해 `visualViewport.scroll` thrash 방지

### 시도하지 않은 것

- `<input>`을 `contenteditable` div로 교체해 accessory bar를 완전히 숨기는 방법은 한국어 IME 합성 처리·placeholder·clear 버튼·Enter 제출·접근성 모두 직접 구현해야 하고, 한글 검색이 핵심 기능이라 회귀 위험이 너무 커 채택하지 않음.

## Test plan

iOS 시뮬레이터는 accessory bar가 실제 디바이스와 다르게 그려져 **실기기 iPhone Safari** 검증이 필수.

- [ ] `python3 scripts/serve.py 8080` 실행 후 iPhone에서 접속
- [ ] Safari 브라우저: 검색 시트 열기 → 입력 포커스 → accessory bar 위로 시트 하단이 정확히 닿고 본문이 비치지 않는지 확인
- [ ] PWA 스탠드얼론(홈 화면 추가)에서 동일 시나리오 재테스트
- [ ] 가로 모드: accessory bar 자동 숨김/레이아웃 무결성 확인
- [ ] 한글 IME로 "사랑" 등 입력 시 자모 결합 정상 동작 확인 (input 속성 변경 회귀 체크)
- [ ] Return 키가 돋보기(`enterkeyhint="search"`)로 표시되는지 확인
- [ ] 키보드 dismiss(스와이프 다운) 시 시트 위치/높이 복구 확인
- [ ] `pytest tests/e2e/test_search.py -v` desktop 회귀 없는지 확인

https://claude.ai/code/session_01SF4X9WyFCXmwn1G5gxLG4F

---
_Generated by [Claude Code](https://claude.ai/code/session_01SF4X9WyFCXmwn1G5gxLG4F)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts mobile viewport/safe-area and `visualViewport` keyboard handling, which can affect layout on iOS/Android across device/orientation combinations. Risk is limited to search bottom-sheet/FAB positioning and related sticky header behavior.
> 
> **Overview**
> Improves iOS Safari/PWA UX when the **search bottom sheet** is focused by accounting for notch/home-indicator safe areas and preventing background “bleed” under WebKit’s translucent form accessory bar.
> 
> Updates layout to use `env(safe-area-inset-*)` for the sticky header and search FAB, adds bottom padding/background clipping plus a small `#search-sheet::after` sliver, and tweaks the search input attributes for a better mobile keyboard/IME experience.
> 
> Refines `adjustSheetForKeyboard()` to stop using `visualViewport.offsetTop` (avoids pinch-zoom/pan misplacement) and skips <1px bottom changes to reduce resize/scroll thrash; also removes an accidental merge-conflict block in the verse-select FAB rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 897f7b82aae5d7502f86c53b39a39301945b40dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->