### PR TITLE
fix: 북마크 드로어 절 참조에 책·장 번호 포함

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2888,6 +2888,34 @@ body.verse-select-active .verse.verse-poetry[data-vref] {
   background: color-mix(in srgb, var(--accent) 8%, transparent);
 }
 
+.bm-folder-combobox-new {
+  list-style: none;
+  margin-top: 0.25rem;
+  padding-top: 0.25rem;
+  border-top: 1px solid var(--border);
+}
+
+.bm-folder-combobox-new-btn {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  width: 100%;
+  padding: 0.4rem 0.6rem;
+  font-family: inherit;
+  font-size: 0.9rem;
+  background: transparent;
+  border: 0;
+  color: var(--accent);
+  cursor: pointer;
+  text-align: left;
+}
+
+.bm-folder-combobox-new-btn:hover,
+.bm-folder-combobox-new-btn:focus {
+  background: color-mix(in srgb, var(--accent) 8%, transparent);
+  outline: none;
+}
+
 .bm-form-input:focus,
 .bm-form-textarea:focus,
 .bm-form-select:focus,
@@ -2945,6 +2973,67 @@ body.verse-select-active .verse.verse-poetry[data-vref] {
 
 .bm-btn-secondary:hover {
   background: var(--border);
+}
+
+/* ── New folder modal (stacks above save modal) ── */
+
+#bm-new-folder-scrim {
+  display: none;
+  position: fixed;
+  inset: 0;
+  z-index: 76;
+  background: rgba(0, 0, 0, 0.45);
+}
+
+#bm-new-folder-scrim:not([hidden]) {
+  display: block;
+}
+
+#bm-new-folder-modal {
+  font-family: -apple-system, BlinkMacSystemFont, "Apple SD Gothic Neo", "Noto Sans KR", sans-serif;
+  display: none;
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 77;
+  width: min(92vw, 360px);
+  background: var(--bg-card);
+  color: var(--text);
+  border-radius: 14px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.25);
+  padding: 1.25rem 1.25rem 1rem;
+}
+
+#bm-new-folder-modal:not([hidden]) {
+  display: block;
+}
+
+#bm-new-folder-title {
+  margin: 0 2rem 0.85rem 0;
+  font-size: 1.05rem;
+  font-weight: 700;
+}
+
+#bm-new-folder-close {
+  position: absolute;
+  top: 0.25rem;
+  right: 0.25rem;
+  background: transparent;
+  border: 0;
+  color: var(--text-secondary);
+  font-size: 1.6rem;
+  line-height: 1;
+  min-width: 44px;
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+#bm-new-folder-close:hover {
+  color: var(--text);
 }
 
 /* ── Merge confirmation modal ── */

--- a/index.html
+++ b/index.html
@@ -199,6 +199,21 @@
     <div id="bm-save-body"></div>
   </div>
 
+  <!-- ── New Folder Modal (stacks above save modal) ── -->
+  <div id="bm-new-folder-scrim" aria-hidden="true" hidden></div>
+  <div id="bm-new-folder-modal" role="dialog" aria-modal="true" aria-labelledby="bm-new-folder-title" hidden>
+    <button id="bm-new-folder-close" type="button" aria-label="닫기">&times;</button>
+    <h2 id="bm-new-folder-title">새 폴더</h2>
+    <div class="bm-form-field">
+      <label class="bm-form-label" for="bm-new-folder-input">폴더 이름</label>
+      <input id="bm-new-folder-input" class="bm-form-input" type="text" maxlength="50" placeholder="예: 대림1주일" />
+    </div>
+    <div class="bm-form-actions">
+      <button id="bm-new-folder-cancel" class="bm-btn-secondary" type="button">취소</button>
+      <button id="bm-new-folder-confirm" class="bm-btn-primary" type="button">만들기</button>
+    </div>
+  </div>
+
   <!-- ── Import Bookmarks Modal ── -->
   <div id="bm-import-scrim" aria-hidden="true" hidden></div>
   <div id="bm-import-modal" role="dialog" aria-modal="true" aria-labelledby="bm-import-title" hidden>

--- a/js/app.js
+++ b/js/app.js
@@ -3943,11 +3943,12 @@ function _buildBookmarkItem(bm, depth) {
   typeIcon.appendChild(_buildBookmarkTypeIcon(isActive));
   const link = el("a", { className: "bm-bookmark-link", href: _bookmarkHref(bm), draggable: "false" });
   link.appendChild(el("span", { className: "bm-bookmark-label" }, bm.label));
-  if (bm.verseSpec !== "all") {
-    const book = booksCache && booksCache.find(b => b.id === bm.bookId);
-    const bookName = book ? (book.short_name_ko || book.name_ko) : bm.bookId;
-    link.appendChild(el("span", { className: "bm-bookmark-ref" }, `${bookName} ${bm.chapter}:${bm.verseSpec}`));
-  }
+  const book = booksCache && booksCache.find(b => b.id === bm.bookId);
+  const bookName = book ? (book.short_name_ko || book.name_ko) : bm.bookId;
+  const refText = bm.verseSpec === "all"
+    ? `${bookName} ${bm.chapter}${chUnit(bm.bookId)}`
+    : `${bookName} ${bm.chapter}:${bm.verseSpec}`;
+  link.appendChild(el("span", { className: "bm-bookmark-ref" }, refText));
   link.addEventListener("click", (e) => {
     e.preventDefault();
     if (row.classList.contains("bm-swiped")) {

--- a/js/app.js
+++ b/js/app.js
@@ -4114,9 +4114,11 @@ function _buildFolderCombobox(folderOptions, selectedFolderId) {
   const list = el("ul", { id: listId, className: "bm-folder-combobox-list", role: "listbox" });
   list.hidden = true;
 
+  let currentOptions = folderOptions;
+
   function labelForId(id) {
     if (id === "" || id == null) return "최상위";
-    const o = folderOptions.find(f => f.id === id);
+    const o = currentOptions.find(f => f.id === id);
     return o ? o.name : "최상위";
   }
 
@@ -4208,6 +4210,7 @@ function _buildFolderCombobox(folderOptions, selectedFolderId) {
   newFolderItem.appendChild(newFolderBtn);
 
   function rebuildOptions(options) {
+    currentOptions = options;
     list.replaceChildren();
     addOption("", "최상위", 0);
     for (const o of options) addOption(String(o.id), o.name, o.depth);

--- a/js/app.js
+++ b/js/app.js
@@ -3944,7 +3944,9 @@ function _buildBookmarkItem(bm, depth) {
   const link = el("a", { className: "bm-bookmark-link", href: _bookmarkHref(bm), draggable: "false" });
   link.appendChild(el("span", { className: "bm-bookmark-label" }, bm.label));
   if (bm.verseSpec !== "all") {
-    link.appendChild(el("span", { className: "bm-bookmark-ref" }, bm.verseSpec));
+    const book = booksCache && booksCache.find(b => b.id === bm.bookId);
+    const bookName = book ? (book.short_name_ko || book.name_ko) : bm.bookId;
+    link.appendChild(el("span", { className: "bm-bookmark-ref" }, `${bookName} ${bm.chapter}:${bm.verseSpec}`));
   }
   link.addEventListener("click", (e) => {
     e.preventDefault();

--- a/js/app.js
+++ b/js/app.js
@@ -108,6 +108,8 @@ let _bookmarkDrawerTrap = null;
 let _bookmarkDrawerLastFocus = null;
 let _bmSaveModalTrap = null;
 let _bmMergeModalTrap = null;
+let _bmNewFolderTrap = null;
+let _bmNewFolderCallback = null;
 let _bookmarkDrawerCloseSeq = 0;
 let _bookmarkDrawerCloseTimer = null;
 let _dragState = null; // { id, ghost, origLi, startY, origTop }
@@ -3789,6 +3791,12 @@ const $bmSaveModal = document.getElementById("bm-save-modal");
 const $bmSaveClose = document.getElementById("bm-save-close");
 const $bmSaveTitle = document.getElementById("bm-save-title");
 const $bmSaveBody = document.getElementById("bm-save-body");
+const $bmNewFolderScrim = document.getElementById("bm-new-folder-scrim");
+const $bmNewFolderModal = document.getElementById("bm-new-folder-modal");
+const $bmNewFolderClose = document.getElementById("bm-new-folder-close");
+const $bmNewFolderInput = document.getElementById("bm-new-folder-input");
+const $bmNewFolderConfirm = document.getElementById("bm-new-folder-confirm");
+const $bmNewFolderCancel = document.getElementById("bm-new-folder-cancel");
 const $bmMergeScrim = document.getElementById("bm-merge-scrim");
 const $bmMergeModal = document.getElementById("bm-merge-modal");
 const $bmMergeBody = document.getElementById("bm-merge-body");
@@ -4179,8 +4187,34 @@ function _buildFolderCombobox(folderOptions, selectedFolderId) {
     list.appendChild(li);
   }
 
-  addOption("", "최상위", 0);
-  for (const o of folderOptions) addOption(String(o.id), o.name, o.depth);
+  // Persistent "+ 새 폴더" action at the bottom of the listbox.
+  // role="presentation" so screen readers don't read it as a folder option.
+  const newFolderItem = el("li", { role: "presentation", className: "bm-folder-combobox-new" });
+  const newFolderBtn = el("button", {
+    type: "button",
+    className: "bm-folder-combobox-new-btn",
+  }, "+ 새 폴더");
+  newFolderBtn.addEventListener("click", (e) => {
+    e.stopPropagation();
+    closeList();
+    openNewFolderModal((newId) => {
+      const updated = collectFolderOptions(loadBookmarks());
+      rebuildOptions(updated);
+      hidden.value = String(newId);
+      updateButton();
+      updateOptionSelected();
+    });
+  });
+  newFolderItem.appendChild(newFolderBtn);
+
+  function rebuildOptions(options) {
+    list.replaceChildren();
+    addOption("", "최상위", 0);
+    for (const o of options) addOption(String(o.id), o.name, o.depth);
+    list.appendChild(newFolderItem);
+  }
+
+  rebuildOptions(folderOptions);
   updateButton();
   updateOptionSelected();
 
@@ -4535,6 +4569,41 @@ function closeSaveModal() {
   if (_bmSaveModalTrap) { _bmSaveModalTrap(); _bmSaveModalTrap = null; }
 }
 
+function openNewFolderModal(onConfirm) {
+  $bmNewFolderInput.value = "";
+  $bmNewFolderInput.removeAttribute("aria-invalid");
+  _bmNewFolderCallback = onConfirm || null;
+  $bmNewFolderScrim.hidden = false;
+  $bmNewFolderModal.hidden = false;
+  _bmNewFolderTrap = trapFocus($bmNewFolderModal);
+  requestAnimationFrame(() => $bmNewFolderInput.focus());
+}
+
+function closeNewFolderModal() {
+  $bmNewFolderScrim.hidden = true;
+  $bmNewFolderModal.hidden = true;
+  _bmNewFolderCallback = null;
+  if (_bmNewFolderTrap) { _bmNewFolderTrap(); _bmNewFolderTrap = null; }
+}
+
+function _commitNewFolder() {
+  const name = $bmNewFolderInput.value.trim();
+  if (!name) {
+    $bmNewFolderInput.setAttribute("aria-invalid", "true");
+    $bmNewFolderInput.focus();
+    return;
+  }
+  $bmNewFolderInput.removeAttribute("aria-invalid");
+  const store = loadBookmarks();
+  const id = generateId();
+  store.push({ type: "folder", id, name, children: [], expanded: false });
+  saveBookmarks(store);
+  renderBookmarkTree();
+  const cb = _bmNewFolderCallback;
+  closeNewFolderModal();
+  if (cb) cb(id);
+}
+
 function commitSaveBookmark(existingId, label, note, folderId, bookId, chapter, verseSpec) {
   const store = loadBookmarks();
   if (existingId) {
@@ -4821,6 +4890,15 @@ $bookmarkScrim.addEventListener("click", closeBookmarkDrawer);
 
 $bmSaveClose.addEventListener("click", closeSaveModal);
 $bmSaveScrim.addEventListener("click", closeSaveModal);
+
+$bmNewFolderClose.addEventListener("click", closeNewFolderModal);
+$bmNewFolderScrim.addEventListener("click", closeNewFolderModal);
+$bmNewFolderCancel.addEventListener("click", closeNewFolderModal);
+$bmNewFolderConfirm.addEventListener("click", _commitNewFolder);
+$bmNewFolderInput.addEventListener("keydown", (e) => {
+  if (e.key === "Enter") { e.preventDefault(); _commitNewFolder(); }
+  else if (e.key === "Escape") { e.preventDefault(); closeNewFolderModal(); }
+});
 
 $bmSaveChapterBtn.addEventListener("click", () => {
   openSaveModal("chapter");


### PR DESCRIPTION
## 요약

북마크 드로어에서 제목 아래 보조 텍스트가 절 범위만(`22-23`) 표시되어 어느 책·장의 절인지 한눈에 알아볼 수 없었습니다. 이제 책 이름과 장 번호를 포함한 정식 참조 형식(`요한 5:22-23`)으로 표시합니다. 전체 장 북마크에도 `요한 5장`, `시편 23편` 형태로 책·장 단위까지 보조 라인에 노출합니다.

또한 북마크 저장 모달의 폴더 콤보박스에서 `+ 새 폴더` 액션으로 즉시 새 폴더를 만들어 선택할 수 있도록 했습니다.

## 변경 사항

- `js/app.js` `_buildBookmarkItem`: `bm-bookmark-ref` 텍스트를 `${bookName} ${chapter}:${verseSpec}` 형식으로 포맷. 전체 장 북마크는 `${bookName} ${chapter}장/편` 형식으로 노출
- 사용자가 제목을 자유롭게 수정해도 보조 라인은 항상 정확한 성경 참조를 보여줌
- `index.html`, `css/style.css`, `js/app.js`: 폴더 콤보박스 하단에 `+ 새 폴더` 액션과 새 폴더 모달 추가 (스크림 적층, 포커스 트랩, 키보드 닫기 포함)
- 새 폴더 생성 시 콤보박스 옵션을 재수집하고 새 폴더가 자동으로 선택됨
- `js/app.js` `_buildFolderCombobox`: `currentOptions`를 도입해 `rebuildOptions` 시 라벨 조회 배열도 함께 갱신 (Bugbot Medium: stale closure 수정)

## 테스트 계획

- [ ] 절 범위 북마크(예: 요한 5:22-23) 생성 후 북마크 드로어에서 보조 텍스트가 `요한 5:22-23` 으로 보이는지 확인
- [ ] 단일 절 북마크(예: 요한 5:20) 보조 텍스트가 `요한 5:20` 으로 보이는지 확인
- [ ] 시편(`ps`) 북마크에서 약칭(`시편`) 사용 여부 확인
- [ ] 전체 장 북마크 보조 라인이 `요한 5장`, `시편 23편` 등으로 노출되는지 확인
- [ ] 저장 모달에서 `+ 새 폴더`로 폴더 생성 시 콤보박스 라벨이 새 폴더 이름으로 즉시 갱신되는지 확인