### PR TITLE
fix: 업데이트 토스트가 좁은 뷰포트에서 한 글자씩 세로로 쌓이는 문제

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2016,9 +2016,12 @@ mark.search-highlight {
   transform: translateX(-50%);
   z-index: 10000;
   display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
   align-items: center;
-  gap: 0.75rem;
+  gap: 0.5rem 0.75rem;
   padding: 0.75rem 1rem;
+  max-width: calc(100vw - 2rem);
   background: var(--bg-card);
   color: var(--text);
   border: 1px solid var(--border);
@@ -2026,6 +2029,10 @@ mark.search-highlight {
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
   font-size: 0.9rem;
   animation: toast-in 0.3s ease-out;
+}
+
+#sw-update-toast > span {
+  white-space: nowrap;
 }
 
 #sw-update-release-link {


### PR DESCRIPTION
## 문제

좁은 뷰포트에서 SW 업데이트 토스트가 다음과 같이 깨져 보임:

```
새
버
전
이
있         1.3.0  [업데이트]
습
니
다:
```

## 원인

`#sw-update-toast`는 flex 컨테이너이고 자식 중 `#sw-update-release-link`(버전)와 `#sw-update-btn`(업데이트 버튼)에는 `white-space: nowrap`이 있어 자기 자연 너비를 유지한다. 반면 "새 버전이 있습니다:" span에는 `nowrap`이 없다.

flex 항목의 기본 `min-width: auto`는 콘텐츠의 `min-content` 너비로 해석되는데, 한국어는 글자 사이마다 줄바꿈 가능 지점이라 `min-content`가 **한 글자 너비**다. 그래서 토스트의 자연 너비가 뷰포트를 살짝 넘는 상황에서 다른 두 항목은 안 줄어들고 span만 한 글자 너비까지 압축되어 세로로 쌓였다.

## 해결

`css/style.css`의 `#sw-update-toast`:
- span에 `white-space: nowrap` 적용해 글자 단위 줄바꿈 차단
- `flex-wrap: wrap` + `max-width: calc(100vw - 2rem)`로 정말 좁은 화면에선 항목 단위로 두 줄로 자연스럽게 감싸지도록
- `gap`을 row/column 분리해 줄바꿈 시 행간 확보

## Test plan

- [ ] 좁은 뷰포트(예: iPhone SE/13 mini, ~375px)에서 업데이트 알림이 떴을 때 "새 버전이 있습니다:"가 가로로 한 줄에 표기되는지
- [ ] 매우 좁은 뷰포트에서 토스트가 화면을 벗어나지 않고 항목 단위로 두 줄로 감싸지는지
- [ ] 일반 뷰포트(데스크탑/태블릿)에서 한 줄 레이아웃이 그대로 유지되는지

https://claude.ai/code/session_016A9D6Xkz9Hfc9ebd28i9NM

---
_Generated by [Claude Code](https://claude.ai/code/session_016A9D6Xkz9Hfc9ebd28i9NM)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CSS-only change scoped to `#sw-update-toast` layout; potential impact is limited to toast wrapping/alignment on small screens.
> 
> **Overview**
> Fixes the SW update toast layout on narrow viewports by allowing the toast to *wrap as a whole* while preventing the message text from breaking into single-character lines.
> 
> Updates `#sw-update-toast` to use `flex-wrap`, centered wrapping, a two-dimensional `gap`, and a `max-width` constraint, and applies `white-space: nowrap` to the leading message `span`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81d539b95ad398a471a24af131d95f05686c1110. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->