### PR TITLE
fix: 컴팩트 검색 모달에서 safe-area로 칩이 잘리는 문제 해결

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1027,7 +1027,12 @@ body {
    left/right margins are inherited from the base rule (already 0.75rem); the
    bottom is applied via JS in adjustSheetForKeyboard (keyboardOffset + 12). */
 #search-sheet[data-state="compact"] {
-  height: 6.4rem;
+  /* Add the safe-area inset so it doesn't eat the chip row. With
+     box-sizing:border-box the base `padding-bottom: env(safe-area-inset-bottom)`
+     subtracts from the fixed height, and on devices with a home indicator the
+     value stays >0 even while the keyboard is up (it tracks the layout viewport,
+     not the visual one). */
+  height: calc(6.4rem + env(safe-area-inset-bottom));
   /* Omnidirectional shadow so the modal reads as a floating card. The base
      rule's negative-Y shadow only suits the bottom-attached expanded state. */
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.22);


### PR DESCRIPTION
## Summary
- 컴팩트 검색 모달의 `+ in:` 칩이 iPhone에서 절반쯤 잘려 보이던 문제를 수정
- 원인: `#search-sheet` 의 `padding-bottom: env(safe-area-inset-bottom)` 이 `box-sizing: border-box` 와 만나 고정 높이(`6.4rem`)에서 안전 영역만큼 콘텐츠 공간을 깎아냄. 키보드가 떠 있어도 `env(safe-area-inset-bottom)` 은 layout viewport 기준이라 0이 되지 않음
- 해결: 컴팩트 상태 height 를 `calc(6.4rem + env(safe-area-inset-bottom))` 로 바꿔 콘텐츠 영역이 항상 `6.4rem` 을 유지하도록 함

## Test plan
- [ ] iPhone(홈 인디케이터 있는 모델) Safari 에서 검색 FAB → 컴팩트 모달 진입 시 `+ in:` 칩이 온전히 보이는지 확인
- [ ] 키보드가 올라온 상태에서도 칩이 잘리지 않는지 확인
- [ ] 데스크톱에서는 모달이 숨겨져 있어 영향 없음 확인 (`@media (min-width: 769px)` 에서 `display: none`)
- [ ] 컴팩트 ↔ 확장 전환 220ms height 트랜지션이 정상 동작하는지 확인

https://claude.ai/code/session_01Wz3ZAagn8oLLSHCN3kUxRV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wz3ZAagn8oLLSHCN3kUxRV)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CSS-only change that adjusts the compact search sheet height calculation to account for `env(safe-area-inset-bottom)` on iOS; potential impact is limited to mobile search modal layout/transition sizing.
> 
> **Overview**
> Fixes an iOS Safari layout issue where the compact search bottom sheet’s chip row could be clipped by the persistent `safe-area` bottom padding.
> 
> In `css/style.css`, the compact `#search-sheet` height is changed from a fixed `6.4rem` to `calc(6.4rem + env(safe-area-inset-bottom))` so the usable content area remains consistent on devices with a home indicator while preserving the existing height transition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e418ba946de2995a4c1c05631a555314b87967b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->