### PR TITLE
feat: PWA실행 중 주기적으로 새 버전 확인

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -5170,23 +5170,39 @@ function registerServiceWorker() {
   }
 
   function trackInstalling(reg) {
+    if (!reg.installing) return;
     reg.installing.addEventListener("statechange", () => {
       if (reg.waiting) showUpdateToast(reg.waiting);
     });
   }
 
+  // Poll for a new SW at most once per hour, and only while the tab is visible
+  // and online — a phone in the user's pocket performs zero update traffic.
+  // visibilitychange/online also retrigger the check on tab return / reconnect,
+  // since interval timers are heavily throttled in hidden tabs.
+  const UPDATE_CHECK_INTERVAL_MS = 60 * 60 * 1000;
+  function schedulePeriodicUpdate(reg) {
+    let lastCheck = Date.now();
+    const tick = () => {
+      if (document.visibilityState !== "visible") return;
+      if (navigator.onLine === false) return;
+      const now = Date.now();
+      if (now - lastCheck < UPDATE_CHECK_INTERVAL_MS) return;
+      lastCheck = now;
+      reg.update().catch(() => {});
+    };
+    setInterval(tick, UPDATE_CHECK_INTERVAL_MS);
+    document.addEventListener("visibilitychange", tick);
+    window.addEventListener("online", tick);
+  }
+
   navigator.serviceWorker.register("/sw.js", { updateViaCache: "none" }).then((reg) => {
     // A waiting SW already exists (e.g. installed on a previous visit)
-    if (reg.waiting) {
-      showUpdateToast(reg.waiting);
-      return;
-    }
+    if (reg.waiting) showUpdateToast(reg.waiting);
     // A new SW is being installed right now
-    if (reg.installing) {
-      trackInstalling(reg);
-      return;
-    }
-    // Listen for future updates
+    else if (reg.installing) trackInstalling(reg);
+    // Listen for future updates — fired when reg.update() finds a new SW too
     reg.addEventListener("updatefound", () => trackInstalling(reg));
+    schedulePeriodicUpdate(reg);
   }).catch(() => {});
 }


### PR DESCRIPTION
## 배경

PWA를 한 번 실행한 뒤 닫지 않고 계속 사용하는 경우, 새 릴리스가 배포되어도 다음 실행 시점까지 업데이트 토스트가 뜨지 않았다. 서버 푸시가 없으므로 클라이언트가 주기적으로 확인해야 한다.

## 변경 내용

`js/app.js`의 `registerServiceWorker`에 `schedulePeriodicUpdate(reg)`를 추가하여 `reg.update()`를 주기적으로 호출한다.

배터리·데이터 영향 최소화 정책:
- **간격: 1시간** (`UPDATE_CHECK_INTERVAL_MS = 60 * 60 * 1000`)
- `document.visibilityState === "visible"`이고 `navigator.onLine`일 때만 네트워크 요청 — 주머니 속 단말은 0회
- `visibilitychange` / `online` 이벤트로도 tick 호출 → 숨김 탭에서 throttle되는 인터벌을 보완. 마지막 체크 후 1시간 경과 시에만 실제 요청

함께 정리한 부분:
- `reg.waiting` / `reg.installing` 분기의 early return 제거 — `updatefound` 리스너가 항상 등록되도록 하여 `reg.update()`가 신규 SW를 발견했을 때도 토스트가 동작
- `trackInstalling`에 `if (!reg.installing) return` 가드 추가

## 수동 확인 사항

- [ ] 다음 릴리스 시 PWA를 백그라운드 → 포그라운드로 전환하면 1시간 이내에 토스트가 노출되는지
- [ ] 비행기 모드 → 복귀 시 `online` 이벤트로 즉시 재확인되는지
- [ ] 토스트의 `업데이트` 버튼이 종전과 동일하게 `SKIP_WAITING` → controllerchange → reload 순서로 동작하는지

https://claude.ai/code/session_017wqrz2ZKxd3kJ1449PfvRJ

---
_Generated by [Claude Code](https://claude.ai/code/session_017wqrz2ZKxd3kJ1449PfvRJ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes service worker update behavior by adding periodic `reg.update()` polling and adjusting registration flow, which could affect update/toast timing and network usage for all PWA users.
> 
> **Overview**
> Enables long-running PWA sessions to detect new releases without a full restart by periodically calling `ServiceWorkerRegistration.update()` (capped at once per hour) and retriggering checks on `visibilitychange` and `online` events, only when the tab is visible and connected.
> 
> Also refactors the SW registration branching so the `updatefound` listener and periodic scheduler are always installed (no early `return`s) and adds a guard in `trackInstalling` to avoid attaching listeners when `reg.installing` is missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a6020740041b4859592e2c741dca9a460a85e82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->