### PR TITLE
fix: SW 업데이트 토스트가 새 버전 대신 현재 버전을 표시하던 문제 수정

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -5146,10 +5146,33 @@ function registerServiceWorker() {
     window.location.reload();
   });
 
+  // Ask the waiting SW for the version it has cached, since loadVersion()
+  // returns the version of the currently running app (served by the active SW).
+  // Falls back to "" on timeout/error so the toast still renders.
+  function fetchWaitingVersion(waitingSW) {
+    return new Promise((resolve) => {
+      const channel = new MessageChannel();
+      let settled = false;
+      const finish = (v) => {
+        if (settled) return;
+        settled = true;
+        resolve(v || "");
+      };
+      channel.port1.onmessage = (e) => finish(e.data && e.data.version);
+      try {
+        waitingSW.postMessage({ type: "GET_VERSION" }, [channel.port2]);
+      } catch {
+        finish("");
+        return;
+      }
+      setTimeout(() => finish(""), 1500);
+    });
+  }
+
   async function showUpdateToast(waitingSW) {
     // Prevent duplicate toasts
     if (document.getElementById("sw-update-toast")) return;
-    const version = await loadVersion();
+    const version = await fetchWaitingVersion(waitingSW);
     const btn = el("button", { id: "sw-update-btn", "aria-label": "새 버전이 있습니다." }, "업데이트");
     const versionLink = el("a", {
       href: "https://github.com/anglican-kr/common-bible/releases",

--- a/sw.js
+++ b/sw.js
@@ -42,10 +42,26 @@ self.addEventListener("install", (event) => {
   );
 });
 
-// Allow the client to trigger skipWaiting via postMessage
+// Allow the client to trigger skipWaiting via postMessage,
+// or to query this SW's bundled version for the update toast.
+// GET_VERSION reads /version.json from THIS SW's own CACHE_NAME so the
+// reply reflects the version about to be installed, not the one currently
+// active in the page (the active SW serves a stale copy of version.json).
 self.addEventListener("message", (event) => {
   if (event.data && event.data.type === "SKIP_WAITING") {
     self.skipWaiting();
+    return;
+  }
+  if (event.data && event.data.type === "GET_VERSION") {
+    const port = event.ports && event.ports[0];
+    if (!port) return;
+    event.waitUntil(
+      caches.open(CACHE_NAME)
+        .then((cache) => cache.match("/version.json"))
+        .then((res) => (res ? res.json() : null))
+        .then((data) => port.postMessage({ version: (data && data.version) || "" }))
+        .catch(() => port.postMessage({ version: "" }))
+    );
   }
 });
 

--- a/tests/e2e/test_update_toast.py
+++ b/tests/e2e/test_update_toast.py
@@ -5,6 +5,8 @@ registration을 즉시 반환한다. 앱이 reg.waiting을 감지하면 showUpda
 호출해 #sw-update-toast가 삽입된다.
 """
 
+import json
+
 BASE = "http://localhost:8080"
 
 # navigator.serviceWorker.register를 완전히 교체: waiting SW가 있는 reg를 즉시 반환.
@@ -66,5 +68,100 @@ def test_update_btn_sends_skip_waiting(browser):
         msg = page.evaluate("() => window.__swSkipMsg")
         assert msg is not None, "No postMessage sent to waiting SW"
         assert msg.get("type") == "SKIP_WAITING", f"Unexpected message type: {msg}"
+    finally:
+        ctx.close()
+
+
+# ── GET_VERSION roundtrip ─────────────────────────────────────────────────────
+# waiting SW가 GET_VERSION에 MessageChannel 포트로 응답하면 토스트는 active SW의
+# version.json이 아니라 응답된 새 버전을 표시해야 한다.
+
+_SW_WAITING_STUB_RESPONDING = """
+window.__swMessages = [];
+navigator.serviceWorker.register = async function() {
+    const fakeSW = {
+        postMessage: function(msg, transfer) {
+            window.__swMessages.push({ type: msg && msg.type });
+            if (msg && msg.type === 'GET_VERSION' && transfer && transfer[0]) {
+                transfer[0].postMessage({ version: window.__stubVersion });
+                return;
+            }
+            if (msg && msg.type === 'SKIP_WAITING') {
+                window.__swSkipMsg = msg;
+            }
+        }
+    };
+    return {
+        waiting: fakeSW,
+        installing: null,
+        active: null,
+        addEventListener: function() {},
+    };
+};
+"""
+
+
+def _make_page_with_responding_sw(browser, version):
+    """GET_VERSION에 `version`으로 응답하는 waiting SW stub을 주입한다."""
+    ctx = browser.new_context(service_workers="block")
+    ctx.add_init_script(f"window.__stubVersion = {json.dumps(version)};")
+    ctx.add_init_script(_SW_WAITING_STUB_RESPONDING)
+    page = ctx.new_page()
+    page.goto(BASE)
+    return ctx, page
+
+
+def test_update_toast_shows_waiting_sw_version(browser):
+    """토스트 버전 라벨은 active SW의 version.json이 아니라 waiting SW가 응답한 값이다."""
+    ctx, page = _make_page_with_responding_sw(browser, "9.9.9-test")
+    try:
+        page.wait_for_selector("#sw-update-release-link", timeout=5_000)
+        text = page.text_content("#sw-update-release-link")
+        assert text == "9.9.9-test", (
+            f"Expected toast to display waiting SW version '9.9.9-test', got {text!r}"
+        )
+    finally:
+        ctx.close()
+
+
+def test_get_version_message_sent_to_waiting_sw(browser):
+    """앱은 waiting SW에 GET_VERSION 메시지를 전송해 버전을 조회한다."""
+    ctx, page = _make_page_with_responding_sw(browser, "9.9.9-test")
+    try:
+        page.wait_for_selector("#sw-update-toast", timeout=5_000)
+        page.wait_for_function(
+            "() => (window.__swMessages || []).some(m => m.type === 'GET_VERSION')",
+            timeout=2_000,
+        )
+    finally:
+        ctx.close()
+
+
+def test_update_toast_falls_back_when_sw_does_not_respond(browser):
+    """waiting SW가 GET_VERSION에 응답하지 않으면 1.5s 타임아웃 후 '최신 버전' 폴백."""
+    no_reply_stub = """
+    navigator.serviceWorker.register = async function() {
+        const fakeSW = {
+            postMessage: function() { /* no reply */ }
+        };
+        return {
+            waiting: fakeSW,
+            installing: null,
+            active: null,
+            addEventListener: function() {},
+        };
+    };
+    """
+    ctx = browser.new_context(service_workers="block")
+    ctx.add_init_script(no_reply_stub)
+    page = ctx.new_page()
+    page.goto(BASE)
+    try:
+        # fetchWaitingVersion 1.5s 타임아웃 → 토스트 삽입까지 대기
+        page.wait_for_selector("#sw-update-release-link", timeout=5_000)
+        text = page.text_content("#sw-update-release-link")
+        assert text == "최신 버전", (
+            f"Expected fallback label '최신 버전' on no-response, got {text!r}"
+        )
     finally:
         ctx.close()


### PR DESCRIPTION
## Summary
- 토스트 \"새 버전이 있습니다: …\"가 active SW가 서빙하는 `version.json`(=실행 중인 구 버전)을 보여주던 문제 수정
- waiting SW가 자신의 `CACHE_NAME` 안에 fresh로 캐시한 `version.json`을 `GET_VERSION` 메시지 + `MessageChannel`로 응답하도록 변경 — 곧 설치될 버전이 노출되며 오프라인에서도 동작
- e2e 회귀 가드 3건 추가 (응답 케이스 라벨 검증, 메시지 전송 검증, 무응답 시 1.5s 타임아웃 → \"최신 버전\" 폴백)

## 변경 파일
- [sw.js](sw.js): `message` 핸들러에 `GET_VERSION` 분기 추가 — `caches.open(CACHE_NAME)` → `match('/version.json')` → `port.postMessage({ version })`
- [js/app.js](js/app.js): `showUpdateToast`가 `loadVersion()`(active SW 경유, 메모리 캐시) 대신 `fetchWaitingVersion(waitingSW)` 호출. 1.5s 타임아웃·예외 시 빈 문자열 → 기존 \"최신 버전\" 폴백 유지
- [tests/e2e/test_update_toast.py](tests/e2e/test_update_toast.py): GET_VERSION 라운드트립 stub 헬퍼 + 신규 테스트 3건

## Test plan
- [x] `pytest tests/test_completeness.py tests/test_ordering.py tests/test_snapshots.py` (선행 `isa-2` 실패는 main 기준 동일, 본 변경과 무관)
- [x] `pytest tests/e2e/` 163건 전부 통과 (update-toast 6건 포함)
- [ ] 다음 릴리스 (`scripts/release.py patch`)에서 실제 SW 업데이트 흐름으로 토스트가 새 버전 문자열을 표시하는지 수동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches service worker messaging and cache reads; a mistake could break update prompts or SW lifecycle behavior across browsers, though the change is narrowly scoped and has E2E coverage.
> 
> **Overview**
> Fixes the SW update toast so it displays the *incoming* (waiting) service worker’s version instead of the currently active app version.
> 
> `js/app.js` now queries the waiting SW via `MessageChannel` (`GET_VERSION`) with a 1.5s timeout/empty-string fallback, and `sw.js` handles `GET_VERSION` by reading `/version.json` from the waiting SW’s own `CACHE_NAME` and replying with `{ version }`.
> 
> Adds E2E coverage to assert the `GET_VERSION` roundtrip (label uses the waiting SW’s version), that the message is sent, and that the UI falls back to “최신 버전” when the SW doesn’t respond.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed7f4d4393ac706a496ac449f1b29391f4099c45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->