### PR TITLE
chore: state-machine 유닛 테스트 + CI 워크플로우

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+name: Tests
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  unit:
+    name: Unit tests (state-machine)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+      - run: node --test tests/unit/state-machine.test.js

--- a/tests/unit/harness.js
+++ b/tests/unit/harness.js
@@ -1,0 +1,221 @@
+// ── Test harness for js/sync/state-machine.js ────────────────────────────────
+// Loads the state machine inside a fresh node:vm context per test, with all
+// browser-only globals (window, localStorage, navigator, document, setTimeout)
+// stubbed. Exposes loadMachine(opts) which returns { machine, ctx, stubs,
+// logEntries, fireAllTimers } so tests can drive transitions and inspect
+// internal state via the L.log spy.
+//
+// Why node:vm? state-machine.js is loaded as a classic <script> in the browser
+// — it relies on `window.syncTransport`, `window.syncStoreV2`, `window.syncDebugLog`
+// being set before the file runs, and exports its factory by writing to
+// `window.createSyncMachine`. We replicate that environment without ESM.
+
+import vm from "node:vm";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const STATE_MACHINE_PATH = path.resolve(__dirname, "../../js/sync/state-machine.js");
+const SOURCE = fs.readFileSync(STATE_MACHINE_PATH, "utf8");
+
+// Constants mirrored from state-machine.js — kept here so tests can assert
+// against them without parsing the source.
+export const REDIRECT_ATTEMPTS_KEY = "bible-drive-redirect-attempts";
+export const SYNC_ENABLED_KEY = "bible-drive-sync";
+export const SYNC_EMAIL_KEY = "bible-drive-sync-email";
+export const MAX_REDIRECT_ATTEMPTS = 3;
+export const MAX_REAUTH = 3;
+
+// ── In-memory localStorage ───────────────────────────────────────────────────
+
+function makeLocalStorage(initial = {}) {
+  const store = { ...initial };
+  return {
+    getItem: (k) => (k in store ? store[k] : null),
+    setItem: (k, v) => { store[k] = String(v); },
+    removeItem: (k) => { delete store[k]; },
+    clear: () => { for (const k of Object.keys(store)) delete store[k]; },
+    _raw: store,
+  };
+}
+
+// ── Stub factories ───────────────────────────────────────────────────────────
+
+function makeTransportStub({ isIOS = false, hasGoogleId = false, uploadResult, findFileId, downloadResult } = {}) {
+  return {
+    isIOS: () => isIOS,
+    initTokenClient: () => ({ requestAccessToken: () => {} }),
+    requestSilentToken: () => {},
+    requestConsentToken: () => {},
+    revokeToken: () => {},
+    initIdentityClient: () => hasGoogleId,
+    promptIdentity: () => {},
+    cancelIdentityPrompt: () => {},
+    parseIdToken: () => ({ email: "test@example.com" }),
+    beginRedirectAuth: () => {},
+    fetchUserInfo: async () => ({ email: "test@example.com" }),
+    findSyncFileId: async () => (findFileId !== undefined ? findFileId : null),
+    downloadSyncFile: async () => (downloadResult ?? { doc: null, etag: null, status: 200 }),
+    uploadSyncFile: async () => (uploadResult ?? { ok: true, status: 200, etag: '"etag-1"' }),
+    deleteSyncFile: async () => ({ ok: true }),
+    consumeRedirectCallback: () => null,
+    DRIVE_HOSTNAMES: [],
+  };
+}
+
+function makeStoreV2Stub() {
+  const emptyDoc = () => ({
+    bookmarks: { items: {}, tombstones: {} },
+    settings: {
+      fontSize: { v: null, _u: 0 }, colorScheme: { v: null, _u: 0 },
+      theme: { v: null, _u: 0 }, bookOrder: { v: null, _u: 0 },
+      startupBehavior: { v: null, _u: 0 },
+    },
+    lastRead: { v: null, _u: 0 },
+  });
+  return {
+    getDeviceId: () => "test-device",
+    loadLocal: () => emptyDoc(),
+    saveLocal: () => {},
+    sweepTombstones: () => {},
+    loadBookmarks: () => [],
+    saveBookmarks: () => {},
+    saveSetting: () => {},
+    saveLastRead: () => {},
+    migrateLegacyIfNeeded: () => {},
+    mergeDocs: (local) => local,
+    maxU: () => 0,
+    buildSyncPayload: (deviceId) => ({ schemaVersion: 2, deviceId, ...emptyDoc() }),
+    validateRemote: () => true,
+    bookmarkTreeFromFlat: () => [],
+    applyToLegacyKeys: () => {},
+  };
+}
+
+function makeDebugLogStub() {
+  const entries = [];
+  return {
+    entries,
+    log: (entry) => { entries.push(entry); },
+    mask: (_, value) => (value == null ? value : `[masked]`),
+    dump: () => "",
+    copyToClipboard: async () => true,
+  };
+}
+
+// ── Fake timers ──────────────────────────────────────────────────────────────
+// Stored as { id, fn, delay } so tests can fire all pending timers and observe
+// resulting transitions. Used when useRealTimers: false. The map is created
+// per-loader-call inside loadMachine so each machine has independent state.
+
+function fireAllPending(pending) {
+  const ids = [...pending.keys()];
+  const fns = ids.map((id) => pending.get(id).fn);
+  pending.clear();
+  for (const fn of fns) {
+    try { fn(); } catch (_) { /* surface via test assertions */ }
+  }
+}
+
+// ── Main loader ──────────────────────────────────────────────────────────────
+
+export function loadMachine(opts = {}) {
+  const {
+    isIOS = false,
+    hasGoogleId = false,
+    uploadResult,
+    findFileId,
+    downloadResult,
+    initialStorage = {},
+    activeReading = false,
+    overrideStubs = {},
+    useRealTimers = true,
+    onlineFlag = true,
+  } = opts;
+
+  const localStorage = makeLocalStorage(initialStorage);
+  const T = { ...makeTransportStub({ isIOS, hasGoogleId, uploadResult, findFileId, downloadResult }), ...overrideStubs.T };
+  const V2 = { ...makeStoreV2Stub(), ...overrideStubs.V2 };
+  const L = makeDebugLogStub();
+
+  const fakePending = new Map();
+  let fakeNextId = 1;
+  const fakeSetTimeout = (fn, delay) => {
+    const id = fakeNextId++;
+    fakePending.set(id, { fn, delay });
+    return id;
+  };
+  const fakeClearTimeout = (id) => { fakePending.delete(id); };
+
+  // Build context. window/self-reference must be set after createContext.
+  const ctx = {
+    console,
+    Date,
+    Math,
+    Promise,
+    Object,
+    Array,
+    Set,
+    Map,
+    JSON,
+    Error,
+    parseInt,
+    parseFloat,
+    String,
+    Number,
+    Boolean,
+    Symbol,
+    isFinite,
+    isNaN,
+    setTimeout: useRealTimers ? setTimeout : fakeSetTimeout,
+    clearTimeout: useRealTimers ? clearTimeout : fakeClearTimeout,
+    setImmediate,
+    clearImmediate,
+    localStorage,
+    navigator: { onLine: onlineFlag },
+    document: {
+      visibilityState: "visible",
+      hasFocus: () => true,
+    },
+    google: hasGoogleId ? { accounts: { id: {}, oauth2: {} } } : undefined,
+    syncTransport: T,
+    syncStoreV2: V2,
+    syncDebugLog: L,
+    _syncClientId: "test-client-id",
+    __driveSyncInteractionTs: () => (activeReading ? Date.now() - 1000 : 0),
+  };
+
+  vm.createContext(ctx);
+  // Self-reference: scripts that read `window.X` should resolve to the same
+  // bag of globals that the script writes to (e.g. `window.createSyncMachine = ...`).
+  ctx.window = ctx;
+
+  vm.runInContext(SOURCE, ctx, { filename: "state-machine.js" });
+
+  const onStateChange = () => {};
+  const machine = ctx.createSyncMachine({ onStateChange });
+
+  // Helper: find ctx snapshot at a specific event in the log.
+  function ctxAt(eventType) {
+    const entry = L.entries.find((e) => e.kind === "ACTION" && e.event === eventType);
+    return entry?.ctx ?? null;
+  }
+
+  // Helper: drain microtasks so async _syncCycle settles.
+  async function drain(times = 1) {
+    for (let i = 0; i < times; i++) await new Promise((r) => setImmediate(r));
+  }
+
+  return {
+    machine,
+    ctx,
+    stubs: { T, V2, L },
+    logEntries: L.entries,
+    localStorage,
+    ctxAt,
+    drain,
+    fireAllTimers: () => fireAllPending(fakePending),
+    pendingTimers: fakePending,
+  };
+}

--- a/tests/unit/harness.js
+++ b/tests/unit/harness.js
@@ -20,12 +20,10 @@ const STATE_MACHINE_PATH = path.resolve(__dirname, "../../js/sync/state-machine.
 const SOURCE = fs.readFileSync(STATE_MACHINE_PATH, "utf8");
 
 // Constants mirrored from state-machine.js — kept here so tests can assert
-// against them without parsing the source.
+// against them without parsing the source. Only those actually used by
+// state-machine.test.js are exported.
 export const REDIRECT_ATTEMPTS_KEY = "bible-drive-redirect-attempts";
-export const SYNC_ENABLED_KEY = "bible-drive-sync";
-export const SYNC_EMAIL_KEY = "bible-drive-sync-email";
 export const MAX_REDIRECT_ATTEMPTS = 3;
-export const MAX_REAUTH = 3;
 
 // ── In-memory localStorage ───────────────────────────────────────────────────
 

--- a/tests/unit/state-machine.test.js
+++ b/tests/unit/state-machine.test.js
@@ -184,6 +184,9 @@ test("12. iOS OFFLINE → NET_RECOVERED → NEEDS_CONSENT (commit 87b1896 회귀
   await drain(5);
   // navigator.onLine=false → 첫 5xx에서 즉시 OFFLINE
   assert.equal(machine.getState(), "OFFLINE");
+  // 사이클이 backoff retry 없이 단번에 OFFLINE으로 갔는지 확인 — onLine=false가
+  // MAX_NET_RETRIES 카운트를 무시하고 첫 실패에서 곧장 OFFLINE 분기를 타게 한다.
+  assert.equal(downloadFails, 1, "첫 다운로드 실패에서 즉시 OFFLINE으로 진입");
   // NET_RECOVERED 디스패치
   machine.dispatch({ type: "NET_RECOVERED" });
   assert.equal(machine.getState(), "NEEDS_CONSENT");

--- a/tests/unit/state-machine.test.js
+++ b/tests/unit/state-machine.test.js
@@ -1,0 +1,244 @@
+// ── state-machine.js unit tests ─────────────────────────────────────────────
+// Run with: node --test tests/unit/state-machine.test.js
+//
+// Each test loads a fresh state machine via loadMachine() so closures
+// (_state, _ctx, _token) don't bleed between cases. Async _syncCycle settles
+// after `drain()` (one setImmediate). Timer-driven tests use useRealTimers:
+// false + fireAllTimers().
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  loadMachine,
+  REDIRECT_ATTEMPTS_KEY,
+  MAX_REDIRECT_ATTEMPTS,
+} from "./harness.js";
+
+// ── Group 1: ENABLE 분기 ─────────────────────────────────────────────────────
+
+test("1. 초기 상태는 DISABLED", () => {
+  const { machine } = loadMachine();
+  assert.equal(machine.getState(), "DISABLED");
+  assert.equal(machine.isEnabled(), false);
+  assert.equal(machine.isAuthenticated(), false);
+});
+
+test("2. non-iOS + GIS 미준비 → INITIALIZING", () => {
+  const { machine } = loadMachine({ isIOS: false, hasGoogleId: false });
+  machine.enable();
+  assert.equal(machine.getState(), "INITIALIZING");
+});
+
+test("3. iOS ENABLE → NEEDS_CONSENT (Phase 2f 회귀 방어)", () => {
+  // iOS는 GIS 자체를 거치지 않고 사용자 제스처(_연결_ 클릭)에서만
+  // OAuth 리디렉션이 시작돼야 한다. enable() 직후엔 redirect를 트리거하지 않고
+  // NEEDS_CONSENT에 정착해 설정 UI에 "연결" 버튼이 노출되도록 한다.
+  const { machine } = loadMachine({ isIOS: true });
+  machine.enable();
+  assert.equal(machine.getState(), "NEEDS_CONSENT");
+});
+
+// ── Group 2: acceptRedirectToken (iOS redirect 흐름) ─────────────────────────
+
+test("4. acceptRedirectToken('') → no-op (commit 682292d 회귀 방어)", () => {
+  const { machine } = loadMachine({ isIOS: true });
+  machine.acceptRedirectToken("");
+  assert.equal(machine.getState(), "DISABLED");
+  assert.equal(machine.isAuthenticated(), false);
+});
+
+test("5. acceptRedirectToken(null) → no-op", () => {
+  const { machine } = loadMachine({ isIOS: true });
+  machine.acceptRedirectToken(null);
+  assert.equal(machine.getState(), "DISABLED");
+  assert.equal(machine.isAuthenticated(), false);
+});
+
+test("6. 유효 토큰 → IDLE → SYNCING (drain 후) → IDLE (sync 완료 후)", async () => {
+  const { machine, drain } = loadMachine({
+    isIOS: true,
+    findFileId: null,
+    uploadResult: { ok: true, status: 200, etag: '"e1"' },
+  });
+  machine.acceptRedirectToken("test-token-abc");
+  // _storeToken은 동기, _transition(IDLE) 동기, dispatch(SYNC_REQUEST)도 동기 →
+  // SYNCING 상태로 진입하지만 _syncCycle 자체는 비동기.
+  assert.equal(machine.getState(), "SYNCING");
+  assert.equal(machine.isAuthenticated(), true);
+  await drain(3);
+  // findFileId=null + uploadResult.ok=true → SYNC_DONE → IDLE
+  assert.equal(machine.getState(), "IDLE");
+});
+
+test("7. 토큰 수신만으로는 redirect-attempts 카운터 리셋 안 됨 (loop cap 회귀 방어)", async () => {
+  const initial = { [REDIRECT_ATTEMPTS_KEY]: "2" };
+  // findFileId 호출이 401을 시뮬레이션하도록 transport stub 교체:
+  // downloadSyncFile은 status 401 반환 → SYNC_FAIL("401")로 무한 루프 방지 확인 위해
+  // 여기서는 단순히 동기화 사이클이 시도되기 전 카운터 값만 검증.
+  const { machine, localStorage } = loadMachine({
+    isIOS: true,
+    initialStorage: initial,
+    findFileId: null,
+    uploadResult: { ok: true, status: 200, etag: '"e1"' },
+  });
+  machine.acceptRedirectToken("test-token");
+  // SYNC_DONE 전 상태에서 카운터 보존되는지 확인
+  assert.equal(localStorage.getItem(REDIRECT_ATTEMPTS_KEY), "2");
+});
+
+// ── Group 3: SYNC_DONE ───────────────────────────────────────────────────────
+
+test("8. SYNC_DONE 시에만 redirect-attempts 카운터가 0으로 리셋됨", async () => {
+  const initial = { [REDIRECT_ATTEMPTS_KEY]: "2" };
+  const { machine, localStorage, drain } = loadMachine({
+    isIOS: true,
+    initialStorage: initial,
+    findFileId: null,
+    uploadResult: { ok: true, status: 200, etag: '"e1"' },
+  });
+  machine.acceptRedirectToken("test-token");
+  assert.equal(localStorage.getItem(REDIRECT_ATTEMPTS_KEY), "2", "토큰 수신 직후엔 보존");
+  await drain(3);
+  // SYNC_DONE이 발화하면 카운터를 "0"으로 명시 설정
+  assert.equal(localStorage.getItem(REDIRECT_ATTEMPTS_KEY), "0", "SYNC_DONE 후 리셋");
+});
+
+// ── Group 4: SYNC_FAIL 401 / reAuthFails ─────────────────────────────────────
+
+test("9. non-iOS + GIS id available + 401 → IDENTIFYING, reAuthFails 1로 증가", async () => {
+  const { machine, drain } = loadMachine({
+    isIOS: false,
+    hasGoogleId: true,
+    findFileId: "fid",
+    downloadResult: { doc: null, etag: null, status: 401 },
+  });
+  // 직접 IDLE 상태로 진입시키기 위해 acceptRedirectToken 사용 (iOS=false에서도 동작)
+  // — acceptRedirectToken은 iOS-only가 아닌 토큰 직접 주입 경로
+  machine.acceptRedirectToken("token");
+  await drain(3);
+  // 401 수신 → _handleSyncFail("401") → IDENTIFYING (hasGoogleId true 분기)
+  assert.equal(machine.getState(), "IDENTIFYING");
+  // ctxAt: dispatch 시점의 ctx 스냅샷. _handleSyncFail은 reAuthFails+1 패치.
+  // dispatch SYNC_FAIL 직후 _transition이 호출되며 그 시점 _ctx는 reAuthFails: 0
+  // (이전 cycle에 저장된 값) — 실제 증가는 _transition 내부에서 이뤄짐.
+  // 직접 검증은 어려우므로 다음 cycle 진입을 의미하는 IDENTIFYING 상태만 확인.
+});
+
+test("10. iOS 401 + 활발히 읽는 중 → NEEDS_CONSENT (commit 682292d 회귀 방어)", async () => {
+  const { machine, drain } = loadMachine({
+    isIOS: true,
+    activeReading: true,
+    findFileId: "fid",
+    downloadResult: { doc: null, etag: null, status: 401 },
+  });
+  machine.acceptRedirectToken("token");
+  await drain(3);
+  // 사용자가 능동적으로 읽는 중엔 disruptive redirect 대신 snackbar+park.
+  assert.equal(machine.getState(), "NEEDS_CONSENT");
+});
+
+test("11. 401 SYNC_FAIL → REAUTH 로그 attempt=1 + ctx에 reAuthFails 증가 기록", async () => {
+  // MAX_REAUTH ≥ 3 분기는 정상 이벤트 흐름으로 도달 불가:
+  // - AUTHENTICATING + TOKEN_OK → IDLE (empty ctxPatch) → reAuthFails 리셋
+  // - IDENTIFYING/AUTHENTICATING/NEEDS_CONSENT에서 SYNC_FAIL은 핸들러 없음 (no-op)
+  // - iOS active-reading 경로는 _beginRedirect로 페이지 이탈 → 새 세션 시작
+  // 따라서 cap 자체는 방어 코드. 대신 첫 401 발생 시 카운터 증가 의도가
+  // 로그에 정확히 기록되는지를 회귀 방어 지점으로 검증한다.
+  const { machine, drain, logEntries } = loadMachine({
+    isIOS: false,
+    hasGoogleId: true,
+    findFileId: "fid",
+    downloadResult: { doc: null, etag: null, status: 401 },
+  });
+  machine.acceptRedirectToken("token");
+  await drain(3);
+  const reauth = logEntries.find((e) => e.event === "REAUTH");
+  assert.ok(reauth, "REAUTH 로그 엔트리 존재");
+  assert.equal(reauth.attempt, 1, "첫 401에서 attempt=1");
+  assert.equal(machine.getState(), "IDENTIFYING");
+});
+
+// ── Group 5: OFFLINE + NET_RECOVERED ─────────────────────────────────────────
+
+test("12. iOS OFFLINE → NET_RECOVERED → NEEDS_CONSENT (commit 87b1896 회귀 방어)", async () => {
+  // OFFLINE 진입 경로: navigator.onLine=false + 5xx → 첫 실패에서 즉시 OFFLINE.
+  // 이전 코드는 AUTHENTICATING로 갔지만 GIS 미사용 iOS 경로에선 dispatch 진행
+  // 불가로 stuck. 현재 코드는 NEEDS_CONSENT로 정착해 사용자 제스처를 대기한다.
+  // OFFLINE 도달: navigator.onLine=false + sync 5xx 반복으로 OFFLINE 진입
+  let downloadFails = 0;
+  const { machine, drain } = loadMachine({
+    isIOS: true,
+    onlineFlag: false,
+    findFileId: "fid",
+    overrideStubs: {
+      T: {
+        downloadSyncFile: async () => {
+          downloadFails++;
+          return { doc: null, etag: null, status: 500 };
+        },
+      },
+    },
+    useRealTimers: true,
+  });
+  machine.acceptRedirectToken("token");
+  await drain(5);
+  // navigator.onLine=false → 첫 5xx에서 즉시 OFFLINE
+  assert.equal(machine.getState(), "OFFLINE");
+  // NET_RECOVERED 디스패치
+  machine.dispatch({ type: "NET_RECOVERED" });
+  assert.equal(machine.getState(), "NEEDS_CONSENT");
+});
+
+test("13. non-iOS OFFLINE → NET_RECOVERED → AUTHENTICATING", async () => {
+  const { machine, drain } = loadMachine({
+    isIOS: false,
+    hasGoogleId: false, // GIS id 없음 → AUTHENTICATING로 직접 진입
+    onlineFlag: false,
+    findFileId: "fid",
+    overrideStubs: {
+      T: { downloadSyncFile: async () => ({ doc: null, etag: null, status: 500 }) },
+    },
+  });
+  machine.acceptRedirectToken("token");
+  await drain(3);
+  assert.equal(machine.getState(), "OFFLINE");
+  machine.dispatch({ type: "NET_RECOVERED" });
+  // hasGoogleId=false → IDENTIFYING이 아닌 AUTHENTICATING로 분기
+  assert.equal(machine.getState(), "AUTHENTICATING");
+});
+
+// ── Group 6: _beginRedirect cap ──────────────────────────────────────────────
+
+test("14. iOS USER_CONSENT_REQUEST + attempts<MAX_REDIRECT_ATTEMPTS → beginRedirectAuth 호출", () => {
+  let beginCalls = 0;
+  const initial = { [REDIRECT_ATTEMPTS_KEY]: "2" };
+  const { machine, localStorage } = loadMachine({
+    isIOS: true,
+    initialStorage: initial,
+    overrideStubs: {
+      T: { beginRedirectAuth: () => { beginCalls++; } },
+    },
+  });
+  machine.enable();
+  assert.equal(machine.getState(), "NEEDS_CONSENT");
+  machine.dispatch({ type: "USER_CONSENT_REQUEST" });
+  assert.equal(beginCalls, 1, "리디렉션 호출 발생");
+  assert.equal(localStorage.getItem(REDIRECT_ATTEMPTS_KEY), "3", "카운터 1 증가");
+});
+
+test("15. iOS USER_CONSENT_REQUEST + attempts≥MAX → ERROR + beginRedirectAuth 미호출 (commit e6179d1 회귀 방어)", () => {
+  let beginCalls = 0;
+  const initial = { [REDIRECT_ATTEMPTS_KEY]: String(MAX_REDIRECT_ATTEMPTS) };
+  const { machine } = loadMachine({
+    isIOS: true,
+    initialStorage: initial,
+    overrideStubs: {
+      T: { beginRedirectAuth: () => { beginCalls++; } },
+    },
+  });
+  machine.enable();
+  assert.equal(machine.getState(), "NEEDS_CONSENT");
+  machine.dispatch({ type: "USER_CONSENT_REQUEST" });
+  assert.equal(beginCalls, 0, "cap 초과 시 리디렉션 호출 차단");
+  assert.equal(machine.getState(), "ERROR");
+});


### PR DESCRIPTION
## Summary

`js/sync/state-machine.js` 상태 전이 로직에 유닛 테스트 도입. 브라우저 없이 Node.js 24 내장 `node:vm` + `node --test`로 실행, npm/package.json 불필요.

## 동기

state-machine.js는 fix 커밋이 반복돼 왔습니다:
- `reAuthFails` 카운터 누락 (commit 682292d)
- iOS redirect cap 미처리 (commit e6179d1)
- 빈 토큰 acceptRedirectToken no-op (commit 682292d)
- `OFFLINE → NET_RECOVERED` iOS 분기 누락 (commit 87b1896)
- ...

PR #39의 `// @ts-check` + JSDoc은 컴파일 타임 타입 안전성을 잡았지만, **런타임 상태 전이 자체**는 검증되지 않았습니다. 이 PR이 그 갭을 닫습니다.

## 변경 파일

| 파일 | 역할 |
|------|------|
| `tests/unit/harness.js` | `node:vm` 컨텍스트 셋업 + stub 팩토리. `loadMachine(opts)`로 매 테스트마다 독립 클로저 |
| `tests/unit/state-machine.test.js` | 15개 회귀 방어 테스트 |
| `.github/workflows/test.yml` | push/PR마다 `node --test` 자동 실행 |

## 테스트 시나리오 (15개)

### Group 1: ENABLE 분기
1. 초기 상태는 DISABLED
2. non-iOS + GIS 미준비 → INITIALIZING
3. **iOS ENABLE → NEEDS_CONSENT** (Phase 2f 회귀)

### Group 2: acceptRedirectToken
4. **`acceptRedirectToken('')` no-op** (commit 682292d)
5. `acceptRedirectToken(null)` no-op
6. 유효 토큰 → IDLE → SYNCING → IDLE
7. **토큰 수신만으로는 redirect-attempts 카운터 리셋 안 됨** (loop cap)

### Group 3: SYNC_DONE
8. **SYNC_DONE 시에만 redirect-attempts 0으로 리셋**

### Group 4: SYNC_FAIL 401
9. non-iOS 401 → IDENTIFYING
10. **iOS active-reading 401 → NEEDS_CONSENT** (commit 682292d)
11. 401 → REAUTH 로그 `attempt=1`

### Group 5: OFFLINE + NET_RECOVERED
12. **iOS OFFLINE → NET_RECOVERED → NEEDS_CONSENT** (commit 87b1896)
13. non-iOS OFFLINE → NET_RECOVERED → AUTHENTICATING

### Group 6: _beginRedirect cap
14. attempts<MAX → beginRedirectAuth 호출, 카운터 +1
15. **attempts≥MAX → ERROR + beginRedirectAuth 미호출** (commit e6179d1)

## CI 범위

플랜 원안에는 데이터 파이프라인 잡(Level 1-3)도 있었으나 GitHub Actions 환경에서 재현 불가 — `data/bible/*.json`은 `.gitignore`이고 `data/source/`는 private submodule. **유닛 테스트 잡만 포함**, 데이터 파이프라인 테스트는 로컬에서 별도 실행.

## 보안 검토

워크플로우 파일은 `${{ github.event.* }}` 신뢰할 수 없는 입력을 `run:` 명령에 인터폴레이션하지 않음. 단순 `node --test` 고정 경로 호출만.

## 검증

- ✅ `node --test tests/unit/state-machine.test.js` → 15/15 통과 (~70ms)
- ✅ 회귀 시나리오 매핑된 commit hash 함께 코멘트로 명시

## Test plan

- [ ] CI 잡 통과 확인 (Node 24 + Ubuntu)
- [ ] 로컬에서 `node --test tests/unit/state-machine.test.js` 재실행 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds CI workflow and Node-based unit tests only, with no production code changes. Main risk is CI noise/flakiness due to timing assumptions (Node 24, async drains), but it doesn’t affect runtime behavior.
> 
> **Overview**
> Adds a GitHub Actions workflow (`.github/workflows/test.yml`) to run `node --test` on every push/PR using Node 24.
> 
> Introduces a Node `vm`-based harness (`tests/unit/harness.js`) that loads `js/sync/state-machine.js` with stubbed browser globals and injectable transport/store behaviors.
> 
> Adds a focused unit test suite (`tests/unit/state-machine.test.js`) with 15 regression tests covering key state transitions around iOS redirect auth, `acceptRedirectToken` no-ops, `SYNC_DONE` redirect-attempt reset, 401/reauth handling, `OFFLINE → NET_RECOVERED` branching, and redirect-attempt caps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b895bd107aa5574cde8177249df0003afb734713. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->