### PR TITLE
docs: iOS 7일 ITP 적용 범위 정정 — 홈 화면 PWA는 면제

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,9 @@ iOS 한정 추가 동작:
 
 ### 알려진 한계
 
-- **iOS Safari 7일 ITP**: PWA를 7일 이상 미사용 시 storage(쿠키 + localStorage 포함) 정리 → 동기화 재연결 필요.
+- **iOS Safari 탭 사용 시 7일 ITP**: 홈 화면에 설치하지 않고 Safari 탭에서 직접 여는 경우, 7일 미사용 시 ITP가 storage(쿠키 + localStorage 포함)를 정리 → 동기화 재연결 필요. **홈 화면 설치 PWA(iOS 17+ HSWA)는 storage가 영속되어 ITP 적용 대상 아님** — ADR-011 §맥락 참고.
 - **iOS 모든 버전 Implicit Flow**: refresh token 미발급. 토큰은 1시간 만료 + 메모리 전용 → 매 cold start에 silent 재인증 round-trip 발생 (브리프 깜박임 < 1초).
+- **Google 자체 세션 만료**: Google OAuth 세션이 서버 측에서 약 2주 비활성 후 만료되면 silent 재인증이 실패 → "연결" 버튼 노출.
 - **iOS Chrome/Firefox 등 WebKit 래퍼 브라우저**: 설치 불가 + Drive 동기화 시 PWA-격리 컨텍스트 미보장.
 
 ## 프로젝트 구조

--- a/docs/decisions/011-bookmark-sync.md
+++ b/docs/decisions/011-bookmark-sync.md
@@ -481,8 +481,8 @@ ADR-013 (클라이언트 JS 유닛 테스트 전략) 참고. 위 6차 리뷰 정
 ### 알려진 트레이드오프
 
 - **앱 오픈 깜박임**: 매 cold start마다 accounts.google.com으로의 짧은 round-trip 발생. 빠른 망에서 < 1초, 느린 모바일 망에서 1~3초. `prompt=none`은 UI를 표시하지 않으므로 도메인 플래시만 보임.
-- **Google 측 세션 만료(ITP)**: Safari ITP가 Google 쿠키를 정리한 경우 silent가 실패 → silent-blocked=1 → 사용자가 "연결" 다시 눌러야 함. 첫 실패는 묵묵히 NEEDS_CONSENT, 이후 자동 시도 없음.
-- **외부 revoke 감지**: 사용자가 Google 계정 설정에서 권한을 끊으면 silent 시도가 실패하여 silent-blocked=1로 빠진다. 이는 의도된 동작 — 다음 사용자 제스처 시점에 명시적 consent로 복구.
+- **Google 자체 세션 만료**: Google OAuth 세션은 서버 측에서 일정 기간(약 2주) 비활성 시 만료된다. 이 경우 silent 시도는 `login_required`를 반환 → silent-blocked=1로 떨어져 사용자가 "연결"을 다시 눌러야 한다. 첫 실패는 묵묵히 NEEDS_CONSENT, 이후 자동 시도 없음. (※ iOS Safari 탭 7일 ITP storage cap은 **홈 화면 PWA에는 적용되지 않으므로** 설치 사용자에겐 무관 — ADR-011 §맥락 참고.)
+- **외부 revoke 감지**: 사용자가 Google 계정 설정에서 권한을 끊으면 silent 시도는 `consent_required`를 반환 → silent-blocked=1. 이는 의도된 동작 — 다음 사용자 제스처 시점에 명시적 consent로 복구.
 
 ### Bugbot 1차 리뷰 정제 (PR #43)
 


### PR DESCRIPTION
## Summary

ADR-011 §맥락(line 26-27)은 이미 "홈 화면 PWA로 설치하면 ITP 적용이 제외되어 안전하지만, 미설치 사용자는 여전히 취약하다"고 정확히 기록하고 있었으나, Phase 2g 트레이드오프 노트와 README \"알려진 한계\" 섹션은 그 사실과 어긋나 **PWA 일반에 7일 ITP가 적용되는 것처럼 잘못 기술**되어 있었습니다.

## 실제 동작

| 환경 | 7일 ITP storage cap |
|------|---------------------|
| Safari 탭에서 bible.anglican.kr 직접 열기 | 적용 — 7일 미사용 시 storage 정리 |
| **홈 화면에 설치한 PWA (iOS 17+ HSWA)** | **면제** — storage 영속 |

따라서 Phase 2g silent 재인증 실패의 실제 사유는:
1. **Google 자체 세션 만료** — 서버 측에서 약 2주 비활성 시 만료, silent → \`login_required\`
2. **외부 revoke** — 사용자가 Google 계정 설정에서 권한 해제, silent → \`consent_required\`

## 변경 파일

- \`README.md\` \"알려진 한계\" 섹션 — 7일 ITP는 Safari 탭 한정, PWA 영속 명시 + Google 자체 세션 만료 항목 분리
- \`docs/decisions/011-bookmark-sync.md\` Phase 2g 트레이드오프 — 동일 정정 + ADR §맥락 cross-reference

## Test plan
- [x] 본문 맥락 확인 (ADR-011 §맥락 line 26-27의 기존 기술과 정합)
- [x] 1.4.4 릴리스 노트(이미 발행)는 \"오랜 기간(약 2주) Google 측 세션 만료\"로 이미 정정 발행됨

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates clarifying iOS storage persistence and silent reauth failure causes; no runtime code changes.
> 
> **Overview**
> Updates the iOS Drive sync documentation to clarify that **Safari’s 7-day ITP storage purge applies to users opening the site in a Safari tab**, while **home-screen installed PWAs (iOS 17+ HSWA) keep persistent storage and aren’t subject to that ITP behavior**.
> 
> Also documents **Google’s own OAuth session expiry (~2 weeks inactivity)** as a distinct reason silent re-auth (`prompt=none`) can fail, and aligns ADR-011 tradeoff notes (including error codes like `login_required`/`consent_required`) with this corrected explanation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25df6ae4974caba0649438586d2c473d76a201d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->