### PR TITLE
fix: 설정 팝오버 모바일 첫 버튼 포커스 박스 제거

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -228,6 +228,13 @@ body {
   white-space: nowrap;
 }
 
+/* Container is programmatically focused on pointer-driven open so the first
+   button doesn't catch a stray :focus-visible ring (iOS Safari). */
+.settings-popover:focus,
+.settings-popover:focus-visible {
+  outline: none;
+}
+
 /* ── Drive sync settings UI ── */
 
 .settings-drive-info-btn {

--- a/js/app.js
+++ b/js/app.js
@@ -42,7 +42,7 @@ function trapFocus(container) {
     if (!focusable.length) return;
     const first = focusable[0];
     const last = focusable[focusable.length - 1];
-    if (e.shiftKey && document.activeElement === first) {
+    if (e.shiftKey && (document.activeElement === first || document.activeElement === container)) {
       e.preventDefault();
       last.focus();
     } else if (!e.shiftKey && document.activeElement === last) {

--- a/js/app.js
+++ b/js/app.js
@@ -258,7 +258,7 @@ function initSettings() {
   settingsSvg.appendChild(gearCircle);
   settingsSvg.appendChild(gearPath);
   btn.appendChild(settingsSvg);
-  const popover = el("div", { className: "settings-popover" });
+  const popover = el("div", { className: "settings-popover", tabindex: "-1" });
   popover.hidden = true;
   popover.addEventListener("click", (e) => e.stopPropagation());
 
@@ -557,8 +557,11 @@ function initSettings() {
     popover.appendChild(aboutRow);
 
     if (!popover.hidden) {
-      const firstFocusable = popover.querySelector("button:not([disabled]), a[href], input:not([disabled])");
-      if (firstFocusable) firstFocusable.focus();
+      // Move focus to the popover container so re-renders (e.g. drive sync
+      // state updates) don't leave focus on a removed node. Pointer-driven
+      // programmatic focus on a tabindex="-1" container does not match
+      // :focus-visible, so no ring is drawn; Tab still leads into buttons.
+      popover.focus();
     }
   }
 
@@ -570,15 +573,23 @@ function initSettings() {
 
   let cleanupTrap = null;
 
-  btn.addEventListener("click", () => {
+  btn.addEventListener("click", (e) => {
     const open = !popover.hidden;
     if (!open) { rebuild(); positionPopover(); }
     popover.hidden = open;
     btn.setAttribute("aria-expanded", String(!open));
     if (!open) {
       cleanupTrap = trapFocus(popover);
-      const first = popover.querySelector('button, a[href], input');
-      if (first) first.focus();
+      // event.detail === 0 means activation via keyboard (Enter/Space). Focus
+      // the first button so keyboard users land on an actionable target. For
+      // pointer activation, focus the popover container itself to avoid a
+      // stray :focus-visible ring on the first button (iOS Safari).
+      if (e.detail === 0) {
+        const first = popover.querySelector('button, a[href], input');
+        if (first) first.focus();
+      } else {
+        popover.focus();
+      }
     } else if (cleanupTrap) {
       cleanupTrap(); cleanupTrap = null;
     }


### PR DESCRIPTION
## 문제

모바일(iOS Safari)에서 설정 톱니바퀴를 탭하면 팝오버가 열리면서 첫 버튼("읽던 곳")에 파란 `:focus-visible` 외곽선이 그려졌다. 사용자는 키보드를 사용하지 않았는데도 포커스 링이 나타나 시각적으로 거슬렸다.

## 원인

`js/app.js` 클릭 핸들러가 팝오버를 열 때 `popover.querySelector('button, …').focus()`로 첫 버튼에 포커스를 강제 이동했다. iOS Safari는 터치 직후의 프로그래매틱 focus를 `:focus-visible`로 매칭해 전역 규칙(`css/style.css` `:focus-visible`)이 적용되었다.

## 변경

- 팝오버 컨테이너에 `tabindex="-1"` 부여
- 클릭 핸들러에서 `event.detail`로 활성화 수단 구분
  - `=== 0` (Enter/Space로 키보드 활성화): 기존대로 첫 버튼에 포커스 → 키보드 사용자에게 즉시 액션 가능 지점 제공
  - 그 외 (포인터/터치): 팝오버 컨테이너 자체에 포커스 → 시각적 링 없음, Tab으로 자연스럽게 첫 버튼 진입
- `rebuild()` 후 재포커스도 컨테이너로 이동 (Drive 상태 변화 시 호출)
- 안전망으로 `.settings-popover:focus{outline:none}` 추가 (컨테이너 자체에 링이 그려지는 브라우저 대비; 내부 버튼의 focus-visible은 영향 없음)

## 접근성

- 키보드 사용자: Enter/Space로 톱니바퀴 활성화 시 기존과 동일하게 첫 버튼 focus-visible 표시 유지
- Tab 이동 시 내부 버튼들의 focus-visible 정상 동작
- 포커스 트랩(`trapFocus`)은 그대로 유지되어 모달 밖 탈출 방지

## Test plan

- [ ] 모바일(iOS Safari)에서 톱니바퀴 탭 → 첫 버튼에 박스 없는지 확인
- [ ] 데스크톱에서 톱니바퀴 클릭 → 첫 버튼에 박스 없는지 확인
- [ ] 데스크톱에서 Tab으로 톱니바퀴 포커스 후 Enter → 첫 버튼에 focus-visible 나타나는지 확인
- [ ] 팝오버 내부 Tab 이동 시 각 버튼의 focus-visible 정상 표시 확인
- [ ] Drive 동기화 상태 변경 트리거 → 팝오버 재렌더 시 포커스 사라지지 않는지 확인

---
_Generated by [Claude Code](https://claude.ai/code/session_01TdxFDqbAqJpuE8DAkTaxVT)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/accessibility tweak that only changes focus management and a small CSS outline rule for the settings popover; main risk is minor regressions in keyboard tab order/focus trapping.
> 
> **Overview**
> Adjusts the settings popover’s focus behavior to prevent iOS Safari from drawing a `:focus-visible` ring on the first button when the popover is opened via touch.
> 
> The popover container is now focusable (`tabindex="-1"`) and is focused on pointer-driven open and after `rebuild()` re-renders, while keyboard activation (Enter/Space) still focuses the first actionable control; `trapFocus()` is updated to handle Shift-Tab when focus starts on the container. Adds a CSS rule to suppress outlines on the focused popover container without affecting inner controls’ `:focus-visible` styling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76d72a6c0b8ba76ac1d3889864c19a996d7eec1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->