### PR TITLE
fix: 오디오 플레이어 활성 시 FAB가 장 이동 버튼을 가리는 문제

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -766,7 +766,7 @@ body {
 
 /* Lift FAB when audio bar is visible */
 #audio-bar:not([hidden]) ~ #search-fab {
-  bottom: max(calc(5rem + env(safe-area-inset-bottom)), calc(var(--fab-lift-nav, 0px) + 3.5rem));
+  bottom: max(calc(5rem + env(safe-area-inset-bottom)), var(--fab-lift-nav, 0px));
 }
 
 /* ── Install guide modal ── */

--- a/js/app.js
+++ b/js/app.js
@@ -2507,6 +2507,7 @@ function observeFabLift() {
     window.removeEventListener("scroll", _fabScrollHandler);
     _fabScrollHandler = null;
   }
+  _fabRafPending = false;
   const nav = $app.querySelector(".chapter-nav");
   if (!nav) return;
   const onScroll = () => {
@@ -2514,6 +2515,7 @@ function observeFabLift() {
     _fabRafPending = true;
     requestAnimationFrame(() => {
       _fabRafPending = false;
+      if (!nav.isConnected) return;
       _updateFabLift(nav);
     });
   };

--- a/js/app.js
+++ b/js/app.js
@@ -2487,23 +2487,50 @@ function formatTime(sec) {
   return `${m}:${s.toString().padStart(2, "0")}`;
 }
 
-// Lift FAB above chapter-nav when it scrolls into view on mobile
+// Lift FAB above chapter-nav when it scrolls into view on mobile.
+// Anchors against the nav's real viewport position so the audio bar's
+// height doesn't matter — the FAB always sits centered in the gap
+// above chapter-nav.
 let _fabNavObserver = null;
+let _fabScrollHandler = null;
+let _fabRafPending = false;
+function _updateFabLift(nav) {
+  const fabH = $searchFab.offsetHeight;
+  const gapPx = parseFloat(getComputedStyle(nav).marginTop) || 0;
+  const navTop = nav.getBoundingClientRect().top;
+  const liftPx = window.innerHeight - navTop + (gapPx - fabH) / 2;
+  $searchFab.style.setProperty("--fab-lift-nav", `${Math.max(liftPx, 0)}px`);
+}
 function observeFabLift() {
   if (_fabNavObserver) { _fabNavObserver.disconnect(); _fabNavObserver = null; }
+  if (_fabScrollHandler) {
+    window.removeEventListener("scroll", _fabScrollHandler);
+    _fabScrollHandler = null;
+  }
   const nav = $app.querySelector(".chapter-nav");
   if (!nav) return;
+  const onScroll = () => {
+    if (_fabRafPending) return;
+    _fabRafPending = true;
+    requestAnimationFrame(() => {
+      _fabRafPending = false;
+      _updateFabLift(nav);
+    });
+  };
   _fabNavObserver = new IntersectionObserver((entries) => {
     const visible = entries[0].isIntersecting;
     if (visible) {
-      // Center the FAB vertically in the gap (margin-top: 4.5rem) above chapter-nav
-      const navH = nav.offsetHeight;
-      const fabH = $searchFab.offsetHeight;
-      const gapPx = parseFloat(getComputedStyle(nav).marginTop);
-      const liftPx = navH + (gapPx - fabH) / 2;
-      $searchFab.style.setProperty("--fab-lift-nav", `${Math.max(liftPx, navH + 4)}px`);
+      _updateFabLift(nav);
+      if (!_fabScrollHandler) {
+        _fabScrollHandler = onScroll;
+        window.addEventListener("scroll", onScroll, { passive: true });
+      }
     } else {
       $searchFab.style.removeProperty("--fab-lift-nav");
+      if (_fabScrollHandler) {
+        window.removeEventListener("scroll", _fabScrollHandler);
+        _fabScrollHandler = null;
+      }
     }
   }, { threshold: 0 });
   _fabNavObserver.observe(nav);


### PR DESCRIPTION
## 문제

iOS에서 오디오 플레이어 하단이 화면 모서리에 가려지는 문제를 해결하려 플레이어 높이를 늘렸더니, 화면을 아래로 스크롤해 chapter-nav (← N장 / N+1장 →) 가 보일 때 검색 FAB가 다음 장 이동 버튼 위에 겹쳐 보이는 회귀가 발생했다.

## 원인

기존 `observeFabLift()`는 chapter-nav가 viewport 하단에 붙어 있다고 가정하고 `nav.offsetHeight + (gap - fabH)/2` 로 lift 값을 계산했다. 오디오 바가 chapter-nav 아래에 자리잡으면 chapter-nav는 viewport 하단보다 위로 밀려나는데, 이 계산은 그 변화를 반영하지 못해 FAB가 chapter-nav 위로 겹쳤다. 오디오 바 variant CSS는 `+ 3.5rem` 하드코딩으로 보정했으나 실제 오디오 바 높이/safe-area에 비례하지 않아 더 큰 플레이어에서는 무력했다.

## 수정

- `_updateFabLift()`에서 `getBoundingClientRect().top`으로 chapter-nav의 실제 viewport 위치를 측정해 gap 중앙에 FAB를 정렬한다.
- IntersectionObserver가 chapter-nav 가시 상태를 감지하면 `scroll` 리스너를 `requestAnimationFrame` 스로틀로 부착해, 사용자가 스크롤하는 동안에도 FAB가 chapter-nav 위에 머물도록 위치를 갱신한다. chapter-nav가 사라지면 리스너를 분리한다.
- CSS의 `#audio-bar:not([hidden]) ~ #search-fab` rule에서 `+ 3.5rem` 하드코딩 보정을 제거 — 이제 lift 값이 viewport 절대 좌표로 일관되게 동작한다.

## Test plan

- [ ] iOS Safari (PWA) 에서 오디오 플레이어 활성 상태로 본문 끝까지 스크롤 → FAB가 chapter-nav 버튼을 가리지 않음
- [ ] 오디오 플레이어 비활성 상태에서도 FAB가 chapter-nav 위에 정상 정렬
- [ ] 절 선택 모드(verse-select-active) 에서 FAB 위치 확인
- [ ] Android Chrome / 데스크톱 회귀 없음

https://claude.ai/code/session_01DLS3mczqBZUxSSDqJrvTGT

---
_Generated by [Claude Code](https://claude.ai/code/session_01DLS3mczqBZUxSSDqJrvTGT)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only positioning changes plus a scoped, throttled scroll listener; main risk is minor layout/performance regressions on mobile scrolling.
> 
> **Overview**
> Adjusts mobile search FAB lifting logic to **anchor against the `chapter-nav`’s actual viewport position** (via `getBoundingClientRect()`), rather than assuming the nav sits at the viewport bottom.
> 
> When `chapter-nav` is visible, `observeFabLift()` now attaches a `scroll` listener (rAF-throttled) to continuously update `--fab-lift-nav`, and cleans it up when the nav leaves view. The CSS special-case that hard-coded an extra offset for the audio bar is removed so FAB placement is driven consistently by `--fab-lift-nav`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd74d2bcf855fd522c34cffe97160bbd84a8d741. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->