### PR TITLE
fix: 모바일 북마크 스와이프 시 텍스트 고정 + 폴더 행 높이 통일

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3413,10 +3413,10 @@ body.verse-select-active .verse.verse-poetry[data-vref] {
   .bm-row-content {
     padding: 0.3rem 0.75rem;
     background: var(--bg);
-    transition: transform 0.2s cubic-bezier(0.25, 0.46, 0.45, 0.94);
-    will-change: transform;
     position: relative;
-    z-index: 1;
+    z-index: 0;
+    min-height: 44px;
+    box-sizing: border-box;
   }
 
   .bm-bookmark-row.bm-active {
@@ -3434,17 +3434,8 @@ body.verse-select-active .verse.verse-poetry[data-vref] {
     background: transparent;
   }
 
-  .bm-bookmark-row.bm-swiped .bm-row-content,
-  .bm-folder-row.bm-swiped .bm-row-content {
-    transform: translateX(-140px);
-  }
-
-  /* Disable the snap-back transition while the finger is dragging the row. */
-  .bm-bookmark-row.bm-swiping .bm-row-content,
-  .bm-folder-row.bm-swiping .bm-row-content {
-    transition: none;
-  }
-
+  /* Action panel slides in from the right and overlays the content;
+     the row text stays in place per the mobile UX request. */
   .bm-row-actions-mobile {
     display: flex;
     position: absolute;
@@ -3452,7 +3443,21 @@ body.verse-select-active .verse.verse-poetry[data-vref] {
     right: 0;
     bottom: 0;
     width: 140px;
-    z-index: 0;
+    z-index: 1;
+    transform: translateX(100%);
+    transition: transform 0.2s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+    will-change: transform;
+  }
+
+  .bm-bookmark-row.bm-swiped .bm-row-actions-mobile,
+  .bm-folder-row.bm-swiped .bm-row-actions-mobile {
+    transform: translateX(0);
+  }
+
+  /* Disable the snap-back transition while the finger is dragging the row. */
+  .bm-bookmark-row.bm-swiping .bm-row-actions-mobile,
+  .bm-folder-row.bm-swiping .bm-row-actions-mobile {
+    transition: none;
   }
 
   .bm-mobile-action-btn {
@@ -3486,7 +3491,7 @@ body.verse-select-active .verse.verse-poetry[data-vref] {
   #bookmark-drawer.drawer-closing {
     animation: none;
   }
-  .bm-row-content {
+  .bm-row-actions-mobile {
     transition: none;
   }
 }

--- a/docs/decisions/010-bookmark-feature.md
+++ b/docs/decisions/010-bookmark-feature.md
@@ -321,3 +321,11 @@ li.bm-bookmark
   - 모바일 미디어 쿼리에서 `.bm-item-actions { display:none }`, swipe 슬라이드 스타일,
     모바일 액션 버튼 스타일 추가
   - `prefers-reduced-motion`에 `.bm-row-content { transition: none }` 추가
+
+> **개정 (2026-05-06):** 모바일 스와이프 시 행 텍스트가 좌측으로 밀려 사라지는 문제 수정.
+> 이제 `.bm-row-content`는 고정되어 있고, `.bm-row-actions-mobile` 패널이 우측에서
+> `translateX(100% → 0)`으로 슬라이드 인하여 행의 우측 부분을 **오버레이**한다 (z-index:1).
+> 텍스트가 길면 액션 버튼이 텍스트 위를 가리는 동작은 의도된 것이다.
+> 또한 `.bm-row-content`에 `min-height: 44px`를 적용해 폴더와 북마크 행 높이를 일치시키고
+> 터치 타겟을 WCAG 기준에 맞춤. `prefers-reduced-motion` 처리 대상도
+> `.bm-row-content` → `.bm-row-actions-mobile`로 이동.

--- a/js/app.js
+++ b/js/app.js
@@ -1136,8 +1136,8 @@ function _isMobileViewport() {
 function closeSwipedRow(except) {
   if (_swipedRow && _swipedRow !== except) {
     _swipedRow.classList.remove("bm-swiped");
-    const prevContent = _swipedRow.querySelector(".bm-row-content");
-    if (prevContent) prevContent.style.transform = "";
+    const prevActions = _swipedRow.querySelector(".bm-row-actions-mobile");
+    if (prevActions) prevActions.style.transform = "";
     _swipedRow = null;
   }
 }
@@ -1145,8 +1145,8 @@ function closeSwipedRow(except) {
 function _openSwipedRow(row) {
   closeSwipedRow(row);
   row.classList.add("bm-swiped");
-  const content = row.querySelector(".bm-row-content");
-  if (content) content.style.transform = "";
+  const actions = row.querySelector(".bm-row-actions-mobile");
+  if (actions) actions.style.transform = "";
   _swipedRow = row;
 }
 
@@ -1162,8 +1162,8 @@ function _setupDragHandle(li, row) {
     const startY = e.clientY;
     const origRect = li.getBoundingClientRect();
     const isMobile = _isMobileViewport();
-    const swipeContent = row.querySelector(".bm-row-content");
-    const canSwipe = isMobile && !!swipeContent;
+    const swipeActions = row.querySelector(".bm-row-actions-mobile");
+    const canSwipe = isMobile && !!swipeActions;
     // null until the first significant move classifies the gesture.
     // "drag" → reorder, "swipe" → reveal actions, "longpress" → reveal via hold
     let mode = null;
@@ -1222,7 +1222,12 @@ function _setupDragHandle(li, row) {
         let offset = baseOffset + dx;
         if (offset > 0) offset = 0;
         if (offset < -SWIPE_REVEAL_PX * 1.2) offset = -SWIPE_REVEAL_PX * 1.2;
-        if (swipeContent) swipeContent.style.transform = `translateX(${offset}px)`;
+        // Slide the action panel in from the right; row content stays put.
+        // offset 0 → panel translateX(140) (off-screen); offset -140 → translateX(0) (open).
+        if (swipeActions) {
+          const panelTx = SWIPE_REVEAL_PX + offset;
+          swipeActions.style.transform = `translateX(${panelTx}px)`;
+        }
         return;
       }
 
@@ -1261,7 +1266,7 @@ function _setupDragHandle(li, row) {
           _openSwipedRow(row);
         } else {
           row.classList.remove("bm-swiped");
-          if (swipeContent) swipeContent.style.transform = "";
+          if (swipeActions) swipeActions.style.transform = "";
           if (_swipedRow === row) _swipedRow = null;
         }
         return;
@@ -1299,7 +1304,7 @@ function _setupDragHandle(li, row) {
           _openSwipedRow(row);
         } else {
           row.classList.remove("bm-swiped");
-          if (swipeContent) swipeContent.style.transform = "";
+          if (swipeActions) swipeActions.style.transform = "";
           if (_swipedRow === row) _swipedRow = null;
         }
         return;
@@ -4100,7 +4105,7 @@ function _buildBookmarkItem(bm, depth) {
   actions.appendChild(delBtn);
 
   // Mobile swipe-to-reveal actions panel (hidden on desktop via CSS).
-  // Sits behind the sliding row content; revealed when row.bm-swiped translates left.
+  // Slides in from the right and overlays the right edge of the row content.
   const mobileActions = el("div", { className: "bm-row-actions-mobile", "aria-hidden": "true" });
   const mEditBtn = el("button", {
     className: "bm-mobile-action-btn bm-mobile-edit-btn",


### PR DESCRIPTION
## 변경 사항

### 1. 스와이프 시 행 텍스트 고정 (북마크 + 폴더)
기존에는 `.bm-row-content` 전체가 좌측으로 `translateX(-140px)` 되어, 스와이프 시 행의 텍스트가 화면 밖으로 밀려나 사라졌다. 이제 콘텐츠는 고정되고, 우측의 `.bm-row-actions-mobile` 패널이 `translateX(100% → 0)`으로 **슬라이드 인하여 행의 우측 부분을 오버레이**한다 (z-index: 1).

- 텍스트가 길 경우 액션 버튼이 텍스트 위를 가리는 동작은 의도된 디자인.
- 폴더 행도 동일하게 적용.

### 2. 폴더 행 높이를 북마크와 통일
`.bm-row-content`에 `min-height: 44px`를 적용하여:
- 폴더 (1줄 텍스트)와 북마크 (2줄: label + ref) 행 높이가 모바일에서 동일.
- WCAG 2.1 AA 최소 터치 타겟(44px) 충족.

## 변경 파일

- `css/style.css` — 모바일 미디어 쿼리에서 transform 대상을 `.bm-row-content` → `.bm-row-actions-mobile`로 이동, `min-height` 추가.
- `js/app.js` — `_setupDragHandle()`, `closeSwipedRow()`, `_openSwipedRow()`에서 transform을 액션 패널에 적용.
- `docs/decisions/010-bookmark-feature.md` — 2026-05-06 개정 블록 추가.

## Test plan

- [ ] iOS Safari에서 북마크 좌측 스와이프 시 텍스트가 제자리에 남아있고 수정/삭제 버튼이 우측에서 슬라이드 인하는지
- [ ] 폴더에 대해서도 동일하게 동작하는지
- [ ] 폴더와 북마크 행 높이가 동일한지
- [ ] 단일 탭 → 이동, 롱프레스 → 액션 노출, 수직 드래그 → reorder 가 그대로 동작하는지
- [ ] `prefers-reduced-motion` 환경에서 transition 없이 즉시 노출되는지
- [x] `node --test tests/unit/state-machine.test.js` 통과

https://claude.ai/code/session_01SYcVNPwx8xkYmSLFsLJ7wA

---
_Generated by [Claude Code](https://claude.ai/code/session_01SYcVNPwx8xkYmSLFsLJ7wA)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to mobile bookmark drawer CSS/gesture behavior; main risk is regressions in swipe/long-press/drag interaction and layering on small viewports.
> 
> **Overview**
> Fixes the mobile bookmark/folder swipe UX so swiping no longer translates the entire row content (which pushed text off-screen); instead the `.bm-row-actions-mobile` panel slides in from the right and overlays the row.
> 
> Updates pointer-gesture handling in `js/app.js` (`closeSwipedRow`, `_openSwipedRow`, `_setupDragHandle`) to apply live `transform` updates to the actions panel rather than `.bm-row-content`, and adjusts CSS layering (`z-index`) plus `prefers-reduced-motion` handling accordingly.
> 
> Adds `min-height: 44px` to `.bm-row-content` on mobile to standardize folder/bookmark row heights and meet touch target sizing, and documents the behavioral change in ADR-010.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 598adae4f97bfb9c49c8ac0d21b343e2374aac8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->