### PR TITLE
style: 절 선택 모드일 때 검색 FAB 숨김

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2230,8 +2230,8 @@ body.verse-select-active #audio-bar {
   display: none;
 }
 
-body.verse-select-active #audio-bar ~ #search-fab {
-  bottom: max(calc(1.5rem + env(safe-area-inset-bottom)), var(--fab-lift-nav, 0px));
+body.verse-select-active #search-fab {
+  display: none !important;
 }
 
 


### PR DESCRIPTION
## Summary
- 절 선택 모드(`body.verse-select-active`)일 때 우측 하단 검색 FAB를 숨김
- 모드 진입 시 표시되는 하단 액션 바(북마크/취소)와 FAB가 시각적으로 겹치는 문제 해결
- 기존에 있던 `#audio-bar ~ #search-fab` 위치 보정 규칙은 더 이상 불필요하므로 제거 (audio-bar는 이미 verse-select 중 숨김 처리됨)

## Test plan
- [ ] 모바일 뷰포트(≤768px)에서 장 본문 진입 → 절을 길게 눌러 선택 모드 진입 → FAB가 사라지는지 확인
- [ ] 취소 또는 북마크 저장으로 선택 모드 종료 시 FAB가 다시 표시되는지 확인
- [ ] 오디오 재생 중에도 선택 모드에서 FAB가 숨겨지는지 확인
- [ ] 데스크톱(≥769px)에서 동작 변화 없는지 확인 (FAB는 원래 숨김)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JHLG7MseG4GtsCVnU9sq8A)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only change that only affects mobile UI visibility during a specific interaction mode, with minimal functional risk.
> 
> **Overview**
> When verse selection mode (`body.verse-select-active`) is active, the mobile `#search-fab` is now force-hidden to avoid visually overlapping the bottom verse-selection action bar.
> 
> The previous positioning workaround that adjusted the FAB when `#audio-bar` is hidden/visible in this mode was removed as unnecessary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b16b163cedcf4c5e4c7c4b2d702099f607b5a600. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->