### PR TITLE
feat: refresh-store 모듈 추가 (Phase 2i 단계 1)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,11 +8,11 @@ on:
 
 jobs:
   unit:
-    name: Unit tests (state-machine)
+    name: Unit tests (sync layer)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: "24"
-      - run: node --test tests/unit/state-machine.test.js
+      - run: node --test tests/unit/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,4 +15,4 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "24"
-      - run: node --test tests/unit/
+      - run: node --test tests/unit/*.test.js

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,7 @@ js/
     transport.js        ← GIS / Drive REST / iOS OAuth 리디렉션 (ADR-011)
     store-v2.js         ← per-record mtime + tombstone 머지 (Phase 2c)
     debug-log.js        ← ring buffer 진단 로그
+    refresh-store.js    ← OAuth refresh token 암호화 IDB 저장소 (Phase 2i)
 css/
   style.css             ← 메인 스타일
 assets/

--- a/index.html
+++ b/index.html
@@ -265,8 +265,9 @@
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-CWVVPW11TE"></script>
   <!-- Google Identity Services (async — GIS polls in drive-sync.js) -->
   <script async src="https://accounts.google.com/gsi/client"></script>
-  <!-- Drive sync modules (load order matters: debug-log → transport → state-machine → facade) -->
+  <!-- Drive sync modules (load order matters: debug-log → refresh-store → transport → state-machine → facade) -->
   <script defer src="/js/sync/debug-log.js"></script>
+  <script defer src="/js/sync/refresh-store.js"></script>
   <script defer src="/js/sync/transport.js"></script>
   <script defer src="/js/sync/store-v2.js"></script>
   <script defer src="/js/sync/state-machine.js"></script>

--- a/js/sync/refresh-store.js
+++ b/js/sync/refresh-store.js
@@ -1,0 +1,188 @@
+// @ts-check
+// ── Refresh Token Store ───────────────────────────────────────────────────────
+// AES-GCM encrypted IndexedDB store for OAuth refresh tokens (Phase 2i / PKCE).
+//
+// Key is generated extractable: false so structured-clone roundtrip into IDB
+// preserves it, but no JS code (ours or attacker's via subtle.exportKey) can
+// pull the raw bytes out — the key only flows through encrypt/decrypt.
+//
+// XSS still beats us: an attacker that runs in our origin can call
+// loadRefreshToken() the same way we do. Strict CSP (index.html line 5) is
+// the actual XSS defense; encryption-at-rest only hardens against passive
+// storage exfiltration (malicious extensions reading IDB, device-level dump).
+//
+// IndexedDB layout:
+//   db   = "bible-drive-sync" (v1)
+//   keys store: { id="aes" → CryptoKey (non-extractable AES-GCM 256) }
+//   tokens store: { id="refresh" → { iv: Uint8Array(12), ciphertext: ArrayBuffer } }
+
+/** @typedef {import("../types").RefreshTokenStore} RefreshTokenStore */
+
+const _DB_NAME = "bible-drive-sync";
+const _DB_VERSION = 1;
+const _KEYS_STORE = "keys";
+const _TOKENS_STORE = "tokens";
+const _KEY_ID = "aes";
+const _TOKEN_ID = "refresh";
+
+// ── IndexedDB plumbing ────────────────────────────────────────────────────────
+// Each operation opens its own connection and closes it when done. IDB
+// connections are cheap; sharing one across async work invites version-change
+// blocking when the schema upgrades in another tab.
+
+/** @returns {Promise<IDBDatabase>} */
+function _openDB() {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(_DB_NAME, _DB_VERSION);
+    req.onerror = () => reject(req.error);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(_KEYS_STORE))   db.createObjectStore(_KEYS_STORE);
+      if (!db.objectStoreNames.contains(_TOKENS_STORE)) db.createObjectStore(_TOKENS_STORE);
+    };
+    req.onsuccess = () => resolve(req.result);
+  });
+}
+
+/**
+ * @template T
+ * @param {IDBRequest<T>} req
+ * @returns {Promise<T>}
+ */
+function _reqAsPromise(req) {
+  return new Promise((resolve, reject) => {
+    req.onsuccess = () => resolve(req.result);
+    req.onerror   = () => reject(req.error);
+  });
+}
+
+// ── Key management ────────────────────────────────────────────────────────────
+
+/** @returns {Promise<CryptoKey>} */
+async function _getOrCreateKey() {
+  const db = await _openDB();
+  try {
+    /** @type {CryptoKey | undefined} */
+    const existing = await _reqAsPromise(
+      db.transaction(_KEYS_STORE, "readonly").objectStore(_KEYS_STORE).get(_KEY_ID),
+    );
+    if (existing) return existing;
+
+    // First call ever: generate a fresh AES-GCM key. extractable: false is the
+    // load-bearing flag — once stored, neither our code nor an attacker can
+    // call subtle.exportKey on it.
+    const key = await crypto.subtle.generateKey(
+      { name: "AES-GCM", length: 256 },
+      false,
+      ["encrypt", "decrypt"],
+    );
+    await _reqAsPromise(
+      db.transaction(_KEYS_STORE, "readwrite").objectStore(_KEYS_STORE).put(key, _KEY_ID),
+    );
+    return key;
+  } finally {
+    db.close();
+  }
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/**
+ * @param {string} plain
+ * @returns {Promise<void>}
+ */
+async function saveRefreshToken(plain) {
+  const key = await _getOrCreateKey();
+  // AES-GCM requires a unique IV per (key, plaintext) pair. 12 bytes is the
+  // standard length and keeps overhead minimal.
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const ciphertext = await crypto.subtle.encrypt(
+    { name: "AES-GCM", iv },
+    key,
+    new TextEncoder().encode(plain),
+  );
+  const db = await _openDB();
+  try {
+    await _reqAsPromise(
+      db.transaction(_TOKENS_STORE, "readwrite")
+        .objectStore(_TOKENS_STORE)
+        .put({ iv, ciphertext }, _TOKEN_ID),
+    );
+  } finally {
+    db.close();
+  }
+}
+
+/** @returns {Promise<string | null>} */
+async function loadRefreshToken() {
+  /** @type {IDBDatabase} */
+  let db;
+  try {
+    db = await _openDB();
+  } catch {
+    // Safari private mode, quota exhausted, etc. Caller treats as "no token"
+    // and falls through to NEEDS_CONSENT.
+    return null;
+  }
+
+  try {
+    /** @type {{ iv: Uint8Array; ciphertext: ArrayBuffer } | undefined} */
+    const record = await _reqAsPromise(
+      db.transaction(_TOKENS_STORE, "readonly").objectStore(_TOKENS_STORE).get(_TOKEN_ID),
+    );
+    if (!record) return null;
+
+    let key;
+    try {
+      key = await _getOrCreateKey();
+    } catch {
+      return null;
+    }
+
+    try {
+      // Cast around TS 5.7+ Uint8Array<ArrayBufferLike> vs ArrayBuffer
+      // distinction. Runtime invariant: we only ever store Uint8Array IVs
+      // produced by crypto.getRandomValues, which are always ArrayBuffer-backed.
+      const plain = await crypto.subtle.decrypt(
+        { name: "AES-GCM", iv: /** @type {BufferSource} */ (record.iv) },
+        key,
+        record.ciphertext,
+      );
+      return new TextDecoder().decode(plain);
+    } catch {
+      // Decrypt failure = stale ciphertext (key was regenerated, IDB partially
+      // wiped, etc.). Drop the unrecoverable record so we don't loop on every
+      // cold start.
+      await _reqAsPromise(
+        db.transaction(_TOKENS_STORE, "readwrite")
+          .objectStore(_TOKENS_STORE)
+          .delete(_TOKEN_ID),
+      ).catch(() => {});
+      return null;
+    }
+  } finally {
+    db.close();
+  }
+}
+
+/** @returns {Promise<void>} */
+async function clearRefreshToken() {
+  /** @type {IDBDatabase} */
+  let db;
+  try {
+    db = await _openDB();
+  } catch {
+    return;
+  }
+  try {
+    await _reqAsPromise(
+      db.transaction(_TOKENS_STORE, "readwrite")
+        .objectStore(_TOKENS_STORE)
+        .delete(_TOKEN_ID),
+    ).catch(() => {});
+  } finally {
+    db.close();
+  }
+}
+
+window.refreshStore = { saveRefreshToken, loadRefreshToken, clearRefreshToken };

--- a/js/types.d.ts
+++ b/js/types.d.ts
@@ -246,6 +246,15 @@ export interface SyncTransport {
   deleteSyncFile: (token: string, fileId: string) => Promise<{ ok: boolean }>;
 }
 
+// ── Refresh Token Store (Phase 2i) ───────────────────────────────────────────
+// AES-GCM encrypted IndexedDB persistence for OAuth refresh tokens.
+
+export interface RefreshTokenStore {
+  saveRefreshToken: (plain: string) => Promise<void>;
+  loadRefreshToken: () => Promise<string | null>;
+  clearRefreshToken: () => Promise<void>;
+}
+
 // ── Store v2 ─────────────────────────────────────────────────────────────────
 
 export interface SyncStoreV2 {
@@ -346,6 +355,7 @@ declare global {
     syncTransport: SyncTransport;
     syncStoreV2: SyncStoreV2;
     syncDebugLog: SyncDebugLog;
+    refreshStore: RefreshTokenStore;
     createSyncMachine: (opts?: {
       onStateChange?: (state: SyncState) => void;
     }) => SyncMachine;

--- a/tests/unit/harness.js
+++ b/tests/unit/harness.js
@@ -18,6 +18,8 @@ import { fileURLToPath } from "node:url";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const STATE_MACHINE_PATH = path.resolve(__dirname, "../../js/sync/state-machine.js");
 const SOURCE = fs.readFileSync(STATE_MACHINE_PATH, "utf8");
+const REFRESH_STORE_PATH = path.resolve(__dirname, "../../js/sync/refresh-store.js");
+const REFRESH_STORE_SOURCE = fs.readFileSync(REFRESH_STORE_PATH, "utf8");
 
 // Constants mirrored from state-machine.js — kept here so tests can assert
 // against them without parsing the source. Only those actually used by
@@ -116,6 +118,136 @@ function fireAllPending(pending) {
   for (const fn of fns) {
     try { fn(); } catch (_) { /* surface via test assertions */ }
   }
+}
+
+// ── Minimal in-memory IndexedDB ──────────────────────────────────────────────
+// Just enough surface for refresh-store.js: open() + transaction(name).objectStore(name)
+// + get/put/delete returning IDBRequest-shaped objects. CryptoKey values are
+// stored by reference (no structured-clone) which is fine for unit tests.
+
+function makeFakeIndexedDB() {
+  /** Map<dbName, { version, stores: Map<storeName, Map<key, value>> }> */
+  const databases = new Map();
+
+  function _fireAsync(req, fn) {
+    Promise.resolve().then(() => {
+      try {
+        const result = fn();
+        req.result = result;
+        if (req.onsuccess) req.onsuccess({ target: req });
+      } catch (err) {
+        req.error = err;
+        if (req.onerror) req.onerror({ target: req });
+      }
+    });
+  }
+
+  function _makeStore(map) {
+    return {
+      get(key) {
+        const req = { result: undefined, error: null, onsuccess: null, onerror: null };
+        _fireAsync(req, () => map.get(key));
+        return req;
+      },
+      put(value, key) {
+        const req = { result: undefined, error: null, onsuccess: null, onerror: null };
+        _fireAsync(req, () => { map.set(key, value); return key; });
+        return req;
+      },
+      delete(key) {
+        const req = { result: undefined, error: null, onsuccess: null, onerror: null };
+        _fireAsync(req, () => { map.delete(key); return undefined; });
+        return req;
+      },
+    };
+  }
+
+  function _makeDb(record) {
+    return {
+      get objectStoreNames() {
+        return { contains: (n) => record.stores.has(n) };
+      },
+      createObjectStore(name) {
+        if (!record.stores.has(name)) record.stores.set(name, new Map());
+        return _makeStore(record.stores.get(name));
+      },
+      transaction(storeNames, _mode) {
+        const names = Array.isArray(storeNames) ? storeNames : [storeNames];
+        return {
+          objectStore(n) {
+            if (!names.includes(n)) throw new Error(`store ${n} not in transaction scope`);
+            const map = record.stores.get(n);
+            if (!map) throw new Error(`store ${n} not found`);
+            return _makeStore(map);
+          },
+        };
+      },
+      close() {},
+    };
+  }
+
+  const indexedDB = {
+    open(name, version) {
+      const req = {
+        result: null, error: null,
+        onsuccess: null, onupgradeneeded: null, onerror: null,
+      };
+      Promise.resolve().then(() => {
+        let record = databases.get(name);
+        const isUpgrade = !record || record.version < version;
+        if (!record) {
+          record = { version: 0, stores: new Map() };
+          databases.set(name, record);
+        }
+        const dbHandle = _makeDb(record);
+        req.result = dbHandle;
+        if (isUpgrade) {
+          const oldVersion = record.version;
+          record.version = version;
+          if (req.onupgradeneeded) req.onupgradeneeded({ oldVersion, newVersion: version, target: req });
+        }
+        if (req.onsuccess) req.onsuccess({ target: req });
+      });
+      return req;
+    },
+  };
+
+  return {
+    indexedDB,
+    /** Direct access to underlying maps for assertions / tampering. */
+    _peek: (dbName, storeName) => {
+      const rec = databases.get(dbName);
+      return rec ? rec.stores.get(storeName) : undefined;
+    },
+    _reset: () => databases.clear(),
+  };
+}
+
+// ── refresh-store loader ─────────────────────────────────────────────────────
+// Each call creates a fresh vm context with isolated fake IDB + Node's real
+// Web Crypto. Real crypto means the AES-GCM round-trip and `extractable: false`
+// behavior are exercised, not just stubbed.
+
+export function loadRefreshStore() {
+  const { indexedDB, _peek, _reset } = makeFakeIndexedDB();
+
+  const ctx = {
+    console, Promise, Object, Array, Map, Set, JSON, Error,
+    Uint8Array, ArrayBuffer, DataView,
+    TextEncoder, TextDecoder,
+    crypto: globalThis.crypto,
+    indexedDB,
+  };
+  vm.createContext(ctx);
+  ctx.window = ctx;
+  vm.runInContext(REFRESH_STORE_SOURCE, ctx, { filename: "refresh-store.js" });
+
+  return {
+    store: ctx.refreshStore,
+    ctx,
+    peek: _peek,
+    reset: _reset,
+  };
 }
 
 // ── Main loader ──────────────────────────────────────────────────────────────

--- a/tests/unit/refresh-store.test.js
+++ b/tests/unit/refresh-store.test.js
@@ -1,0 +1,158 @@
+// ── refresh-store.js unit tests ─────────────────────────────────────────────
+// Run with: node --test tests/unit/refresh-store.test.js
+//
+// Each test loads a fresh refresh-store via loadRefreshStore() so the in-memory
+// fake IDB is isolated. Real Node Web Crypto is used for AES-GCM so the
+// extractable: false guarantee and round-trip semantics are genuinely
+// exercised, not stubbed.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { loadRefreshStore } from "./harness.js";
+
+const DB_NAME = "bible-drive-sync";
+const KEYS_STORE = "keys";
+const TOKENS_STORE = "tokens";
+const KEY_ID = "aes";
+const TOKEN_ID = "refresh";
+
+// ── 기본 round-trip ──────────────────────────────────────────────────────────
+
+test("1. save → load round-trip이 원문을 복원한다", async () => {
+  const { store } = loadRefreshStore();
+  await store.saveRefreshToken("rt-abc-123");
+  const loaded = await store.loadRefreshToken();
+  assert.equal(loaded, "rt-abc-123");
+});
+
+test("2. 토큰 미저장 상태에서 load → null", async () => {
+  const { store } = loadRefreshStore();
+  const loaded = await store.loadRefreshToken();
+  assert.equal(loaded, null);
+});
+
+test("3. clear 후 load → null", async () => {
+  const { store } = loadRefreshStore();
+  await store.saveRefreshToken("rt-abc-123");
+  await store.clearRefreshToken();
+  const loaded = await store.loadRefreshToken();
+  assert.equal(loaded, null);
+});
+
+test("4. save를 두 번 하면 두 번째 값이 우선", async () => {
+  const { store } = loadRefreshStore();
+  await store.saveRefreshToken("rt-old");
+  await store.saveRefreshToken("rt-new");
+  assert.equal(await store.loadRefreshToken(), "rt-new");
+});
+
+// ── 키 비추출성 (extractable: false) ─────────────────────────────────────────
+
+test("5. 저장된 AES-GCM 키는 extractable === false (XSS 방어 모델 핵심)", async () => {
+  const { store, peek } = loadRefreshStore();
+  await store.saveRefreshToken("rt-anything");
+  const keyMap = peek(DB_NAME, KEYS_STORE);
+  const storedKey = keyMap.get(KEY_ID);
+  assert.ok(storedKey, "키가 저장돼 있어야 함");
+  assert.equal(storedKey.extractable, false, "키가 export 가능하면 보안 모델 무너짐");
+});
+
+test("6. 비추출 키는 subtle.exportKey 호출 시 거부된다", async () => {
+  const { store, peek } = loadRefreshStore();
+  await store.saveRefreshToken("rt-x");
+  const storedKey = peek(DB_NAME, KEYS_STORE).get(KEY_ID);
+  await assert.rejects(
+    () => globalThis.crypto.subtle.exportKey("raw", storedKey),
+    "extractable: false 키는 export 시 InvalidAccessError를 던져야 함",
+  );
+});
+
+// ── IV 유일성 (AES-GCM nonce 재사용 방지) ────────────────────────────────────
+
+test("7. 같은 평문을 두 번 암호화해도 ciphertext와 IV가 매번 달라진다", async () => {
+  const { store, peek } = loadRefreshStore();
+  await store.saveRefreshToken("rt-same");
+  const tokensMap = peek(DB_NAME, TOKENS_STORE);
+  const r1 = tokensMap.get(TOKEN_ID);
+  // Snapshot before second save
+  const iv1 = new Uint8Array(r1.iv);
+  const ct1 = new Uint8Array(r1.ciphertext);
+
+  await store.saveRefreshToken("rt-same");
+  const r2 = tokensMap.get(TOKEN_ID);
+  const iv2 = new Uint8Array(r2.iv);
+  const ct2 = new Uint8Array(r2.ciphertext);
+
+  assert.notDeepEqual(Array.from(iv1), Array.from(iv2), "IV가 매번 새로 생성돼야 함");
+  assert.notDeepEqual(Array.from(ct1), Array.from(ct2), "ciphertext도 IV와 함께 달라져야 함");
+});
+
+test("8. IV 길이는 12바이트 (AES-GCM 표준)", async () => {
+  const { store, peek } = loadRefreshStore();
+  await store.saveRefreshToken("rt-x");
+  const record = peek(DB_NAME, TOKENS_STORE).get(TOKEN_ID);
+  const iv = new Uint8Array(record.iv);
+  assert.equal(iv.length, 12);
+});
+
+// ── 손상 복구 (decrypt 실패 시 null + 레코드 삭제) ──────────────────────────
+
+test("9. ciphertext 손상 → load는 null, 손상 레코드 자동 삭제", async () => {
+  const { store, peek } = loadRefreshStore();
+  await store.saveRefreshToken("rt-original");
+
+  // Tamper directly with the IDB-backing map — simulates partial wipe / key
+  // regeneration / cross-version corruption that Phase 2i guards against.
+  const tokensMap = peek(DB_NAME, TOKENS_STORE);
+  const record = tokensMap.get(TOKEN_ID);
+  const tampered = new Uint8Array(record.ciphertext);
+  tampered[0] ^= 0xff;
+  tokensMap.set(TOKEN_ID, { iv: record.iv, ciphertext: tampered.buffer });
+
+  const loaded = await store.loadRefreshToken();
+  assert.equal(loaded, null, "복호화 실패 시 null 반환");
+  assert.equal(tokensMap.has(TOKEN_ID), false, "손상 레코드는 자동 삭제 (재시도 루프 방지)");
+});
+
+test("10. 손상 → 삭제 후 다시 save 가능 (자가 복구 흐름)", async () => {
+  const { store, peek } = loadRefreshStore();
+  await store.saveRefreshToken("rt-original");
+  const tokensMap = peek(DB_NAME, TOKENS_STORE);
+  const record = tokensMap.get(TOKEN_ID);
+  const tampered = new Uint8Array(record.ciphertext);
+  tampered[0] ^= 0xff;
+  tokensMap.set(TOKEN_ID, { iv: record.iv, ciphertext: tampered.buffer });
+
+  // First load triggers cleanup
+  assert.equal(await store.loadRefreshToken(), null);
+
+  // After re-auth in production the new refresh token can be saved cleanly
+  await store.saveRefreshToken("rt-fresh");
+  assert.equal(await store.loadRefreshToken(), "rt-fresh");
+});
+
+// ── 키 영속성 (다중 호출 간 같은 키 재사용) ─────────────────────────────────
+
+test("11. 동일 인스턴스에서 save 여러 번 호출해도 키는 한 번만 생성", async () => {
+  const { store, peek } = loadRefreshStore();
+  await store.saveRefreshToken("a");
+  const keyAfter1 = peek(DB_NAME, KEYS_STORE).get(KEY_ID);
+  await store.saveRefreshToken("b");
+  const keyAfter2 = peek(DB_NAME, KEYS_STORE).get(KEY_ID);
+  assert.strictEqual(keyAfter1, keyAfter2, "같은 키 객체가 재사용돼야 함");
+});
+
+// ── 빈 문자열 / 큰 페이로드 경계 ─────────────────────────────────────────────
+
+test("12. 빈 문자열도 round-trip 정상", async () => {
+  const { store } = loadRefreshStore();
+  await store.saveRefreshToken("");
+  assert.equal(await store.loadRefreshToken(), "");
+});
+
+test("13. 긴 토큰(2KB)도 round-trip 정상", async () => {
+  const { store } = loadRefreshStore();
+  const big = "x".repeat(2048);
+  await store.saveRefreshToken(big);
+  assert.equal(await store.loadRefreshToken(), big);
+});


### PR DESCRIPTION
## Summary

PKCE 마이그레이션(Phase 2i) 단계 1 — OAuth refresh token용 AES-GCM 암호화 IndexedDB 저장소 신설.

- `js/sync/refresh-store.js` 신규 모듈: `saveRefreshToken` / `loadRefreshToken` / `clearRefreshToken`
- AES-GCM 256-bit 키를 `extractable: false`로 생성해 IDB에 영속 저장 — 같은 origin JS는 encrypt/decrypt API로만 키를 사용 가능, raw 바이트는 추출 불가
- 토큰마다 새 12-byte IV 생성 (AES-GCM nonce 재사용 방지)
- 복호화 실패 시 손상된 레코드 자동 삭제 (재시도 루프 방지)
- IDB 열기 실패 시(Safari private mode 등) 조용히 null 반환 → 호출자가 NEEDS_CONSENT로 폴백

## 보안 모델

XSS 방어 1차는 이미 적용된 strict CSP (index.html line 5). IDB 암호화는 추가 방어층으로 **storage-level 도용**(악성 브라우저 확장, 디바이스 덤프)을 방어. XSS 자체에 대해선 동일 origin JS가 우리 decrypt 함수를 그대로 호출할 수 있으므로 동일하게 취약 — 이는 SPA의 본질적 한계.

## 단계 1의 안전성

이 PR은 어떤 흐름과도 결합되지 않은 신규 모듈만 추가:
- `js/types.d.ts`: `RefreshTokenStore` 인터페이스 + `Window.refreshStore` augmentation
- `index.html`: `<script defer>` 한 줄
- 어디에서도 `window.refreshStore`를 호출하지 않음 → **사용자 영향 0**

다음 PR(단계 2)에서 transport.js의 PKCE 유틸과 함께 사용 시작 예정.

## Test plan

- [x] `node --test tests/unit/refresh-store.test.js` — 13/13 통과
  - round-trip 정상
  - 토큰 미저장 → null
  - clear 후 → null
  - 두 번 save 시 두 번째 값 우선
  - **`extractable === false` 보장** (보안 모델 핵심)
  - **`subtle.exportKey`가 비추출 키 거부 확인**
  - 같은 평문이라도 IV/ciphertext가 매번 달라짐 (nonce 재사용 방지)
  - IV 길이 12바이트
  - ciphertext 손상 → null + 레코드 자동 삭제
  - 손상 후 재저장으로 자가 복구
  - 키 영속성 (다중 호출에 한 번만 생성)
  - 빈 문자열 / 2KB 토큰 경계
- [x] `node --test tests/unit/state-machine.test.js` — 20/20 회귀 없음
- [x] `tsc -p tsconfig.json --noEmit` — 0 error
- [x] CI workflow가 `tests/unit/` 디렉터리 전체를 실행하도록 갱신 (이후 단계 테스트 자동 포함)

## 다음 단계

[계획 파일](https://github.com/anglican-kr/common-bible/blob/main/docs/decisions/011-bookmark-sync.md)의 Phase 2i 단계 2: transport.js에 PKCE verifier/challenge 생성 + token 교환 endpoint 호출 함수 추가.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit c55d69fe7c8b6bd13acda01763aa21c8e148e56b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->