### PR TITLE
fix: legacy reauth에 DISABLED race 가드 추가 (Bugbot PR #54 3차)

### DIFF
--- a/js/sync/state-machine.js
+++ b/js/sync/state-machine.js
@@ -778,6 +778,17 @@ function createSyncMachine({ onStateChange } = {}) {
     // Phase 2h: cap check + REAUTH log moved upfront to _handleSyncFail("401")
     // so they fire even on the silent-refresh path. Reaching here means
     // reAuthFails < MAX_REAUTH guaranteed.
+    // Race guard (Bugbot PR #54 3차): _kickoff401Reauth awaits IDB inside
+    // _attemptSilentRefresh; if there is no refresh token the silent path
+    // returns false WITHOUT touching state, so its own race guards never
+    // fire. If the user called disable()/signOut() during that async window
+    // we'd resurrect sync from DISABLED into IDENTIFYING/AUTHENTICATING/
+    // NEEDS_CONSENT here. Mirror the localStorage flag check used by the
+    // silent path.
+    if (localStorage.getItem(SYNC_ENABLED_KEY) === "0") {
+      L.log({ kind: "ACTION", event: "LEGACY_REAUTH_RACE_LOST", reason: "sync_disabled" });
+      return;
+    }
     if (T.isIOS()) {
       // Hybrid policy: defer the disruptive full-page redirect when the
       // user is actively reading; otherwise reauthorize transparently.

--- a/tests/unit/state-machine.test.js
+++ b/tests/unit/state-machine.test.js
@@ -687,3 +687,38 @@ test("30. acceptRedirectCode 진행 중 signOut() 호출 → DISABLED 유지 (Bu
   assert.equal(machine.getState(), "DISABLED", "DISABLED 유지 — code 교환 결과 폐기");
   assert.equal(refreshStore._calls.save, 0, "IDB에 refresh token 저장 안 됨");
 });
+
+// ── Bugbot PR #54 (3차): legacy reauth race 가드 ─────────────────────────────
+
+test("33. 401 reauth 진행 중 disable() → DISABLED 유지 (legacy 폴백 차단)", async () => {
+  // 시나리오: SYNCING에서 401 발생 → _kickoff401Reauth가 _attemptSilentRefresh
+  // await 중 사용자가 disable() 호출 → IDB에 refresh token이 없어 silent 경로는
+  // 상태 변경 없이 false 반환 → _legacyReauthAfter401가 DISABLED를 IDENTIFYING/
+  // AUTHENTICATING/NEEDS_CONSENT로 잘못 전이시키면 안 됨.
+  let resolveLoad;
+  const loadPromise = new Promise((r) => { resolveLoad = r; });
+  const refreshStore = {
+    saveRefreshToken: async () => {},
+    loadRefreshToken: () => loadPromise, // 외부 제어 hold
+    clearRefreshToken: async () => {},
+    _peek: () => null,
+    _calls: { save: 0, load: 0, clear: 0 },
+  };
+  const { machine, drain } = loadMachine({
+    hasGoogleId: true, // GIS available — 가드 없을 시 IDENTIFYING으로 이탈
+    findFileId: "fid",
+    downloadResult: { doc: null, etag: null, status: 401 },
+    overrideStubs: { refreshStore },
+  });
+  machine.acceptRedirectToken("expiring-token");
+  await drain(3);
+  // 첫 sync cycle이 401로 _kickoff401Reauth 진입 → loadRefreshToken에서 hold
+  // 사용자 disconnect 클릭 시뮬레이션
+  machine.disable();
+  assert.equal(machine.getState(), "DISABLED", "disable() 즉시 DISABLED");
+  // 이제 IDB load가 null로 resolve → silent refresh false 반환 →
+  // _legacyReauthAfter401 호출. 가드가 SYNC_ENABLED_KEY="0"을 잡아야 함.
+  resolveLoad(null);
+  await drain(5);
+  assert.equal(machine.getState(), "DISABLED", "legacy reauth 가드: DISABLED 유지");
+});


### PR DESCRIPTION
## Summary

[Bugbot 3차 리뷰](https://github.com/anglican-kr/common-bible/pull/54#pullrequestreview-4240432995)가 보고한 race 컨디션 수정.

**Race 시나리오 (`_state === DISABLED` 부활):**
1. SYNCING 중 401 발생 → `_handleSyncFail("401")` → `_kickoff401Reauth(event, ...)`
2. `_kickoff401Reauth`가 `await _attemptSilentRefresh(...)` — **여기서 비동기 gap**
3. 사용자가 disable() / signOut() 클릭 → state 전이 DISABLED, `SYNC_ENABLED_KEY="0"`
4. IDB에 refresh token이 없으므로 silent 경로는 **상태를 건드리지 않고 false 반환** (자체 race 가드도 트리거되지 않음 — early return)
5. `_kickoff401Reauth`가 `_legacyReauthAfter401(event)`로 fall through
6. ❌ 가드 없이 `IDENTIFYING` / `AUTHENTICATING` / `NEEDS_CONSENT`로 전이 → 사용자가 명시적으로 끊은 동기화 부활

**수정**: `_legacyReauthAfter401` 진입 시 `localStorage.getItem(SYNC_ENABLED_KEY) === "0"` 체크. silent refresh / `acceptRedirectCode`가 이미 같은 패턴을 사용 중이라 일관성도 확보.

## Test plan

- [x] `node --test tests/unit/state-machine.test.js` — **39/39 통과** (기존 38 + 회귀 33번 1건 추가)
- [x] 회귀 테스트가 fix 없이는 fail함을 확인 (`git stash` 후 재실행)
- [x] `tsc -p tsconfig.json --noEmit --ignoreDeprecations 6.0` — 0 error

회귀 테스트 33번은 `loadRefreshToken`을 외부 제어 promise로 hold해 race window를 결정론적으로 재현하고, `disable()` 호출 → `null`로 resolve → `_legacyReauthAfter401` 진입 시 `DISABLED` 유지를 검증.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01MFig6vy6R1NxjpYyGUb5pu)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the 401 re-authentication path in the sync state machine; while the change is small, it affects state transitions during auth failures and could impact reconnect behavior if the guard is incorrect.
> 
> **Overview**
> Prevents a race where a user-initiated `disable()`/`signOut()` during a 401 reauth attempt could *resurrect* sync from `DISABLED` via the legacy fallback path.
> 
> Adds a `SYNC_ENABLED_KEY` localStorage check at the start of `_legacyReauthAfter401()` (mirroring the silent-refresh guard) and introduces a deterministic unit test that reproduces the async IDB window and asserts the machine remains `DISABLED`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77fa92e8b96121b710343e971bc843548b893aa4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->