### PR TITLE
feat: 오디오 캐시 LRU 관리 (ADR-016)

### DIFF
--- a/docs/decisions/001-spa-architecture.md
+++ b/docs/decisions/001-spa-architecture.md
@@ -75,6 +75,8 @@ History API SPA 라우팅상 모든 navigation 요청(`/bible/gen/1` 등)은 캐
 
 `/data/audio/*.mp3`는 다시 별도 `AUDIO_CACHE`(예: `audio-1`)에 보관한다. 오디오는 사용자가 재생을 요청할 때만 다운로드되며, 텍스트 데이터와 다른 라이프사이클을 가지므로 분리해 인코딩 변경 시에만 독립적으로 bump한다.
 
+오디오는 73권 전체가 ~6.5 GB로 origin quota를 잠식할 수 있어, **300 MB hard cap + 마지막 재생 시점 기준 LRU**로 자체 정리한다. 자세한 내용은 ADR-016 참고.
+
 ### Google Fonts — `FONT_CACHE`
 
 `fonts.gstatic.com` 파일은 콘텐츠 주소 기반의 불변 URL이므로 별도 `FONT_CACHE`에 저장한다.

--- a/docs/decisions/016-audio-cache-lru.md
+++ b/docs/decisions/016-audio-cache-lru.md
@@ -1,0 +1,165 @@
+# ADR-016: 오디오 캐시 LRU 관리 (300 MB cap, 재생 시점 기준)
+
+- 일시: 2026-05-07
+- 상태: 제안됨
+- 관련 ADR: ADR-001(SPA + 캐시 분리), ADR-015(클라이언트 스토리지 전략)
+
+## 결정
+
+`AUDIO_CACHE`(ADR-001)에 **300 MB hard cap + 마지막 재생 시점 기준 LRU**를 도입한다.
+
+오디오 메타(`{url, byteSize, lastPlayedAt, addedAt}`)는 IndexedDB에 별도 저장하고, `<audio>` 요소의 `play` 이벤트에서 `lastPlayedAt`을 갱신한다. 캐시가 cap을 초과하면 `lastPlayedAt`이 가장 오래된 (null 우선) 항목부터 evict한다.
+
+## 맥락
+
+ADR-001 2026-05-07 개정으로 SW 캐시가 셸/데이터/오디오/폰트 4개로 분리되어, 셸 릴리스마다 사용자 누적 오디오가 통째로 삭제되던 문제는 해결됐다. 그러나 분리만으로는 다음이 남아 있다.
+
+### 1. 오디오는 사실상 무제한 누적
+
+73권 × 1328장 × 평균 4.89 MB ≈ **6.5 GB**. 사용자가 들은 장이 모두 영구 보존되면 origin quota를 잠식한다.
+
+| 환경 | origin quota (대략) | 6.5 GB가 차지 |
+| --- | --- | --- |
+| Chrome / Edge | 디스크의 ~60%, 보통 수십 GB | 여유 |
+| Firefox | origin당 10 GB cap | 65% |
+| Safari (macOS) | 초기 ~1 GB, 초과 시 사용자 prompt | prompt 빈발 |
+| **iOS Safari (브라우저)** | **~1 GB, 7일 미사용 시 evict** | **불가** |
+| iOS PWA (홈 화면) + persist | ~1 GB, evict 면제 | 여전히 quota 초과 |
+
+iOS가 가장 빡빡한 bottleneck.
+
+### 2. 브라우저 evict는 텍스트도 함께 잃을 수 있음
+
+quota 압박 시 브라우저 evict는 origin 단위로 동작하며, AUDIO만 골라 비우지 않는다. 오디오로 quota를 채우면 본문 JSON 캐시(`DATA_CACHE`)까지 함께 evict될 수 있어, 오프라인 사용자가 갑자기 본문도 못 보는 상황이 발생한다.
+
+### 3. "임시 vs 영구"의 구현 부재
+
+오디오는 한 번 들은 후 다시 들을 가능성이 떨어지는 휘발성에 가깝고, 본문 JSON은 콘텐츠가 바뀔 때까지 유지하는 게 자연스럽다. ADR-001은 이 차이를 라이프사이클 분리(릴리스 bump 독립)로만 표현했고, 오디오 측 자체 정리(self-eviction) 정책은 없었다.
+
+## 검토한 대안
+
+### A. cap 후보값
+
+평균 파일 크기 4.89 MB 기준:
+
+| cap | 장 수 | 무엇이 들어가나 | 채택? |
+| --- | --- | --- | --- |
+| 100 MB | ~20 | 한 권의 절반 | 빡빡 |
+| **300 MB** | **~61** | **단권 책 1-2개** | **채택** |
+| 500 MB | ~102 | 4복음서 통째 | iOS quota 50% 부담 |
+| 1 GB | ~204 | 신약 절반 | iOS quota 전체 |
+
+300 MB는 iOS quota(~1 GB)의 30% 수준. DATA_CACHE(~6 MB) + 셸 + 폰트 + Drive sync IDB와 합쳐도 quota에 여유. 미사 낭독·매일 시편 같은 대표 사용 시나리오는 cap 안에 들어오고, 4복음서 전체나 신약 1독 같은 큰 묶음은 LRU churn으로 처리한다.
+
+### B. LRU 기준 시각
+
+| 옵션 | 의미 | 채택? |
+| --- | --- | --- |
+| fetch 시점 (cache put) | 캐시에 처음 들어간 순간 | 미채택 |
+| **재생 시점 (`<audio>` play)** | **사용자가 실제로 들은 순간** | **채택** |
+| 마지막 접근 (cache match) | preload 포함 모든 read | 미채택 |
+
+fetch 시점은 prefetch가 들어오면 모든 prefetch가 "최근"으로 찍혀 LRU 신호가 망가진다. 모든 cache match는 `<audio preload="metadata">`처럼 실제 재생 의도가 없는 접근까지 포함해 노이즈가 크다. 재생 시점은 "사용자가 의도적으로 들은 장"을 정확히 표현한다.
+
+### C. 메타 저장소
+
+| 옵션 | 채택? |
+| --- | --- |
+| Cache API 자체 | 미채택 — access time 노출 안 됨 |
+| `localStorage` | 미채택 — 동기 I/O, 5-10 MB 한도, SW에서 접근 불가 |
+| **IndexedDB** | **채택** |
+
+### D. fetch는 됐지만 안 들은 파일의 우선순위
+
+| 옵션 | 의미 | 채택? |
+| --- | --- | --- |
+| **`lastPlayedAt = null`을 가장 먼저 evict** | "받았지만 안 들은 건 최우선 폐기" | **채택** |
+| fetch 시점을 임시 `lastPlayedAt`으로 사용 | 최근 fetch면 살아남음 | 미채택 — prefetch 노이즈 재발 |
+
+prefetch나 preload로 들어왔지만 실제로 듣지 않은 파일은 LRU 측면에서 가치가 가장 낮다. 이 정책은 prefetch를 적극 추가해도 진짜 들은 장을 보호한다.
+
+### E. 정리 트리거
+
+| 옵션 | 장단점 |
+| --- | --- |
+| 매 cache put 직후 SW 정리 | fetch 핸들러에서 IDB 트랜잭션 — 첫 재생 지연 가능 |
+| **idle 시점 클라이언트 정리 (soft + hard cap)** | cap 살짝 초과 허용, 페이지 idle에 일괄 |
+
+**채택**: soft cap 300 MB / hard cap 360 MB. SW fetch 핸들러는 hard cap만 검사하고, soft cap 미만으로 줄이는 정리는 `requestIdleCallback` 또는 `visibilitychange`('hidden') 시점에 일괄 수행한다.
+
+### F. `navigator.storage.persist()` 호출 시점
+
+origin 전체 persist는 brower evict를 면제(특히 iOS 7일 룰 회피). 단, prompt가 뜰 수 있어 시점 선택이 중요.
+
+| 시점 | 채택? |
+| --- | --- |
+| 앱 첫 로드 시 즉시 | 미채택 — 가치 인식 전 |
+| **북마크 추가 / Drive 첫 로그인 / 첫 오프라인 재생** | **채택** |
+| 호출 안 함 | 미채택 — iOS 7일 evict 노출 |
+
+가치 시점에 호출하면 prompt 수락률이 높고, 거부돼도 LRU 자체는 동작한다.
+
+## 결정 상세
+
+### D1. 메타 스키마
+
+IndexedDB DB 이름 `bible-audio-cache` (`bible-*` 컨벤션 일치), 단일 object store `entries`:
+
+| 필드 | 타입 | 설명 |
+| --- | --- | --- |
+| `url` (key) | `string` | `/data/audio/{book_id}-{chapter}.mp3` |
+| `byteSize` | `number` | `Response.headers.get("content-length")` 또는 `Blob.size` |
+| `lastPlayedAt` | `number \| null` | epoch ms. 미재생이면 null |
+| `addedAt` | `number` | epoch ms. 캐시 진입 시각 (디버그·통계용, evict 결정엔 미사용) |
+
+인덱스: `lastPlayedAt`. evict 시 null 우선 → 그 다음 오름차순 스캔.
+
+### D2. 상수
+
+```js
+const AUDIO_CACHE_SOFT_CAP = 300 * 1024 * 1024; // 300 MB
+const AUDIO_CACHE_HARD_CAP = 360 * 1024 * 1024; // 360 MB
+```
+
+### D3. 라이프사이클
+
+1. **fetch**: SW가 `/data/audio/*.mp3`를 받으면 `AUDIO_CACHE`에 put + `entries`에 `{url, byteSize, lastPlayedAt: null, addedAt: now}` upsert. byteSize는 응답 헤더 또는 blob에서 추출.
+2. **재생**: 메인 스레드 `<audio>`의 `play` 이벤트 핸들러가 `entries`의 `lastPlayedAt`을 `Date.now()`로 갱신.
+3. **soft cap 정리**: `requestIdleCallback`(없으면 `setTimeout(_, 1000)`) 또는 `visibilitychange`('hidden') 시점에 클라이언트가 총 `byteSize` 합산. `> 300 MB`이면 `lastPlayedAt` 오름차순(null 우선)으로 정리해 `≤ 300 MB`까지 줄인다.
+4. **hard cap 차단**: SW fetch 핸들러에서 새 오디오 put 후 합산. `> 360 MB`이면 같은 정렬 기준으로 즉시 정리 (트랜잭션 1회).
+5. **persist 시도**: 북마크 추가, Drive 첫 로그인, 첫 오프라인 재생 중 가장 빠른 시점에 `navigator.storage.persist()` 호출. 결과는 디버그 로그에만 기록(에러 무시).
+
+### D4. evicted 후 오프라인 재생
+
+사용자가 LRU로 evict된 장을 오프라인에서 재생하려 하면 fetch가 실패한다. 기존 오디오 에러 핸들러가 처리하되, 메시지에 "이 장은 오프라인 캐시에서 정리되었습니다. 온라인 상태에서 다시 들으면 자동 저장됩니다." 류 안내를 추가한다.
+
+### D5. 디버그
+
+`debug-log.js` ring buffer에 `audio-evict` 이벤트(삭제된 url 수, 사유: soft/hard, 정리 후 총 크기)를 기록한다. 사용자 설정 페이지의 "오디오 캐시 X / 300 MB" 통계 UI는 v2(필요 시)로 미룬다.
+
+## 근거
+
+1. **300 MB hard cap**: iOS Safari quota(~1 GB)의 30%, 다른 캐시(데이터 6 MB·셸·폰트·Drive IDB)와 합쳐 quota에 여유. 평균 4.89 MB × 61장 = 단권 책 1-2개를 핫 캐시로 보존.
+2. **재생 시점 LRU**: prefetch·preload·`preload="metadata"` 같은 자동 트래픽이 LRU 신호를 오염시키지 않음. "들은 장을 보호한다"는 의도와 일치.
+3. **soft/hard cap 분리**: SW fetch 핸들러를 가볍게 유지(hard cap만 검사). 평소 정리는 페이지 idle에 일괄.
+4. **null `lastPlayedAt` 우선 evict**: prefetch를 적극 추가해도 LRU 안전성 유지.
+5. **IDB 별도 메타**: Cache API는 access time을 노출하지 않으므로 외부 메타 필수. SW·페이지 양쪽 접근 가능.
+6. **persist 가치 시점 호출**: 첫 로드 prompt는 거부율이 높음. 사용자가 앱에 가치를 느낀 시점이 수락률 최고.
+
+## 영향 범위
+
+| 파일 | 변경 |
+| --- | --- |
+| `sw.js` | `/data/audio/*` fetch 핸들러에서 hard cap 검사 + 메타 IDB upsert |
+| `js/app.js` | `<audio>` `play` 이벤트에서 `lastPlayedAt` 갱신, idle 시 soft cap 정리, persist 호출 시점 |
+| `js/audio-cache.js` (신규) | IDB open/upsert/evict/scan 모듈, SW·페이지 공용 |
+| `js/types.d.ts` | `AudioCacheEntry` 타입 추가 |
+| `tests/unit/audio-cache.test.js` (신규) | LRU 정렬, null 우선, hard/soft cap, byte 합산 회귀 |
+| `docs/decisions/001-spa-architecture.md` | "오디오 — `AUDIO_CACHE`" 섹션에 ADR-016 cross-reference |
+
+## 참고
+
+- ADR-001 SPA 아키텍처 (캐시 분리, 2026-05-07 개정)
+- ADR-013 클라이언트 JS 유닛 테스트 (vm 하네스 패턴)
+- W3C Storage API: `navigator.storage.persist()` / `estimate()`
+- WebKit "Storage Quota Limits" (iOS 7일 evict)

--- a/index.html
+++ b/index.html
@@ -278,6 +278,7 @@
   <script defer src="/js/sync/store-v2.js"></script>
   <script defer src="/js/sync/state-machine.js"></script>
   <script defer src="/js/drive-sync.js"></script>
+  <script defer src="/js/audio-cache.js"></script>
   <script defer src="/js/gtag-init.js"></script>
   <script defer src="/js/app.js"></script>
 </body>

--- a/js/app.js
+++ b/js/app.js
@@ -188,6 +188,51 @@ function clearAudioTime() {
   try { localStorage.removeItem(AUDIO_POS_KEY); } catch (_) {}
 }
 
+// ── Audio cache LRU helpers (ADR-016) ──
+// One-shot persisted-storage request: called on the first value moment
+// (audio play, bookmark save, etc.). navigator.storage.persist() may show a
+// browser prompt on Safari/Firefox; on Chrome it grants silently when the
+// site has high engagement. We swallow result errors — even if denied, the
+// LRU loop in audio-cache.js still functions, just without iOS 7-day evict
+// immunity.
+let _persistAttempted = false;
+function _maybeRequestPersist() {
+  if (_persistAttempted) return;
+  _persistAttempted = true;
+  if (!navigator.storage?.persist) return;
+  navigator.storage.persist()
+    .then((granted) => {
+      window.syncDebugLog?.log({ kind: "ACTION", event: "storage-persist", granted });
+    })
+    .catch(() => {});
+}
+
+// Soft-cap eviction. Page-driven (SW only enforces hard cap on put). Called
+// on visibilitychange→hidden so the work runs while the user is not actively
+// reading. SW already opens AUDIO_CACHE under the same name; we use the
+// constant exported by audio-cache.js to avoid drift.
+async function _enforceAudioSoftCap() {
+  const ac = window.bibleAudioCache;
+  if (!ac) return;
+  try {
+    const total = await ac.totalSize();
+    if (total <= ac.SOFT_CAP) return;
+    const { urls } = await ac.pickEvictions(ac.SOFT_CAP);
+    if (!urls.length) return;
+    const cache = await caches.open(ac.AUDIO_CACHE_NAME);
+    await Promise.all(urls.map((u) => cache.delete(u)));
+    await ac.removeEntries(urls);
+    window.syncDebugLog?.log({
+      kind: "ACTION", event: "audio-evict", reason: "soft",
+      count: urls.length, totalBefore: total,
+    });
+  } catch (_) { /* best-effort */ }
+}
+
+document.addEventListener("visibilitychange", () => {
+  if (document.visibilityState === "hidden") _enforceAudioSoftCap();
+});
+
 // ── BEGIN SEARCH HISTORY HELPERS ──
 // Local-only (not Drive-synced — see ADR-014). Whitespace-normalized strings,
 // LRU-deduped, capped at SEARCH_HISTORY_MAX. The block between the BEGIN/END
@@ -931,6 +976,7 @@ function saveBookmarks(store) {
     localStorage.setItem(BOOKMARK_KEY, JSON.stringify(store));
     window.syncStoreV2?.saveBookmarks(store);
     if (window.driveSync) window.driveSync.scheduleUpload();
+    _maybeRequestPersist();
   } catch (_) {}
 }
 
@@ -2716,6 +2762,11 @@ function showAudioPlayer(bookId, chapter) {
   audio.addEventListener("play", () => {
     playBtn.setAttribute("aria-label", "일시정지");
     announce("재생");
+    // Touch LRU metadata + opportunistically request persisted storage on
+    // first play after install (value moment, ADR-016 §F).
+    const absUrl = new URL(src, location.href).href;
+    window.bibleAudioCache?.touch(absUrl).catch(() => {});
+    _maybeRequestPersist();
   }, { signal });
 
   audio.addEventListener("playing", () => {

--- a/js/audio-cache.js
+++ b/js/audio-cache.js
@@ -1,0 +1,187 @@
+// @ts-check
+// ── Audio cache LRU metadata store ────────────────────────────────────────────
+// IndexedDB-backed sidecar metadata for AUDIO_CACHE (sw.js). Used by both the
+// SW (importScripts) and the main page (<script src>). Cache API does not
+// expose access time, so we record byteSize/lastPlayedAt/addedAt here and use
+// them to drive LRU eviction. See ADR-016.
+//
+// IndexedDB layout:
+//   db    = "bible-audio-cache" (v1)
+//   store = "entries" (out-of-line key = url)
+//     value: { url, byteSize, addedAt, lastPlayedAt: number | null }
+//
+// Public surface attached to globalThis.bibleAudioCache:
+//   recordEntry(url, byteSize)  — idempotent insert, preserves play history
+//   touch(url)                  — set lastPlayedAt = now
+//   totalSize()                 — sum byteSize across all entries
+//   pickEvictions(targetCap)    — choose urls to evict (null first, then asc)
+//   removeEntries(urls)         — delete metadata (caller deletes from Cache API)
+//   AUDIO_CACHE_NAME            — must match sw.js AUDIO_CACHE constant
+//   SOFT_CAP, HARD_CAP          — bytes
+//
+// Why metadata-only (no Cache API ops): keeps this module testable without
+// faking Cache API and lets each call site (SW vs page) own its own
+// caches.open() — they already have their cache name in scope.
+
+(function () {
+  /** @typedef {{ url: string, byteSize: number, addedAt: number, lastPlayedAt: number | null }} AudioCacheEntry */
+
+  const DB_NAME = "bible-audio-cache";
+  const DB_VERSION = 1;
+  const STORE = "entries";
+
+  // Mirror sw.js — bump together when re-encoding mp3 files invalidates the cache.
+  const AUDIO_CACHE_NAME = "audio-1";
+  const SOFT_CAP = 300 * 1024 * 1024; // 300 MB
+  const HARD_CAP = 360 * 1024 * 1024; // 360 MB
+
+  /** @returns {Promise<IDBDatabase>} */
+  function _openDB() {
+    return new Promise((resolve, reject) => {
+      const req = indexedDB.open(DB_NAME, DB_VERSION);
+      req.onerror = () => reject(req.error);
+      req.onupgradeneeded = () => {
+        const db = req.result;
+        if (!db.objectStoreNames.contains(STORE)) db.createObjectStore(STORE);
+      };
+      req.onsuccess = () => resolve(req.result);
+    });
+  }
+
+  /**
+   * @template T
+   * @param {IDBRequest<T>} req
+   * @returns {Promise<T>}
+   */
+  function _reqAsPromise(req) {
+    return new Promise((resolve, reject) => {
+      req.onsuccess = () => resolve(req.result);
+      req.onerror = () => reject(req.error);
+    });
+  }
+
+  /**
+   * @template T
+   * @param {IDBTransactionMode} mode
+   * @param {(store: IDBObjectStore) => Promise<T>} fn
+   * @returns {Promise<T>}
+   */
+  async function _withStore(mode, fn) {
+    const db = await _openDB();
+    try {
+      const store = db.transaction(STORE, mode).objectStore(STORE);
+      return await fn(store);
+    } finally {
+      db.close();
+    }
+  }
+
+  /**
+   * Idempotent: re-recording an existing url preserves addedAt and
+   * lastPlayedAt. byteSize is updated (in case the file was re-encoded).
+   * @param {string} url
+   * @param {number} byteSize
+   */
+  async function recordEntry(url, byteSize) {
+    const safeBytes = Number.isFinite(byteSize) ? Math.max(0, Math.trunc(byteSize)) : 0;
+    return _withStore("readwrite", async (store) => {
+      /** @type {AudioCacheEntry | undefined} */
+      const existing = await _reqAsPromise(store.get(url));
+      const now = Date.now();
+      /** @type {AudioCacheEntry} */
+      const entry = {
+        url,
+        byteSize: safeBytes,
+        addedAt: existing?.addedAt ?? now,
+        lastPlayedAt: existing?.lastPlayedAt ?? null,
+      };
+      await _reqAsPromise(store.put(entry, url));
+    });
+  }
+
+  /** @param {string} url */
+  async function touch(url) {
+    return _withStore("readwrite", async (store) => {
+      /** @type {AudioCacheEntry | undefined} */
+      const existing = await _reqAsPromise(store.get(url));
+      if (!existing) return;
+      existing.lastPlayedAt = Date.now();
+      await _reqAsPromise(store.put(existing, url));
+    });
+  }
+
+  /** @returns {Promise<AudioCacheEntry[]>} */
+  async function _listAll() {
+    return _withStore("readonly", async (store) => {
+      /** @type {AudioCacheEntry[]} */
+      const all = await _reqAsPromise(store.getAll());
+      return all || [];
+    });
+  }
+
+  /** @returns {Promise<number>} */
+  async function totalSize() {
+    const all = await _listAll();
+    return all.reduce((s, e) => s + (e.byteSize || 0), 0);
+  }
+
+  /**
+   * Sort: lastPlayedAt === null first (received but never played),
+   * then ascending lastPlayedAt. Tiebreak by addedAt asc so older
+   * unplayed entries go first.
+   * @param {AudioCacheEntry} a
+   * @param {AudioCacheEntry} b
+   */
+  function _evictionOrder(a, b) {
+    if (a.lastPlayedAt === null && b.lastPlayedAt === null) {
+      return (a.addedAt || 0) - (b.addedAt || 0);
+    }
+    if (a.lastPlayedAt === null) return -1;
+    if (b.lastPlayedAt === null) return 1;
+    return a.lastPlayedAt - b.lastPlayedAt;
+  }
+
+  /**
+   * Pick the minimum set of urls to evict so that remaining total <= targetCap.
+   * Returns empty list when already under cap.
+   * @param {number} targetCap
+   * @returns {Promise<{urls: string[], freedBytes: number}>}
+   */
+  async function pickEvictions(targetCap) {
+    const all = await _listAll();
+    const total = all.reduce((s, e) => s + (e.byteSize || 0), 0);
+    if (total <= targetCap) return { urls: [], freedBytes: 0 };
+    all.sort(_evictionOrder);
+    const need = total - targetCap;
+    let freed = 0;
+    /** @type {string[]} */
+    const urls = [];
+    for (const e of all) {
+      if (freed >= need) break;
+      urls.push(e.url);
+      freed += e.byteSize || 0;
+    }
+    return { urls, freedBytes: freed };
+  }
+
+  /** @param {string[]} urls */
+  async function removeEntries(urls) {
+    if (!urls || !urls.length) return;
+    return _withStore("readwrite", async (store) => {
+      for (const url of urls) await _reqAsPromise(store.delete(url));
+    });
+  }
+
+  // Attach to globalThis (works in window, ServiceWorkerGlobalScope, vm context).
+  /** @type {any} */ (globalThis).bibleAudioCache = {
+    recordEntry,
+    touch,
+    totalSize,
+    pickEvictions,
+    removeEntries,
+    AUDIO_CACHE_NAME,
+    SOFT_CAP,
+    HARD_CAP,
+    _listAll, // exposed for diagnostics / tests
+  };
+})();

--- a/js/types.d.ts
+++ b/js/types.d.ts
@@ -264,6 +264,33 @@ export interface RefreshTokenStore {
   clearRefreshToken: () => Promise<void>;
 }
 
+// ── Audio cache LRU sidecar (ADR-016) ────────────────────────────────────────
+// IndexedDB-backed metadata for AUDIO_CACHE (sw.js). Cache API does not
+// expose access time, so we record byteSize/lastPlayedAt/addedAt here and
+// drive LRU eviction from both SW (hard cap on put) and page (soft cap on
+// visibilitychange).
+
+export interface AudioCacheEntry {
+  url: string;
+  byteSize: number;
+  addedAt: number;
+  // null = received but never played; sorted before any non-null entries
+  // when picking eviction candidates (ADR-016 §D).
+  lastPlayedAt: number | null;
+}
+
+export interface BibleAudioCache {
+  recordEntry: (url: string, byteSize: number) => Promise<void>;
+  touch: (url: string) => Promise<void>;
+  totalSize: () => Promise<number>;
+  pickEvictions: (targetCap: number) => Promise<{ urls: string[]; freedBytes: number }>;
+  removeEntries: (urls: string[]) => Promise<void>;
+  AUDIO_CACHE_NAME: string;
+  SOFT_CAP: number;
+  HARD_CAP: number;
+  _listAll: () => Promise<AudioCacheEntry[]>;
+}
+
 // ── Store v2 ─────────────────────────────────────────────────────────────────
 
 export interface SyncStoreV2 {
@@ -330,6 +357,7 @@ declare global {
     syncStoreV2: SyncStoreV2;
     syncDebugLog: SyncDebugLog;
     refreshStore: RefreshTokenStore;
+    bibleAudioCache: BibleAudioCache;
     createSyncMachine: (opts?: {
       onStateChange?: (state: SyncState) => void;
     }) => SyncMachine;

--- a/sw.js
+++ b/sw.js
@@ -5,7 +5,14 @@
 // sources are re-encoded.
 const SHELL_CACHE = "shell-49";
 const DATA_CACHE = "data-1";
-const AUDIO_CACHE = "audio-1";
+const AUDIO_CACHE = "audio-1"; // must equal js/audio-cache.js AUDIO_CACHE_NAME
+
+// LRU metadata sidecar for AUDIO_CACHE. Loaded best-effort: if the import
+// fails (e.g. file missing in older deploy), audio caching still works,
+// just without LRU bookkeeping.
+try {
+  importScripts("/js/audio-cache.js");
+} catch (_) { /* fall through; bibleAudioCache stays undefined */ }
 
 // Separate cache for Google Font files (fonts.gstatic.com).
 // Never cleared on cache bumps — font files are content-addressed and immutable.
@@ -19,6 +26,7 @@ const SHELL_FILES = [
   "/privacy.html",
   "/js/app.js",
   "/js/drive-sync.js",
+  "/js/audio-cache.js",
   "/js/sync/debug-log.js",
   "/js/sync/transport.js",
   "/js/sync/store-v2.js",
@@ -118,6 +126,26 @@ function handleFontFile(event) {
 // Cache invalidation is handled by bumping the relevant cache name on release.
 const DRIVE_HOSTNAMES = ["www.googleapis.com", "content.googleapis.com", "oauth2.googleapis.com", "accounts.google.com"];
 
+// Audio path: store in AUDIO_CACHE, record sidecar metadata, enforce hard cap.
+// Runs inside event.waitUntil so the response is delivered immediately and the
+// bookkeeping completes in background. Errors are swallowed — caching is
+// best-effort and must never break playback. (See ADR-016.)
+async function _putAudioAndEnforceCap(request, response) {
+  const cache = await caches.open(AUDIO_CACHE);
+  await cache.put(request, response);
+  const ac = self.bibleAudioCache;
+  if (!ac) return;
+  const cl = response.headers.get("content-length");
+  const byteSize = cl ? Number(cl) : 0;
+  await ac.recordEntry(request.url, byteSize);
+  const total = await ac.totalSize();
+  if (total <= ac.HARD_CAP) return;
+  const { urls } = await ac.pickEvictions(ac.SOFT_CAP);
+  if (!urls.length) return;
+  await Promise.all(urls.map((u) => cache.delete(u)));
+  await ac.removeEntries(urls);
+}
+
 self.addEventListener("fetch", (event) => {
   const url = new URL(event.request.url);
   const { hostname, pathname } = url;
@@ -153,7 +181,11 @@ self.addEventListener("fetch", (event) => {
       return fetch(new Request(event.request, { cache: "reload" })).then((res) => {
         if (res.ok) {
           const clone = res.clone();
-          caches.open(targetCache).then((cache) => cache.put(event.request, clone));
+          if (targetCache === AUDIO_CACHE) {
+            event.waitUntil(_putAudioAndEnforceCap(event.request, clone).catch(() => {}));
+          } else {
+            caches.open(targetCache).then((cache) => cache.put(event.request, clone));
+          }
         }
         return res;
       });

--- a/tests/unit/audio-cache.test.js
+++ b/tests/unit/audio-cache.test.js
@@ -1,0 +1,331 @@
+// ── Unit tests for js/audio-cache.js ─────────────────────────────────────────
+// Loads audio-cache.js inside a fresh node:vm context per test with an
+// in-memory fake IndexedDB. Asserts the LRU contract: idempotent recordEntry,
+// touch updates lastPlayedAt, pickEvictions sorts null-first then ascending
+// lastPlayedAt with addedAt tiebreak, removeEntries deletes only the named
+// urls, and the public constants stay locked to the ADR-016 values.
+
+import test from "node:test";
+// Non-strict assert: vm-context objects carry a different prototype than the
+// test realm's plain objects, which trips assert/strict's prototype check.
+// We still use strictEqual where prototype/type matters.
+import assert from "node:assert";
+import vm from "node:vm";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SOURCE = fs.readFileSync(
+  path.resolve(__dirname, "../../js/audio-cache.js"),
+  "utf8",
+);
+
+// ── Minimal in-memory IndexedDB ──────────────────────────────────────────────
+// Just enough surface for audio-cache.js: open() with onupgradeneeded,
+// transaction(name).objectStore(name) with get/put/delete/getAll, all
+// returning IDBRequest-shaped objects.
+
+function makeFakeIDB() {
+  /** @type {Map<string, {version: number, stores: Map<string, Map<unknown, unknown>>}>} */
+  const databases = new Map();
+
+  function fire(req, fn) {
+    queueMicrotask(() => {
+      try {
+        req.result = fn();
+        if (req.onsuccess) req.onsuccess({ target: req });
+      } catch (err) {
+        req.error = err;
+        if (req.onerror) req.onerror({ target: req });
+      }
+    });
+  }
+
+  function makeStore(map) {
+    return {
+      get(key) {
+        const req = { result: undefined, error: null, onsuccess: null, onerror: null };
+        fire(req, () => map.get(key));
+        return req;
+      },
+      put(value, key) {
+        const req = { result: undefined, error: null, onsuccess: null, onerror: null };
+        fire(req, () => { map.set(key, value); return key; });
+        return req;
+      },
+      delete(key) {
+        const req = { result: undefined, error: null, onsuccess: null, onerror: null };
+        fire(req, () => { map.delete(key); return undefined; });
+        return req;
+      },
+      getAll() {
+        const req = { result: undefined, error: null, onsuccess: null, onerror: null };
+        fire(req, () => [...map.values()]);
+        return req;
+      },
+    };
+  }
+
+  function makeDb(record) {
+    return {
+      get objectStoreNames() {
+        return { contains: (n) => record.stores.has(n) };
+      },
+      createObjectStore(name) {
+        if (!record.stores.has(name)) record.stores.set(name, new Map());
+        return makeStore(record.stores.get(name));
+      },
+      transaction(storeNames, _mode) {
+        const names = Array.isArray(storeNames) ? storeNames : [storeNames];
+        return {
+          objectStore(n) {
+            if (!names.includes(n)) throw new Error(`store ${n} not in scope`);
+            const map = record.stores.get(n);
+            if (!map) throw new Error(`store ${n} not found`);
+            return makeStore(map);
+          },
+        };
+      },
+      close() {},
+    };
+  }
+
+  return {
+    indexedDB: {
+      open(name, version) {
+        const req = {
+          result: null, error: null,
+          onsuccess: null, onupgradeneeded: null, onerror: null,
+        };
+        queueMicrotask(() => {
+          let rec = databases.get(name);
+          const upgrade = !rec || rec.version < version;
+          if (!rec) {
+            rec = { version: 0, stores: new Map() };
+            databases.set(name, rec);
+          }
+          req.result = makeDb(rec);
+          if (upgrade) {
+            const oldVersion = rec.version;
+            rec.version = version;
+            if (req.onupgradeneeded) req.onupgradeneeded({ oldVersion, newVersion: version, target: req });
+          }
+          if (req.onsuccess) req.onsuccess({ target: req });
+        });
+        return req;
+      },
+    },
+    peek: (db, store) => databases.get(db)?.stores.get(store),
+  };
+}
+
+// ── Loader ───────────────────────────────────────────────────────────────────
+
+function load({ now = 1000 } = {}) {
+  const { indexedDB, peek } = makeFakeIDB();
+  let _now = now;
+  const ctx = {
+    Promise, Object, Array, Map, Set, JSON, Error, Math, Number,
+    setTimeout, clearTimeout,
+    indexedDB,
+    Date: class extends Date {
+      static now() { return _now; }
+    },
+  };
+  vm.createContext(ctx);
+  ctx.globalThis = ctx;
+  vm.runInContext(SOURCE, ctx, { filename: "audio-cache.js" });
+  return {
+    ac: ctx.bibleAudioCache,
+    peek,
+    setNow: (t) => { _now = t; },
+  };
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+test("recordEntry inserts new entry with lastPlayedAt=null and addedAt=now", async () => {
+  const { ac, peek } = load({ now: 5000 });
+  await ac.recordEntry("/audio/gen-1.mp3", 4_000_000);
+  const all = await ac._listAll();
+  assert.equal(all.length, 1);
+  assert.deepEqual(all[0], {
+    url: "/audio/gen-1.mp3",
+    byteSize: 4_000_000,
+    addedAt: 5000,
+    lastPlayedAt: null,
+  });
+  // And it landed in the right store/key
+  const map = peek("bible-audio-cache", "entries");
+  assert.equal(map.size, 1);
+  assert.ok(map.has("/audio/gen-1.mp3"));
+});
+
+test("recordEntry is idempotent: preserves addedAt and lastPlayedAt on re-record", async () => {
+  const { ac, setNow } = load({ now: 1000 });
+  await ac.recordEntry("/audio/gen-1.mp3", 4_000_000);
+  setNow(2000);
+  await ac.touch("/audio/gen-1.mp3");
+  setNow(3000);
+  // Re-record (e.g. fetch happened again somehow). Should keep history.
+  await ac.recordEntry("/audio/gen-1.mp3", 4_500_000);
+  const all = await ac._listAll();
+  assert.equal(all.length, 1);
+  assert.equal(all[0].addedAt, 1000, "addedAt preserved");
+  assert.equal(all[0].lastPlayedAt, 2000, "lastPlayedAt preserved");
+  assert.equal(all[0].byteSize, 4_500_000, "byteSize updated");
+});
+
+test("recordEntry coerces non-finite/negative byteSize to 0", async () => {
+  const { ac } = load();
+  await ac.recordEntry("/a.mp3", NaN);
+  await ac.recordEntry("/b.mp3", -100);
+  await ac.recordEntry("/c.mp3", "not a number");
+  const all = await ac._listAll();
+  for (const e of all) assert.equal(e.byteSize, 0, `${e.url} coerced to 0`);
+});
+
+test("touch sets lastPlayedAt to current time, no-op for missing entries", async () => {
+  const { ac, setNow } = load({ now: 1000 });
+  await ac.recordEntry("/a.mp3", 1000);
+  setNow(7777);
+  await ac.touch("/a.mp3");
+  await ac.touch("/missing.mp3"); // must not throw, must not insert
+  const all = await ac._listAll();
+  assert.equal(all.length, 1);
+  assert.equal(all[0].lastPlayedAt, 7777);
+});
+
+test("totalSize sums byteSize across all entries", async () => {
+  const { ac } = load();
+  await ac.recordEntry("/a.mp3", 1_000_000);
+  await ac.recordEntry("/b.mp3", 2_500_000);
+  await ac.recordEntry("/c.mp3", 0);
+  assert.equal(await ac.totalSize(), 3_500_000);
+});
+
+test("pickEvictions returns empty list when total <= cap", async () => {
+  const { ac } = load();
+  await ac.recordEntry("/a.mp3", 100_000_000);
+  const result = await ac.pickEvictions(200_000_000);
+  assert.deepEqual(result, { urls: [], freedBytes: 0 });
+});
+
+test("pickEvictions sorts null lastPlayedAt before any played entries", async () => {
+  const { ac, setNow } = load({ now: 1000 });
+  // Played entries arrive first
+  await ac.recordEntry("/played-old.mp3", 50_000_000);
+  await ac.touch("/played-old.mp3"); // lastPlayedAt = 1000
+
+  setNow(2000);
+  await ac.recordEntry("/played-recent.mp3", 50_000_000);
+  await ac.touch("/played-recent.mp3"); // lastPlayedAt = 2000
+
+  setNow(3000);
+  await ac.recordEntry("/never-played.mp3", 50_000_000); // lastPlayedAt = null
+  // Total = 150 MB. Target 100 MB → must evict 50 MB.
+  const result = await ac.pickEvictions(100_000_000);
+  // Null entry should be picked first even though it was added LAST.
+  assert.deepEqual(result.urls, ["/never-played.mp3"]);
+  assert.equal(result.freedBytes, 50_000_000);
+});
+
+test("pickEvictions among null entries tiebreaks by addedAt asc", async () => {
+  const { ac, setNow } = load({ now: 1000 });
+  await ac.recordEntry("/older-null.mp3", 50_000_000); // addedAt=1000
+
+  setNow(2000);
+  await ac.recordEntry("/newer-null.mp3", 50_000_000); // addedAt=2000
+
+  // Total 100 MB, target 50 MB → evict one. Older addedAt should go first.
+  const result = await ac.pickEvictions(50_000_000);
+  assert.deepEqual(result.urls, ["/older-null.mp3"]);
+});
+
+test("pickEvictions among played entries sorts by lastPlayedAt asc", async () => {
+  const { ac, setNow } = load({ now: 1000 });
+  await ac.recordEntry("/a.mp3", 30_000_000);
+  await ac.recordEntry("/b.mp3", 30_000_000);
+  await ac.recordEntry("/c.mp3", 30_000_000);
+
+  setNow(5000); await ac.touch("/c.mp3"); // most recent
+  setNow(2000); await ac.touch("/a.mp3"); // oldest
+  setNow(3000); await ac.touch("/b.mp3"); // middle
+
+  // Total 90 MB. Target 60 MB → evict 30 MB worth → /a.mp3 (oldest play).
+  const result = await ac.pickEvictions(60_000_000);
+  assert.deepEqual(result.urls, ["/a.mp3"]);
+});
+
+test("pickEvictions stops at minimum needed to fit cap", async () => {
+  const { ac, setNow } = load({ now: 1000 });
+  // Five 100 MB entries, all unplayed but added in ascending time.
+  for (let i = 1; i <= 5; i++) {
+    setNow(1000 + i);
+    await ac.recordEntry(`/${i}.mp3`, 100_000_000);
+  }
+  // Total 500 MB. Target 250 MB → need to free 250 MB → 3 entries (300 MB).
+  const result = await ac.pickEvictions(250_000_000);
+  assert.equal(result.urls.length, 3);
+  assert.deepEqual(result.urls, ["/1.mp3", "/2.mp3", "/3.mp3"]);
+  assert.equal(result.freedBytes, 300_000_000);
+});
+
+test("removeEntries deletes only the named urls", async () => {
+  const { ac } = load();
+  await ac.recordEntry("/a.mp3", 1000);
+  await ac.recordEntry("/b.mp3", 1000);
+  await ac.recordEntry("/c.mp3", 1000);
+  await ac.removeEntries(["/a.mp3", "/c.mp3"]);
+  const all = await ac._listAll();
+  assert.deepEqual(all.map((e) => e.url), ["/b.mp3"]);
+});
+
+test("removeEntries handles empty/null input without throwing", async () => {
+  const { ac } = load();
+  await ac.recordEntry("/a.mp3", 1000);
+  await ac.removeEntries([]);
+  await ac.removeEntries(null);
+  await ac.removeEntries(undefined);
+  const all = await ac._listAll();
+  assert.equal(all.length, 1);
+});
+
+test("public constants match ADR-016", async () => {
+  const { ac } = load();
+  assert.equal(ac.AUDIO_CACHE_NAME, "audio-1");
+  assert.equal(ac.SOFT_CAP, 300 * 1024 * 1024);
+  assert.equal(ac.HARD_CAP, 360 * 1024 * 1024);
+  assert.ok(ac.SOFT_CAP < ac.HARD_CAP, "soft < hard");
+});
+
+test("end-to-end: hard-cap eviction scenario (SW path)", async () => {
+  // Simulates SW behavior: recordEntry on each fetch, then if total > HARD_CAP
+  // pickEvictions(SOFT_CAP) + removeEntries.
+  const { ac, setNow } = load({ now: 1000 });
+  // Fill with 100 entries × 4 MB = 400 MB (over hard cap 360 MB).
+  for (let i = 1; i <= 100; i++) {
+    setNow(1000 + i);
+    await ac.recordEntry(`/c-${i}.mp3`, 4 * 1024 * 1024);
+    if (i % 3 === 0) {
+      setNow(10000 + i);
+      await ac.touch(`/c-${i}.mp3`); // every 3rd is "played"
+    }
+  }
+  const totalBefore = await ac.totalSize();
+  assert.ok(totalBefore > ac.HARD_CAP, "setup over hard cap");
+
+  const { urls } = await ac.pickEvictions(ac.SOFT_CAP);
+  await ac.removeEntries(urls);
+
+  const totalAfter = await ac.totalSize();
+  assert.ok(totalAfter <= ac.SOFT_CAP, "post-evict total under soft cap");
+  // None of the played entries should be evicted as long as unplayed ones
+  // had enough room. Played entries: i ∈ {3,6,...,99} = 33 entries × 4 MB
+  // = 132 MB, well under 300 MB cap, so none of them are touched.
+  for (const u of urls) {
+    const idx = Number(u.match(/c-(\d+)/)[1]);
+    assert.ok(idx % 3 !== 0, `played entry ${u} should not be evicted`);
+  }
+});


### PR DESCRIPTION
## 요약

`AUDIO_CACHE`(ADR-001)의 자체 정리 정책 부재 문제 해결. 300 MB hard cap + 마지막 재생 시점 기준 LRU.

> **번호 변경**: 같은 사이클에 main에 머지된 ADR-015(클라이언트 스토리지 전략)와 충돌해 ADR-016으로 옮김.

- **cap**: hard 360 MB / soft 300 MB (iOS Safari quota ~1 GB의 30% 수준)
- **LRU 기준**: `<audio>` `play` 이벤트의 `lastPlayedAt` (prefetch·preload 노이즈 회피)
- **메타 저장**: IndexedDB `bible-audio-cache` (Cache API는 access time 미제공)
- **정리 트리거**: SW는 hard cap만 검사(put 직후), 페이지는 visibilitychange→hidden에서 soft cap 정리
- **`navigator.storage.persist()`**: 첫 재생/북마크 추가 시점에 호출 (가치 인식 후)
- **fetch만 됐고 안 들은 파일**: `lastPlayedAt = null`로 가장 먼저 evict (prefetch 안전성)

## 파일

| 파일 | 변경 |
| --- | --- |
| `docs/decisions/016-audio-cache-lru.md` (신규) | ADR 본문 |
| `docs/decisions/001-spa-architecture.md` | 오디오 섹션에 ADR-016 cross-reference |
| `js/audio-cache.js` (신규) | IDB 메타 모듈 (recordEntry, touch, totalSize, pickEvictions, removeEntries). SW·페이지 공용 |
| `sw.js` | importScripts로 audio-cache 로드. AUDIO_CACHE put 후 hard cap 검사 → 초과 시 SOFT_CAP까지 정리 |
| `js/app.js` | `<audio>` play 시 `touch`, visibilitychange→hidden 시 soft cap 정리, 첫 재생/북마크 저장 시 `persist()` |
| `index.html` | drive-sync 다음에 audio-cache.js 스크립트태그 추가 |
| `js/types.d.ts` | `AudioCacheEntry`, `BibleAudioCache` + Window augmentation |
| `tests/unit/audio-cache.test.js` (신규) | 14 케이스 |

## 테스트

- `node --test tests/unit/*.test.js` — **98/98 통과** (기존 84 + 신규 14)
- `npx tsc -p tsconfig.json --noEmit` / `tsconfig.worker.json` — 0 error (기존 deprecation warning 외)

신규 케이스:
- recordEntry idempotency (addedAt/lastPlayedAt 보존)
- touch 갱신·미존재 url no-op
- totalSize 합산
- pickEvictions: 빈 결과(cap 미초과), null 우선, addedAt 타이브레이크, lastPlayedAt asc, 최소 셋만 반환
- removeEntries 부분 삭제·null 입력 안전
- 상수 잠금 (300/360 MB)
- end-to-end: 100장 × 4 MB → SW path 시뮬레이션, 재생된 장은 보존

## 아직 안 한 것

- 사용자 설정 페이지의 "오디오 캐시 X / 300 MB" 통계 UI (ADR-016 §D5에서 v2로 미룸)
- Drive 첫 로그인 시점의 `persist()` 호출 (state-machine 훅 필요해 별도 사이클로)
- 평균 4.89 MB라는 실측은 사용자 제공 정보. Cache API에 들어가는 실제 크기는 `Content-Length` 헤더에서 추출하므로 정확