### PR TITLE
fix: 오디오 캐시 hardening + 2차 보안 감사 보고서 (1.4.6 안정화)

### DIFF
--- a/docs/audit/2026-05-08-second-comprehensive.md
+++ b/docs/audit/2026-05-08-second-comprehensive.md
@@ -1,0 +1,136 @@
+# 2차 통합 보안 감사 (2026-05-08)
+
+1.4.6 prod 배포 직후 통합 감사. 1차 감사들(`2026-05-02-171111.md` Implicit 시점, `2026-05-07-pkce-refresh-token.md` PKCE 시점)이 명시적으로 다루지 않았던 영역 — Python 데이터 파이프라인, 오디오 처리, 최근 JS 추가분(검색 이력·visibility sync·audio cache LRU), 의존성·빌드 파이프라인·정적 호스팅 노출면 — 을 중심으로 sweep. 동시에 OAuth/PKCE/refresh token은 BFF·visibility sync·dev 환경 분리가 추가됨에 따라 re-verify.
+
+## 요약
+
+| 영역 | Critical | High | Medium | Low/Info |
+|-----|---------|------|--------|---------|
+| Python 파이프라인 | 0 | 0 | 2 | 4 |
+| 오디오 처리 | 0 | 3 | 2 | 2 |
+| 검색 이력·visibility sync·BFF·헤더 | 0 | 0 | 2 | 5 |
+| 의존성·빌드·노출면 | 0 | 1 | 3 | 4 |
+| **합계** | **0** | **4** | **9** | **15** |
+
+**Critical 0건, High 4건** — 모두 즉시 처리 가능한 작업량. Medium 9건은 백로그.
+
+## High 발견 (즉시 처리 권장)
+
+### H1. 오디오 캐시 quota 폭발 — `sw.js:139`
+
+```js
+const cl = response.headers.get("content-length");
+const byteSize = cl ? Number(cl) : 0;
+```
+
+`Content-Length` 헤더가 없는 응답(chunked transfer / gzip)은 `byteSize=0`으로 IDB sidecar에 기록 → `totalSize()` 합산에서 빠짐 → LRU cap이 `HARD_CAP`(300 MB) 도달 신호를 못 받음 → Cache API 실제 사용량은 무제한 누적 → 브라우저 quota 초과 시 origin 단위 evict → DATA_CACHE(1328장 본문) + AUDIO_CACHE 둘 다 손실.
+
+**영향:** 사용자 디바이스의 storage 폭발 + 본문 캐시 무효화. 우리 현재 인프라는 nginx + Let's Encrypt에서 Content-Length를 항상 보내지만, CDN·proxy 추가 또는 Range 요청 등으로 누락될 미래 가능성.
+
+**수정:** `byteSize === 0`이면 `await response.clone().blob()` → `blob.size`로 폴백. 비용 1회 추가 read이지만 각 mp3당 한 번뿐.
+
+### H2. 오디오 eviction race — `sw.js:133-147`
+
+`_putAudioAndEnforceCap`이 `event.waitUntil` 안에서 비동기 진행. 두 동시 fetch가 같은 시점에 hard cap 초과를 감지하면 `pickEvictions(SOFT_CAP)`이 둘 다 같은 url 집합을 반환. 더 큰 문제: **방금 put된 새 파일이 다른 fetch의 evict 대상에 포함**되어 사용자가 막 다운로드 받은 mp3가 즉시 삭제되고 재생이 끊김.
+
+**영향:** 재생 중 mp3가 사라지는 사용자 경험 회귀. 빈도는 낮지만 LRU cap 근처에서 재현.
+
+**수정:** in-flight URL set으로 진행 중 다운로드 보호. 또는 IDB 단일 트랜잭션에서 read-evict-write를 atomic하게.
+
+### H3. IDB ↔ Cache API 불일치 — `audio-cache.js:14`, `sw.js:135`
+
+세 시나리오:
+- (a) `cache.put` 성공 → `recordEntry` 실패(IDB 풀 등) → Cache에 mp3는 있는데 IDB 메타 없음 → LRU 추적 누락(영구 누적)
+- (b) DevTools나 브라우저 설정에서 한쪽만 비움 → 무한 fetch(IDB 메타 살아있고 Cache는 비어있음) 또는 stale 메타
+- (c) `audio-cache.js:14` `importScripts` 실패 시 `bibleAudioCache=undefined`인데 caching은 계속 → 메타 없이 Cache API 무한 누적
+
+**수정:** SW `activate` 핸들러에 `cache.keys()` ↔ IDB entries 양방향 reconcile 추가. 첫 install 후 한 번 + 주기적(예: 24h마다 한 번).
+
+### H4. 작업 트리에 평문 `client_secret` 두 개 존재 (운영 위생)
+
+```
+dev_client_secret_359209354241-esbmeba2ku58depo9fgg08v52crfthot.apps.googleusercontent.com.json
+prod_client_secret_359209354241-do8kgvtcbnfvrge01f5hj29fee9cg195.apps.googleusercontent.com.json
+```
+
+`git log --all -p -S 'GOCSPX'` 0 hits → **git history 노출 없음**. `.gitignore:121 *_client_secret_*.json`이 잡고 있음. `build-deploy.sh` zip 화이트리스트에도 미포함 → 배포 zip 검증 0 hits. **그러나 디스크 평문 보관 + 디렉터리 listing 사고 + 백업 동기화 시 유출 위험**이 남는다. 두 secret이 이미 nginx 설정 파일에 안전히 들어갔으므로 디스크의 JSON은 더 이상 필요 없음.
+
+**수정:** 두 파일 삭제. 향후 secret 로테이션 시엔 1Password 등 외부 저장소에서 직접 nginx로.
+
+## Medium 발견 (백로그)
+
+### M1. `requirements.txt` 의존성 핀 부재
+`pytest>=7.4.0` 등 lower-bound만. `cairosvg`·`Pillow` 누락(`generate_splash.py`가 사용). dev-only라 영향 제한적이나 빌드 재현성·CVE 추적 불가. 권장: pip-compile lock 또는 최소한 `Pillow>=10.3.0` (CVE-2023-50447 방어) 명시.
+
+### M2. `split_bible.py:67` 빈 텍스트 IndexError 가능
+`text.split('\n')[1].startswith('¶')` — 정확히 1개 줄바꿈 + 두 번째 줄 비어있으면 OOB. 현재 입력은 안 타지만 `split('\n', 1)` + 길이 체크로 defense-in-depth.
+
+### M3. 오디오 캐시 무결성 검증 부재 — `sw.js:181-187`
+HTTPS origin 동일 출처로 MITM은 TLS로 막히지만, 일단 캐시되면 릴리스 bump까지 영구. 권장: mp3 매니페스트 hash 비교 (별도 ADR 필요).
+
+### M4. 재생 위치 `bible-audio-pos` 검증 — `app.js:179-185`
+`pos.time > 0`만 체크. 사용자가 localStorage에 NaN/Infinity 주입하면 `loadedmetadata` 전 가드 누락. `Number.isFinite && >=0` 검증 추가.
+
+### M5. `/oauth/token` rate limiting 부재 (ADR-017 §"향후 고려")
+공격자가 fake refresh_token 무한 POST → upstream Google 쿼터 소진/IP 차단 위험 → 정상 사용자 동기화 중단. nginx `limit_req_zone` 추가:
+```nginx
+limit_req_zone $binary_remote_addr zone=oauth:10m rate=10r/m;
+limit_req zone=oauth burst=20 nodelay;
+```
+
+### M6. BFF body parameter pollution
+`proxy_set_body "$request_body&client_secret=<SECRET>"` — 클라이언트가 body에 `client_secret=fake&` 또는 trailing `&`을 포함시키면 결과 body에 `client_secret`이 두 번 등장. Google 파서는 보통 마지막 값을 채택해 secret oracle은 안 되나 표준 미정의. 권장: nginx에서 `if ($request_body ~ "client_secret") { return 400; }` 가드, 또는 njs로 body 파싱·재조립.
+
+### M7. deploy zip 누적 (~37 MB)
+작업 트리에 7개 zip. `.gitignore:95 *.zip`으로 git 노출 없으나 디스크 누적·백업 사고 위험. `deploy.sh` 마지막에 `rm -f deploy-*.zip` (또는 7개 이하 유지) 권장.
+
+### M8. `release.py`가 git commit/tag 자동화 없음
+`version.json`·`sw.js` 둘 다 디스크에 쓰지만 git 작업 수동. 한쪽만 bump 후 수동 커밋 누락 시 SW가 기존 캐시 재사용 → stale shell. mitigation 없음. 권장: 스크립트 끝에 `git add` + 사용자 확인 후 commit, 또는 hook으로 검증.
+
+### M9. (생략 — H4와 합쳐 처리됨)
+
+## Low/Info 발견
+
+- **L1 (Python)** `parser.py:128`·`tests/generate_fixtures.py:24` — `parse_md_file(file_path)`·`glob.glob`이 경로 traversal 검증 없음. 위협 모델상 입력 신뢰. 향후 외부 입력 받게 되면 `os.path.abspath` + prefix 체크.
+- **L2 (Python)** `parser.py:108-109` 정규식 — catastrophic backtracking 없음. 안전.
+- **L3 (Python)** `search_indexer.py:34-38` `clean_text` — `\r`, `\t`, U+2028/U+2029 그대로 통과. SPA가 textContent로 렌더하므로 XSS는 아니지만 레이아웃 깨짐 가능. `re.sub(r'\s+', ' ', text)` 권장.
+- **L4 (Python)** 테스트가 ADR-004 Level 1-3 설계 따라 분업 — `test_completeness.py` 1328 하드코딩 + `test_ordering.py` 픽스처 의존 + `test_snapshots.py` 절대값. 거짓 통과 가능성 있으나 의도된 분업이라 설계상 OK.
+- **L5 (Audio)** `lastAccess` 시계 조작 — 본인 디바이스 한정·손해도 본인이라 위협 모델 부합. 무해.
+- **L6 (Audio)** 권한 격리 — 동일 origin, Drive 호스트 우회, path traversal 면역. 안전.
+- **L7 (검색 이력)** 정규화가 trim + 공백 정규화만. 제어문자 통과하나 textContent 렌더라 무해.
+- **L8 (visibility sync 프라이버시)** 비활성 사용자가 다른 탭에 머물다 돌아오면 Drive REST 호출. ADR-011 동의 사용자 한정이라 정책상 OK이나 디버그 로그 PII 마스킹 일관 유지 필요(이미 적용).
+- **L9 (BFF) `proxy_ssl_verify` 누락** — 기본값 off라 upstream 인증서 미검증. `proxy_ssl_verify on; proxy_ssl_trusted_certificate /etc/ssl/certs/ca-certificates.crt;` 권장. (Google CA 침해 시나리오 방어 — 가능성 매우 낮으나 standard hardening)
+- **L10 (BFF) `proxy_hide_header` 미사용** — Google 응답 헤더가 그대로 전달. `Set-Cookie` 등 방어적 hide 권장.
+- **L11 (헤더)** Permissions-Policy 누락 directive — `clipboard-read=()`, `display-capture=()`, `fullscreen=()`, `interest-cohort=()`, `browsing-topics=()` 명시 거부 권장. `clipboard-write`은 명시 안 하거나 `(self)` (앱이 사용).
+- **L12 (의존성)** 외부 스크립트 SRI 누락 — `fonts.googleapis.com/css2`·`googletagmanager.com/gtag/js` 둘 다 dynamic CDN이라 SRI 적용 어려움. CSP sha256 핀이 부분적 방어.
+- **L13 (deploy)** heredoc 변수 보간 (`<<REMOTE` unquoted) — 통제값만 확장되므로 안전. 의도와 일치.
+- **L14 (정적 노출)** `manifest.webmanifest`·`robots.txt`·`sitemap.xml` 모두 공개 의도 콘텐츠만, admin/dev 노출 0건.
+- **L15 (정적 노출)** CSP 견고 — `default-src 'self'`, `object-src 'none'`, script/style sha256 핀, GTM/fonts만 화이트리스트, `worker-src 'self'`·`base-uri 'self'` 포함.
+
+## 1차 감사 대비 변화
+
+| 항목 | 1차 (2026-05-02) | PKCE (2026-05-07) | 2차 (이번) |
+|-----|-----------------|-------------------|-----------|
+| Critical | 0 | 0 | 0 |
+| Medium 처리 | 2건 수정 | 0건 | (백로그 8건 제기) |
+| 인증 흐름 | Implicit + GIS | PKCE 단일 경로 | PKCE + BFF |
+| 신규 표면 | — | refresh-store IDB | nginx BFF, dev/prod 분리, visibility sync |
+| 회귀 | — | 없음 | 없음 |
+
+**OAuth/PKCE/refresh token 영역은 회귀 없음.** BFF 도입으로 client_secret 격리는 강화됐고, Permissions-Policy/COOP 등 브라우저 헤더 추가됐으며, OAuth Client ID 호스트 격리(localhost 제거)로 PKCE 가로채기 표면 닫힘. 새로운 공격 벡터 도입 없음.
+
+## 권장 즉시 처리 (이 감사 산출 PR)
+
+| # | 작업 | 영역 | 예상 PR |
+|---|-----|------|--------|
+| H4 | 디스크 client_secret JSON 두 개 삭제 | 운영 위생 | 즉시 (PR 불필요, 로컬) |
+| M5+M6 | nginx `/oauth/token`에 rate limit + body pollution 가드 + ssl_verify | nginx | 별도 PR (서버 측 변경) |
+| H1 | `sw.js` Content-Length fallback (Blob size) | 코드 | 별도 PR |
+| H2+H3 | 오디오 eviction race + IDB/Cache reconcile | 코드 | 별도 PR (구조 변경 큼) |
+
+Medium 나머지·Low는 백로그 큐.
+
+## 다음 정기 감사 트리거
+
+- CSP 리포트 엔드포인트 도입 후 (백로그 #3, 1.4.6 prod 안정 1주 후 ≈ 2026-05-15)
+- 또는 새로운 인증·외부 통신·서버 측 코드 도입 시

--- a/docs/coding-pitfalls.md
+++ b/docs/coding-pitfalls.md
@@ -264,6 +264,25 @@ OAuth callback이 query string(`?code=...`)으로 오느냐 fragment(`#access_to
 
 ---
 
+## 15. Cache API ↔ IDB sidecar 불일치 + Content-Length 의존
+
+Cache API는 access-time / byte-size 메타데이터를 노출하지 않으므로 LRU·쿼터 추적은 IndexedDB sidecar에 별도 보관하는 패턴이 자연스럽다 (ADR-016). 그러나 두 store가 독립 존재이므로 한쪽만 갱신·소실되면 추적이 영구 어긋난다. 또 Content-Length 헤더에 의존해 byteSize를 기록하면 chunked transfer / gzip / Range 응답에서 0이 들어가 LRU cap이 사실상 무력화된다.
+
+**사례 (2차 보안 감사 — `docs/audit/2026-05-08-second-comprehensive.md` H1·H2·H3):**
+
+- **H1** — `sw.js:139` `byteSize = cl ? Number(cl) : 0`. Content-Length 누락 시 0 기록 → totalSize 합산에서 빠짐 → HARD_CAP 도달 신호 못 받음 → Cache API 무한 누적 → origin-단위 quota 초과 시 DATA_CACHE까지 evict.
+- **H2** — `_putAudioAndEnforceCap`이 두 fetch에서 동시 진행되면 `pickEvictions` 결과가 방금 put된 url을 evict 대상에 포함시켜 재생 중 mp3 삭제.
+- **H3** — `cache.put` 성공 후 `recordEntry` 실패하면 Cache에 mp3는 있고 IDB 메타는 없는 상태로 영구 누적. DevTools에서 한쪽만 비워도 같은 결과.
+
+**규칙:**
+
+- **byteSize는 Content-Length를 우선하되 무효 시 `response.clone().blob().size`로 폴백한다.** 추가 read 1회 비용을 받아들이는 것이 LRU 정확성 손실보다 항상 낫다. clone()은 `cache.put` 전에 (body 소비 전에) 해야 한다.
+- **동시 in-flight URL 추적**: 모듈 레벨 `Set`에 진입 시 add, 종료 시 finally에서 delete. eviction은 이 Set을 filter out — 진행 중 항목이 다른 호출의 cap 정리에 휘말리지 않게.
+- **양 store reconcile**: SW `activate` 핸들러에서 `cache.keys()`와 IDB entries 양방향 비교. (a) Cache에 있고 IDB에 없는 항목 → recordEntry로 채움 (byteSize는 blob.size로). (b) IDB에 있고 Cache에 없는 항목 → orphan removeEntries. 비용은 mismatch 수에 비례하며 healthy 상태에선 microsecond.
+- **회귀 방어**: 단순 throughput 테스트 외에 (i) Content-Length 누락 응답 (ii) 동시 cap 초과 fetch (iii) IDB·Cache 한쪽 비움 시나리오를 명시적으로 다루는 테스트 케이스 필요.
+
+---
+
 ## 부록 A: 변수명 섀도잉
 
 DOM 쿼리 결과에 `el`, `node` 같은 짧은 이름을 쓰면 외부 스코프나 인접 코드의 동명 변수와 컨텍스트가 섞인다.

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -2,6 +2,29 @@
 
 ## 2026-05-08
 
+### 2차 통합 보안 감사 + 오디오 캐시 hardening (PR #67)
+
+`project_security_headers_backlog.md` #4 (2차 보안 감사)를 진행. 1차 감사들이 명시적으로 다루지 않았던 영역(Python 데이터 파이프라인, 오디오 처리, 최근 JS 추가분, 의존성·빌드 파이프라인·정적 호스팅 노출면) 중심으로 sweep. Critical 0건, High 4건, Medium 9건, Low/Info 15건 발견.
+
+**감사 보고서**: `docs/audit/2026-05-08-second-comprehensive.md`.
+
+**즉시 처리 (이 PR):**
+
+- **H1** — `sw.js:139` `byteSize = cl ? Number(cl) : 0`. Content-Length 누락(chunked transfer / gzip / Range) 시 0 기록 → totalSize 합산에서 빠짐 → HARD_CAP 도달 신호 못 받음 → Cache API 무한 누적 → origin-단위 quota 초과 시 DATA_CACHE까지 evict. **수정**: `cache.put` 전에 `response.clone().blob().size` 폴백 (clone은 body 소비 전에 해야 함).
+- **H2** — `_putAudioAndEnforceCap`이 두 fetch에서 동시 진행되면 `pickEvictions` 결과가 방금 put된 url을 evict 대상에 포함시켜 재생 중 mp3 삭제. **수정**: 모듈 레벨 `_inflightAudioUrls` Set + 진입/finally cleanup + eviction 시 filter out.
+- **H3** — `cache.put` 성공 후 `recordEntry` 실패 또는 DevTools에서 한쪽만 비움 → IDB·Cache 영구 어긋남. **수정**: 새 `_reconcileAudioCache` 함수 + `activate` 핸들러에서 호출. (a) Cache에 있고 IDB에 없는 항목 → recordEntry로 채움 (byteSize는 blob.size로). (b) IDB에 있고 Cache에 없는 항목 → orphan removeEntries. 비용은 mismatch 수에 비례, healthy 상태에선 microsecond.
+- **H4** — 작업 트리에 평문 client_secret JSON 두 개 (dev·prod). git history는 clean (`git log --all -p -S 'GOCSPX'` 0 hits) + `.gitignore`로 잡힘 + 배포 zip 미포함. 디스크 삭제 처리. secret 자체는 nginx 설정과 Cloud Console에 살아있어 유실 없음.
+
+**테스트**: 기존 audio-cache 23 + state-machine 26 + transport-pkce 23 + search-history 13 = 85 케이스 모두 통과. sw.js 자체에 대한 유닛 테스트는 미작성 (vm 컨텍스트 + ServiceWorkerGlobalScope 스텁 부담) — 향후 별도 의제.
+
+**배포 영향**: 코드 변경은 sw.js 내부 동작(LRU 정확성·race 가드·reconcile)뿐, 사용자 가시 변화 없음. SW 자체 갱신은 브라우저가 `sw.js` 콘텐츠 변경을 감지해 자동 처리 → 다음 visit 시 새 SW activate + reconcile 1회 실행.
+
+**Medium·Low/Info는 백로그**: requirements.txt 의존성 핀 (M1), split_bible.py 엣지 케이스 (M2), `/oauth/token` rate limiting (M5), BFF body parameter pollution 가드 (M6), deploy zip 정리 (M7), release.py 자동 commit (M8), Permissions-Policy 추가 directive (L11) 등.
+
+**OAuth/PKCE/refresh token 회귀 없음.** BFF + 호스트 격리 + 보안 헤더 통합으로 보안 자세 강화 확인.
+
+**문서**: `docs/coding-pitfalls.md` §15 신규 — Cache API ↔ IDB sidecar 불일치 + Content-Length 의존 함정.
+
 ### README 재구성 — Drive 동기화를 top-level로 분리
 
 기존 `## 플랫폼별 동작 차이` 섹션 안에 Google Drive 동기화가 같이 묶여 있었는데, Phase 2h 단계 4에서 GIS / Implicit Flow / FedCM이 제거되며 동기화가 데스크탑·Android·iOS 동일 코드 경로로 통일됐다 — 더 이상 "플랫폼별 차이"의 사례가 아님. 섹션 분리:

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -15,7 +15,7 @@
 - **H3** — `cache.put` 성공 후 `recordEntry` 실패 또는 DevTools에서 한쪽만 비움 → IDB·Cache 영구 어긋남. **수정**: 새 `_reconcileAudioCache` 함수 + `activate` 핸들러에서 호출. (a) Cache에 있고 IDB에 없는 항목 → recordEntry로 채움 (byteSize는 blob.size로). (b) IDB에 있고 Cache에 없는 항목 → orphan removeEntries. 비용은 mismatch 수에 비례, healthy 상태에선 microsecond.
 - **H4** — 작업 트리에 평문 client_secret JSON 두 개 (dev·prod). git history는 clean (`git log --all -p -S 'GOCSPX'` 0 hits) + `.gitignore`로 잡힘 + 배포 zip 미포함. 디스크 삭제 처리. secret 자체는 nginx 설정과 Cloud Console에 살아있어 유실 없음.
 
-**테스트**: 기존 audio-cache 23 + state-machine 26 + transport-pkce 23 + search-history 13 = 85 케이스 모두 통과. sw.js 자체에 대한 유닛 테스트는 미작성 (vm 컨텍스트 + ServiceWorkerGlobalScope 스텁 부담) — 향후 별도 의제.
+**테스트**: 기존 유닛 테스트 98 케이스 모두 통과 (audio-cache 14 + refresh-store 13 + search-history 19 + state-machine 29 + transport-pkce 23). sw.js 자체에 대한 유닛 테스트는 미작성 (vm 컨텍스트 + ServiceWorkerGlobalScope 스텁 부담) — 향후 별도 의제.
 
 **배포 영향**: 코드 변경은 sw.js 내부 동작(LRU 정확성·race 가드·reconcile)뿐, 사용자 가시 변화 없음. SW 자체 갱신은 브라우저가 `sw.js` 콘텐츠 변경을 감지해 자동 처리 → 다음 visit 시 새 SW activate + reconcile 1회 실행.
 

--- a/sw.js
+++ b/sw.js
@@ -98,13 +98,20 @@ self.addEventListener("message", (event) => {
 // the AUDIO_CACHE sidecar (IDB metadata) with Cache API contents so stale
 // state from prior incomplete writes or DevTools-cleared storage doesn't
 // drift the LRU bookkeeping.
+//
+// clients.claim() is awaited INSIDE waitUntil after reconcile, not outside.
+// If we claimed early, fetch events from claimed clients could arrive while
+// reconcile is mid-flight: a concurrent _putAudioAndEnforceCap recordEntry()
+// could add an IDB row whose URL was orphan in reconcile's snapshot — step
+// (b)'s removeEntries would then delete the freshly added row, recreating
+// the drift we are trying to fix (Bugbot PR #67).
 self.addEventListener("activate", (event) => {
   event.waitUntil((async () => {
     const keys = await caches.keys();
     await Promise.all(keys.filter((k) => !KNOWN_CACHES.has(k)).map((k) => caches.delete(k)));
     await _reconcileAudioCache().catch(() => { /* best-effort */ });
+    await self.clients.claim();
   })());
-  self.clients.claim();
 });
 
 // Cache-first for Google Font files: immutable, content-addressed URLs.

--- a/sw.js
+++ b/sw.js
@@ -94,13 +94,16 @@ self.addEventListener("message", (event) => {
   }
 });
 
-// Remove caches that are not in the active set on activate.
+// Remove caches that are not in the active set on activate, then reconcile
+// the AUDIO_CACHE sidecar (IDB metadata) with Cache API contents so stale
+// state from prior incomplete writes or DevTools-cleared storage doesn't
+// drift the LRU bookkeeping.
 self.addEventListener("activate", (event) => {
-  event.waitUntil(
-    caches.keys().then((keys) =>
-      Promise.all(keys.filter((k) => !KNOWN_CACHES.has(k)).map((k) => caches.delete(k)))
-    )
-  );
+  event.waitUntil((async () => {
+    const keys = await caches.keys();
+    await Promise.all(keys.filter((k) => !KNOWN_CACHES.has(k)).map((k) => caches.delete(k)));
+    await _reconcileAudioCache().catch(() => { /* best-effort */ });
+  })());
   self.clients.claim();
 });
 
@@ -126,24 +129,91 @@ function handleFontFile(event) {
 // Cache invalidation is handled by bumping the relevant cache name on release.
 const DRIVE_HOSTNAMES = ["www.googleapis.com", "content.googleapis.com", "oauth2.googleapis.com", "accounts.google.com"];
 
+// URLs currently being put + cap-enforced. Two concurrent fetches without this
+// guard could pick overlapping eviction sets and delete each other's just-put
+// mp3 before playback starts. Eviction filters this set out.
+const _inflightAudioUrls = new Set();
+
 // Audio path: store in AUDIO_CACHE, record sidecar metadata, enforce hard cap.
 // Runs inside event.waitUntil so the response is delivered immediately and the
 // bookkeeping completes in background. Errors are swallowed — caching is
 // best-effort and must never break playback. (See ADR-016.)
 async function _putAudioAndEnforceCap(request, response) {
-  const cache = await caches.open(AUDIO_CACHE);
-  await cache.put(request, response);
+  _inflightAudioUrls.add(request.url);
+  try {
+    const ac = self.bibleAudioCache;
+
+    // Compute byteSize BEFORE cache.put consumes the response body. Prefer
+    // Content-Length (cheap, no body read), fall back to clone().blob().size
+    // when missing/invalid (chunked transfer / gzip / Range / proxy stripped
+    // it). Without this fallback the LRU sidecar records 0 bytes and the
+    // entry escapes cap accounting forever — quota exhaustion follow.
+    let byteSize = 0;
+    if (ac) {
+      const cl = response.headers.get("content-length");
+      byteSize = cl ? Number(cl) : 0;
+      if (!Number.isFinite(byteSize) || byteSize <= 0) {
+        try {
+          const blob = await response.clone().blob();
+          byteSize = blob.size;
+        } catch { byteSize = 0; }
+      }
+    }
+
+    const cache = await caches.open(AUDIO_CACHE);
+    await cache.put(request, response);
+
+    if (!ac) return;
+    await ac.recordEntry(request.url, byteSize);
+    const total = await ac.totalSize();
+    if (total <= ac.HARD_CAP) return;
+    const { urls } = await ac.pickEvictions(ac.SOFT_CAP);
+    // Filter out URLs currently being put — these are mid-fetch, deleting
+    // them would race the put and break playback. They'll be re-evaluated
+    // after their own _putAudioAndEnforceCap call returns.
+    const evictable = urls.filter((u) => !_inflightAudioUrls.has(u));
+    if (!evictable.length) return;
+    await Promise.all(evictable.map((u) => cache.delete(u)));
+    await ac.removeEntries(evictable);
+  } finally {
+    _inflightAudioUrls.delete(request.url);
+  }
+}
+
+// Reconcile AUDIO_CACHE sidecar (IDB metadata) with Cache API contents.
+// Called on SW activate. Two drift scenarios this fixes:
+//   (a) cache.put succeeded but recordEntry failed in a prior session
+//       → mp3 in Cache, no IDB row → escapes LRU forever. Recover by
+//          recording the entry with byteSize from the cached blob.
+//   (b) DevTools or browser settings cleared one side → IDB rows for mp3s
+//       no longer in Cache → repeated fetches think the file is cached.
+//       Remove orphan IDB rows.
+// Cost is bounded by number of mismatches, not full cache size — typical
+// healthy state finishes in microseconds.
+async function _reconcileAudioCache() {
   const ac = self.bibleAudioCache;
   if (!ac) return;
-  const cl = response.headers.get("content-length");
-  const byteSize = cl ? Number(cl) : 0;
-  await ac.recordEntry(request.url, byteSize);
-  const total = await ac.totalSize();
-  if (total <= ac.HARD_CAP) return;
-  const { urls } = await ac.pickEvictions(ac.SOFT_CAP);
-  if (!urls.length) return;
-  await Promise.all(urls.map((u) => cache.delete(u)));
-  await ac.removeEntries(urls);
+  let cache;
+  try { cache = await caches.open(AUDIO_CACHE); } catch { return; }
+  const requests = await cache.keys();
+  const cacheUrls = new Set(requests.map((r) => r.url));
+  const idbEntries = await ac._listAll();
+  const idbUrls = new Set(idbEntries.map((e) => e.url));
+
+  // (a) Cache entries without IDB metadata → record them.
+  for (const req of requests) {
+    if (idbUrls.has(req.url)) continue;
+    try {
+      const res = await cache.match(req);
+      if (!res) continue;
+      const blob = await res.clone().blob();
+      await ac.recordEntry(req.url, blob.size);
+    } catch { /* skip individual failures, keep reconciling */ }
+  }
+
+  // (b) IDB rows without Cache entries → remove the orphans.
+  const orphans = idbEntries.filter((e) => !cacheUrls.has(e.url)).map((e) => e.url);
+  if (orphans.length) await ac.removeEntries(orphans);
 }
 
 self.addEventListener("fetch", (event) => {


### PR DESCRIPTION
## Summary

2차 통합 보안 감사 ([docs/audit/2026-05-08-second-comprehensive.md](docs/audit/2026-05-08-second-comprehensive.md))에서 발견한 High 4건 수정 + 보고서 commit. Critical 0, Medium 9, Low/Info 15는 백로그.

**이번 PR이 다루는 4건:**

| # | 이슈 | 위치 | 수정 |
|---|------|-----|-----|
| H1 | Content-Length 누락 시 byteSize=0 → quota 폭발 | [sw.js:139](sw.js#L139) | clone().blob().size 폴백 |
| H2 | 동시 fetch eviction race로 방금 put된 mp3 삭제 | [sw.js:133](sw.js#L133) | `_inflightAudioUrls` Set 가드 |
| H3 | IDB ↔ Cache API 양방향 drift | sw.js activate | `_reconcileAudioCache` 추가 |
| H4 | 작업 트리에 평문 client_secret JSON | 로컬 디스크 | 삭제 (git history clean) |

**Bugbot 추가 발견 (수정 완료):** `clients.claim()`이 `event.waitUntil` 밖 동기 실행 → activate 직후 claim된 클라이언트의 fetch가 reconcile 진행 중 도착 → step (b)의 orphan 삭제가 reconcile 시작 시점 snapshot 기반이라 그동안 동시 record된 IDB row가 잘못 삭제. claim을 waitUntil 안 reconcile 뒤로 이동해 race window 닫음.

**감사 영역**: Python 파이프라인 / 오디오 처리 / 검색 이력·visibility sync·BFF·헤더 / 의존성·빌드·노출면. 4개 영역 병렬 sweep. OAuth/PKCE/refresh token 영역은 회귀 없음 확인.

## 배포 영향

코드 변경은 sw.js 내부 동작(LRU 정확성·race 가드·reconcile)뿐, **사용자 가시 변화 없음**. SW 자체 갱신은 브라우저가 sw.js 콘텐츠 변경 감지해 자동 처리 → 다음 visit 시 새 SW activate + reconcile 1회 실행.

버전 bump 안 함 — 이번 변경은 사용자 가시 기능이나 콘텐츠 변경 없음. 다음 사이클에서 다른 백로그(Permissions-Policy 추가 directive·release.py 자동 commit 등)와 묶어 1.4.7로 가는 게 효율적이라 판단.

## 백로그 (Medium·Low/Info, 다음 사이클 후보)

- M1: requirements.txt 의존성 핀
- M2: split_bible.py:67 빈 텍스트 IndexError
- M3: 오디오 캐시 무결성 검증 부재
- M4: bible-audio-pos NaN/Infinity 검증
- M5: /oauth/token rate limiting 부재
- M6: BFF body parameter pollution 가드
- M7: deploy zip 누적 정리
- M8: release.py 자동 commit·tag
- L11: Permissions-Policy 추가 directive (clipboard-read, fullscreen 등)
- 기타 — 보고서 참조

## Test plan
- [x] `node --test tests/unit/*.test.js` — 98/98 통과 (audio-cache 14 + refresh-store 13 + search-history 19 + state-machine 29 + transport-pkce 23)
- [ ] dev 배포 후 오디오 재생·캐싱·LRU 동작 시운전 (대용량 mp3 여러 개 다운로드 → cap 도달 → eviction)
- [ ] dev 배포 후 SW activate 시 reconcile이 0 errors로 통과하는지 콘솔 확인
- [ ] (선택) DevTools에서 `caches.delete('audio-1')` 또는 IDB clear → 페이지 새로고침 → SW activate → reconcile이 양쪽 정합성 회복하는지

🤖 Generated with [Claude Code](https://claude.com/claude-code)