### PR TITLE
feat: 모바일 pull-to-refresh로 북마크 동기화

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -953,6 +953,51 @@ body {
   bottom: max(calc(5rem + env(safe-area-inset-bottom)), var(--fab-lift-nav, 0px));
 }
 
+/* ── Pull-to-refresh indicator (mobile) ── */
+#pull-refresh-indicator {
+  position: fixed;
+  top: env(safe-area-inset-top, 0);
+  left: 50%;
+  transform: translateX(-50%) translateY(0);
+  width: 2.4rem;
+  height: 2.4rem;
+  margin-top: 0.5rem;
+  border-radius: 50%;
+  background: var(--bg-card);
+  color: var(--accent);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  pointer-events: none;
+  z-index: 25;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.18);
+  will-change: transform, opacity;
+}
+
+#pull-refresh-indicator .ptr-icon {
+  transition: transform 0.1s linear;
+}
+
+#pull-refresh-indicator.ptr-loading .ptr-icon {
+  animation: ptr-spin 0.9s linear infinite;
+  transform: none !important;
+}
+
+@keyframes ptr-spin {
+  to { transform: rotate(360deg); }
+}
+
+@media (min-width: 769px) {
+  #pull-refresh-indicator { display: none; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  #pull-refresh-indicator,
+  #pull-refresh-indicator .ptr-icon { transition: none; }
+  #pull-refresh-indicator.ptr-loading .ptr-icon { animation: none; }
+}
+
 /* ── Install guide modal ── */
 #install-scrim {
   display: none;

--- a/js/app.js
+++ b/js/app.js
@@ -241,6 +241,149 @@ document.addEventListener("visibilitychange", () => {
   }
 });
 
+// ── Pull-to-refresh (mobile, page-level) ─────────────────────────────────────
+// Drag-down gesture at the top of the page triggers Drive bookmark sync, the
+// same operation visibilitychange→visible runs. The touchmove listener is
+// non-passive (we preventDefault to suppress the rubber-band overscroll), so
+// it is attached only for the duration of an active pull to keep the global
+// scrolling fast path passive everywhere else.
+(function setupPullToRefresh() {
+  const PULL_THRESHOLD_PX  = 70;   // distance past which release triggers sync
+  const PULL_MAX_PX        = 110;  // visual cap on indicator drop
+  const PULL_RESISTANCE    = 0.5;  // 1px finger movement → 0.5px indicator drop
+  const SYNC_FEEDBACK_MS   = 900;  // how long the spinner stays after trigger
+  // Modal/sheet roots whose internal scroll must not be hijacked by PTR. We
+  // walk e.target to see if the touch landed inside one of these.
+  const MODAL_SELECTORS = "#bookmark-drawer, #search-sheet, #install-modal, #bm-save-modal, #bm-new-folder-modal, #bm-import-modal, #bm-merge-modal, #drive-disconnect-modal, .settings-popover, .chapter-popover, .bc-division-popover, .title-division-popover";
+
+  /** @type {HTMLElement | null} */
+  let indicator = null;
+  let startY = 0;
+  let delta = 0;
+  let active = false;
+  let syncing = false;
+
+  function ensureIndicator() {
+    if (indicator) return indicator;
+    indicator = document.createElement("div");
+    indicator.id = "pull-refresh-indicator";
+    indicator.setAttribute("aria-hidden", "true");
+    indicator.innerHTML =
+      '<svg class="ptr-icon" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' +
+      '<path d="M21 12a9 9 0 1 1-3.3-7"/><polyline points="21 4 21 12 13 12"/>' +
+      '</svg>';
+    document.body.appendChild(indicator);
+    return indicator;
+  }
+
+  function setVisual(d) {
+    const ind = ensureIndicator();
+    const dropped = Math.min(d, PULL_MAX_PX);
+    const progress = Math.min(d / PULL_THRESHOLD_PX, 1);
+    ind.style.transform = `translateX(-50%) translateY(${dropped}px)`;
+    ind.style.opacity = String(progress);
+    const rot = progress * 270;
+    const icon = ind.querySelector(".ptr-icon");
+    if (icon) /** @type {SVGElement} */ (icon).style.transform = `rotate(${rot}deg)`;
+  }
+
+  function resetVisual(animated) {
+    const ind = ensureIndicator();
+    ind.style.transition = animated ? "transform .25s ease, opacity .2s ease" : "";
+    ind.style.transform = "translateX(-50%) translateY(0)";
+    ind.style.opacity = "0";
+    if (animated) {
+      setTimeout(() => {
+        ind.style.transition = "";
+        ind.classList.remove("ptr-loading");
+      }, 260);
+    } else {
+      ind.classList.remove("ptr-loading");
+    }
+  }
+
+  function eligibleAt(target) {
+    if (syncing) return false;
+    if (!window.matchMedia("(max-width: 768px)").matches) return false;
+    if (window.scrollY > 0) return false;
+    if (target instanceof Element && target.closest(MODAL_SELECTORS)) return false;
+    return true;
+  }
+
+  function onMove(e) {
+    if (!active || e.touches.length !== 1) return;
+    const raw = e.touches[0].clientY - startY;
+    if (raw <= 0) {
+      // User reversed direction — let normal scroll resume.
+      active = false;
+      delta = 0;
+      detachMoveEnd();
+      resetVisual(true);
+      return;
+    }
+    delta = raw * PULL_RESISTANCE;
+    setVisual(delta);
+    if (e.cancelable) e.preventDefault();
+  }
+
+  function onEnd() {
+    if (!active) return;
+    const triggered = delta >= PULL_THRESHOLD_PX;
+    active = false;
+    detachMoveEnd();
+    if (triggered) trigger(); else resetVisual(true);
+  }
+
+  function onCancel() {
+    if (!active) return;
+    active = false;
+    detachMoveEnd();
+    resetVisual(true);
+  }
+
+  function attachMoveEnd() {
+    document.addEventListener("touchmove", onMove, { passive: false });
+    document.addEventListener("touchend", onEnd, { passive: true });
+    document.addEventListener("touchcancel", onCancel, { passive: true });
+  }
+
+  function detachMoveEnd() {
+    document.removeEventListener("touchmove", onMove, /** @type {any} */ ({ passive: false }));
+    document.removeEventListener("touchend", onEnd);
+    document.removeEventListener("touchcancel", onCancel);
+  }
+
+  function trigger() {
+    syncing = true;
+    const ind = ensureIndicator();
+    ind.classList.add("ptr-loading");
+    ind.style.transition = "transform .2s ease";
+    ind.style.transform = `translateX(-50%) translateY(${PULL_THRESHOLD_PX}px)`;
+    ind.style.opacity = "1";
+    const sync = window.driveSync;
+    if (sync?.isAuthenticated?.()) {
+      sync.requestSync();
+    } else if (sync?.isEnabled?.()) {
+      window._showSyncSnackbar?.("Google Drive 재연결이 필요합니다.");
+    } else {
+      window._showSyncSnackbar?.("Google Drive 동기화가 꺼져 있습니다.");
+    }
+    setTimeout(() => {
+      syncing = false;
+      resetVisual(true);
+    }, SYNC_FEEDBACK_MS);
+  }
+
+  document.addEventListener("touchstart", (e) => {
+    if (e.touches.length !== 1) return;
+    if (!eligibleAt(e.target)) return;
+    active = true;
+    delta = 0;
+    startY = e.touches[0].clientY;
+    attachMoveEnd();
+  }, { passive: true });
+})();
+
 // ── BEGIN SEARCH HISTORY HELPERS ──
 // Local-only (not Drive-synced — see ADR-014). Whitespace-normalized strings,
 // LRU-deduped, capped at SEARCH_HISTORY_MAX. The block between the BEGIN/END

--- a/js/app.js
+++ b/js/app.js
@@ -263,6 +263,13 @@ document.addEventListener("visibilitychange", () => {
   let active = false;
   let syncing = false;
 
+  // Inline styles always beat non-`!important` CSS, so the
+  // `@media (prefers-reduced-motion: reduce)` block in style.css cannot
+  // override `style.transition = "transform .25s ease, …"` we set below.
+  // Gate the transition strings here in JS to honor the user preference.
+  const _reducedMotionMQL = window.matchMedia("(prefers-reduced-motion: reduce)");
+  function prefersReducedMotion() { return _reducedMotionMQL.matches; }
+
   function ensureIndicator() {
     if (indicator) return indicator;
     indicator = document.createElement("div");
@@ -289,12 +296,13 @@ document.addEventListener("visibilitychange", () => {
 
   function resetVisual(animated) {
     const ind = ensureIndicator();
-    ind.style.transition = animated ? "transform .25s ease, opacity .2s ease" : "";
+    const smooth = animated && !prefersReducedMotion();
+    ind.style.transition = smooth ? "transform .25s ease, opacity .2s ease" : "none";
     ind.style.transform = "translateX(-50%) translateY(0)";
     ind.style.opacity = "0";
-    if (animated) {
+    if (smooth) {
       setTimeout(() => {
-        ind.style.transition = "";
+        ind.style.transition = "none";
         ind.classList.remove("ptr-loading");
       }, 260);
     } else {
@@ -357,7 +365,7 @@ document.addEventListener("visibilitychange", () => {
     syncing = true;
     const ind = ensureIndicator();
     ind.classList.add("ptr-loading");
-    ind.style.transition = "transform .2s ease";
+    ind.style.transition = prefersReducedMotion() ? "none" : "transform .2s ease";
     ind.style.transform = `translateX(-50%) translateY(${PULL_THRESHOLD_PX}px)`;
     ind.style.opacity = "1";
     const sync = window.driveSync;

--- a/js/app.js
+++ b/js/app.js
@@ -262,6 +262,8 @@ document.addEventListener("visibilitychange", () => {
   let delta = 0;
   let active = false;
   let syncing = false;
+  /** @type {ReturnType<typeof setTimeout> | null} */
+  let resetCleanupTimer = null;
 
   // Inline styles always beat non-`!important` CSS, so the
   // `@media (prefers-reduced-motion: reduce)` block in style.css cannot
@@ -287,6 +289,10 @@ document.addEventListener("visibilitychange", () => {
     const ind = ensureIndicator();
     const dropped = Math.min(d, PULL_MAX_PX);
     const progress = Math.min(d / PULL_THRESHOLD_PX, 1);
+    // Force transition off during finger drag so motion tracks 1:1. Without
+    // this, a lingering ease curve from a previous resetVisual would make the
+    // indicator slide rather than follow the finger.
+    ind.style.transition = "none";
     ind.style.transform = `translateX(-50%) translateY(${dropped}px)`;
     ind.style.opacity = String(progress);
     const rot = progress * 270;
@@ -296,12 +302,20 @@ document.addEventListener("visibilitychange", () => {
 
   function resetVisual(animated) {
     const ind = ensureIndicator();
+    // Cancel any pending cleanup from a previous reset so a fast second pull
+    // doesn't have its `ptr-loading` class stripped (or its transition string
+    // overwritten) by a stale timer.
+    if (resetCleanupTimer !== null) {
+      clearTimeout(resetCleanupTimer);
+      resetCleanupTimer = null;
+    }
     const smooth = animated && !prefersReducedMotion();
     ind.style.transition = smooth ? "transform .25s ease, opacity .2s ease" : "none";
     ind.style.transform = "translateX(-50%) translateY(0)";
     ind.style.opacity = "0";
     if (smooth) {
-      setTimeout(() => {
+      resetCleanupTimer = setTimeout(() => {
+        resetCleanupTimer = null;
         ind.style.transition = "none";
         ind.classList.remove("ptr-loading");
       }, 260);
@@ -364,6 +378,12 @@ document.addEventListener("visibilitychange", () => {
   function trigger() {
     syncing = true;
     const ind = ensureIndicator();
+    // Cancel any pending resetVisual cleanup so it doesn't fire mid-spinner
+    // and strip the `ptr-loading` class we just added.
+    if (resetCleanupTimer !== null) {
+      clearTimeout(resetCleanupTimer);
+      resetCleanupTimer = null;
+    }
     ind.classList.add("ptr-loading");
     ind.style.transition = prefersReducedMotion() ? "none" : "transform .2s ease";
     ind.style.transform = `translateX(-50%) translateY(${PULL_THRESHOLD_PX}px)`;


### PR DESCRIPTION
## Summary
- 모바일(<769px)에서 페이지 최상단을 아래로 당겼다 놓으면 `window.driveSync.requestSync()`를 호출 — 기존 visibility→visible 동기화와 동일한 동작이지만 사용자가 즉시 가져오고 싶을 때 의도적으로 트리거할 수 있다.
- 표준 PtR UX: 임계값 70px, 저항계수 0.5, 회전하는 새로 고침 아이콘 + 트리거 후 스피너. 인증 상태별 스낵바 안내 (꺼짐/재연결 필요/즉시 sync).
- 성능: `touchmove`(non-passive, `preventDefault`로 rubber-band 억제)는 풀 시작 시점에만 부착하고 종료 시 제거 → 평상시 스크롤은 passive 그대로.
- 안전 가드: 모달/시트(북마크 드로어, 검색 시트, 설치/저장 모달, popover 등) 내부에서 시작된 터치, `scrollY > 0`, 데스크탑 뷰포트는 모두 통과시킴.
- `prefers-reduced-motion` 존중.

## Test plan
- [ ] 모바일 뷰포트(≤768px)에서 본문 최상단을 끌어내리면 인디케이터가 따라오고, 임계값 이상에서 손을 떼면 스피너 → 동기화 트리거
- [ ] Drive 미연결 상태에서 풀하면 안내 스낵바만 뜨고 sync는 호출되지 않음
- [ ] 본문 중간(스크롤 위치 > 0)에서는 트리거되지 않고 정상 스크롤
- [ ] 북마크 드로어/검색 시트/설치 모달 안에서의 터치는 PtR을 발동하지 않음
- [ ] 데스크탑(≥769px)에서는 인디케이터가 표시되지 않고 동작도 없음
- [ ] `node --test tests/unit/*.test.js` 모두 통과 (98/98 확인됨)
- [ ] `npx tsc -p tsconfig.json --noEmit` 0 error


---
_Generated by [Claude Code](https://claude.ai/code/session_01NHqih7bkdE65srEvmFZuCg)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds global touch-gesture handling and non-passive `touchmove` listeners on mobile, which can impact scroll/gesture behavior if the eligibility checks or listener cleanup misbehave.
> 
> **Overview**
> Adds a **mobile-only pull-to-refresh gesture** at the top of the page that triggers the existing Google Drive bookmark sync (`window.driveSync.requestSync()`) and shows an in-page refresh indicator.
> 
> Implements a fixed `#pull-refresh-indicator` (with spinner/rotation, reduced-motion support, and desktop hide rules) and a JS gesture controller that only activates when at `scrollY==0`, outside modals/sheets, and temporarily attaches a non-passive `touchmove` handler to suppress rubber-band overscroll while pulling; unauthenticated/disabled sync states now surface snackbar guidance during the gesture.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d494fcbe01a0ce8f50b335e285aaddf35646be82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->