### PR TITLE
fix: 북마크 시트 행 높이 정렬 + 모바일 드래그-재정렬 복원

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2941,6 +2941,9 @@ body.verse-select-active .verse.verse-poetry[data-vref] {
   align-items: center;
   padding: 0.3rem 0.75rem;
   gap: 0.4rem;
+  /* Match folder rows to bookmark rows (label 0.88rem + ref 0.72rem,
+     line-height 1.8, gap 0.1rem, padding 0.6rem). */
+  min-height: 3.58rem;
   transition: background 0.1s;
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -3617,7 +3617,12 @@ body.verse-select-active .verse.verse-poetry[data-vref] {
 .bm-folder-row,
 .bm-bookmark-row {
   cursor: grab;
-  touch-action: none;
+  /* pan-y lets the drawer body scroll vertically while JS owns horizontal
+     swipe + long-press-to-drag. Once long-press fires we setPointerCapture,
+     which preempts any subsequent browser scroll for that pointer. */
+  touch-action: pan-y;
+  -webkit-user-select: none;
+  user-select: none;
 }
 
 .bm-folder-row:active,
@@ -3630,7 +3635,11 @@ body.verse-select-active .verse.verse-poetry[data-vref] {
 .bm-bookmark-row button,
 .bm-bookmark-row a {
   cursor: pointer;
-  touch-action: auto;
+  touch-action: pan-y;
+  /* Suppress iOS Safari's native long-press link preview / link drag so the
+     app's long-press-to-drag gesture wins. */
+  -webkit-touch-callout: none;
+  -webkit-user-drag: none;
 }
 
 .bm-folder.bm-dragging > .bm-folder-row,

--- a/js/app.js
+++ b/js/app.js
@@ -1444,26 +1444,43 @@ function _setupDragHandle(li, row) {
     const startX = e.clientX;
     const startY = e.clientY;
     const origRect = li.getBoundingClientRect();
-    const isMobile = _isMobileViewport();
+    const isTouch = e.pointerType !== "mouse";
     const swipeActions = row.querySelector(".bm-row-actions-mobile");
-    const canSwipe = isMobile && !!swipeActions;
+    const canSwipe = _isMobileViewport() && isTouch && !!swipeActions;
     // null until the first significant move classifies the gesture.
-    // "drag" → reorder, "swipe" → reveal actions, "longpress" → reveal via hold
+    // "drag" → reorder, "swipe" → reveal actions, "abort" → cede to browser scroll
     let mode = null;
     let dragStarted = false;
     const startedSwiped = canSwipe && row.classList.contains("bm-swiped");
     const baseOffset = startedSwiped ? -SWIPE_REVEAL_PX : 0;
     let longPressTimer = null;
 
-    if (canSwipe && !startedSwiped) {
+    // Touch devices: long-press without movement enters drag-to-reorder mode
+    // (haptic feedback acts as the visual cue). Action panel reveal is
+    // horizontal-swipe only. Mouse users start dragging immediately on move.
+    if (isTouch && !startedSwiped) {
       longPressTimer = setTimeout(() => {
         if (mode !== null) return;
-        mode = "longpress";
-        _openSwipedRow(row);
+        mode = "drag";
+        _beginDrag();
         if (navigator.vibrate) {
           try { navigator.vibrate(10); } catch {}
         }
       }, LONG_PRESS_MS);
+    }
+
+    function _beginDrag() {
+      dragStarted = true;
+      const ghost = document.createElement("li");
+      ghost.className = "bm-drag-ghost";
+      ghost.style.width = origRect.width + "px";
+      ghost.style.left = origRect.left + "px";
+      const rowClone = (li.querySelector(".bm-folder-row, .bm-bookmark-row") || li.firstElementChild).cloneNode(true);
+      ghost.appendChild(rowClone);
+      document.body.appendChild(ghost);
+      try { row.setPointerCapture(pointerId); } catch {}
+      li.classList.add("bm-dragging");
+      _dragState = { id: li.dataset.id, ghost, origLi: li, startY, origTop: origRect.top };
     }
 
     const clearLongPress = () => {
@@ -1491,13 +1508,21 @@ function _setupDragHandle(li, row) {
       if (mode === null) {
         if (Math.hypot(dx, dy) < 5) return;
         clearLongPress();
-        // Horizontal-dominant gesture on mobile → swipe; otherwise → drag-to-reorder.
         if (canSwipe && Math.abs(dx) > Math.abs(dy)) {
+          // Horizontal-dominant gesture on touch → swipe-reveal action panel.
           mode = "swipe";
           row.classList.add("bm-swiping");
           row.setPointerCapture(pointerId);
+        } else if (isTouch) {
+          // Touch + vertical movement before long-press fired → user is
+          // scrolling the drawer body, not dragging. Cede to the browser.
+          mode = "abort";
+          cleanupPointerHandlers();
+          return;
         } else {
+          // Mouse user → immediate drag-to-reorder on any movement.
           mode = "drag";
+          _beginDrag();
         }
       }
 
@@ -1514,25 +1539,7 @@ function _setupDragHandle(li, row) {
         return;
       }
 
-      if (mode === "longpress") {
-        // After long-press reveal, ignore further movement until pointerup.
-        return;
-      }
-
       // mode === "drag"
-      if (!dragStarted) {
-        dragStarted = true;
-        const ghost = document.createElement("li");
-        ghost.className = "bm-drag-ghost";
-        ghost.style.width = origRect.width + "px";
-        ghost.style.left = origRect.left + "px";
-        const rowClone = (li.querySelector(".bm-folder-row, .bm-bookmark-row") || li.firstElementChild).cloneNode(true);
-        ghost.appendChild(rowClone);
-        document.body.appendChild(ghost);
-        row.setPointerCapture(pointerId);
-        li.classList.add("bm-dragging");
-        _dragState = { id: li.dataset.id, ghost, origLi: li, startY, origTop: origRect.top };
-      }
       if (!_dragState) return;
       _dragState.ghost.style.top = (_dragState.origTop + (e.clientY - _dragState.startY)) + "px";
       _updateDragIndicators(e.clientX, e.clientY);
@@ -1555,11 +1562,11 @@ function _setupDragHandle(li, row) {
         return;
       }
 
-      if (mode === "longpress") {
-        // Suppress the click that the browser fires after pointerup so it doesn't
-        // immediately re-close the just-revealed action row.
+      if (dragStarted) {
+        // Suppress the synthetic click that follows pointerup so the bookmark
+        // link doesn't navigate / the folder doesn't toggle when the user
+        // releases a drag.
         document.addEventListener("click", (ce) => { ce.stopPropagation(); ce.preventDefault(); }, { capture: true, once: true });
-        return;
       }
 
       if (!_dragState) return;

--- a/tests/e2e/test_bookmark_swipe.py
+++ b/tests/e2e/test_bookmark_swipe.py
@@ -119,21 +119,28 @@ def test_swipe_other_row_closes_previous(browser):
         ctx.close()
 
 
-def test_longpress_reveals_mobile_actions(browser):
-    """500ms 이상 롱프레스하면 스와이프와 동일하게 액션 패널이 열린다."""
+def test_longpress_starts_drag(browser):
+    """500ms 이상 롱프레스하면 드래그-재정렬 모드가 시작된다 (액션 패널이 아님)."""
     ctx = browser.new_context(viewport=MOBILE_VIEWPORT, user_agent=IPHONE_UA)
     ctx.add_init_script(CLEAR_APP_STORAGE)
     page = ctx.new_page()
     try:
         _open_drawer(page, [_BM_A])
-        _longpress(page, idx=0, ms=600)
-        page.wait_for_selector(_SWIPED_SEL, timeout=2_000)
+        page.evaluate(_LONGPRESS_DOWN_JS, 0)
+        page.wait_for_timeout(600)
+        # bm-dragging class on the li indicates drag mode entered.
+        page.wait_for_selector("li.bm-bookmark.bm-dragging", timeout=2_000)
+        # Drag ghost element should exist on body.
+        assert page.locator(".bm-drag-ghost").count() > 0
+        # Action panel must NOT be revealed by long-press anymore.
+        assert page.locator(_SWIPED_SEL).count() == 0
+        page.evaluate(_LONGPRESS_UP_JS)
     finally:
         ctx.close()
 
 
-def test_short_press_does_not_reveal_actions(browser):
-    """짧은 press(<500ms)는 롱프레스를 트리거하지 않는다."""
+def test_short_press_does_not_start_drag(browser):
+    """짧은 press(<500ms)는 드래그를 시작하지 않고 액션 패널도 열리지 않는다."""
     ctx = browser.new_context(viewport=MOBILE_VIEWPORT, user_agent=IPHONE_UA)
     ctx.add_init_script(CLEAR_APP_STORAGE)
     page = ctx.new_page()
@@ -142,6 +149,7 @@ def test_short_press_does_not_reveal_actions(browser):
         _longpress(page, idx=0, ms=200)
         page.wait_for_timeout(200)
         assert page.locator(_SWIPED_SEL).count() == 0
+        assert page.locator("li.bm-bookmark.bm-dragging").count() == 0
     finally:
         ctx.close()
 


### PR DESCRIPTION
## Summary

북마크 시트의 시각적 정렬과 모바일 제스처를 함께 정리.

### 1. 행 높이 정렬
- 폴더 행은 폴더명 한 줄, 북마크 행은 라벨 + 참조 두 줄이라 높이가 어긋나 모바일 스와이프 시 액션 패널 높이도 행마다 달라 보였다.
- `.bm-folder-row, .bm-bookmark-row`에 `min-height: 3.58rem`을 추가해 북마크 행의 자연 높이(label 0.88rem + ref 0.72rem, line-height 1.8, gap 0.1rem, padding 0.6rem)에 맞춤. 기준은 북마크 행이므로 북마크 행 자체는 그대로 유지되고 폴더 행만 같은 높이로 늘어남.

### 2. 모바일 드래그-재정렬 복원
iOS Safari가 `<a class="bm-bookmark-link">`에 대해 네이티브 롱프레스 컨텍스트 메뉴 / 링크 드래그를 먼저 발동시켜, 사용자가 북마크를 들어 폴더로 옮기거나 순서를 바꾸려는 의도가 가로채였다. 게다가 앱 자체의 롱프레스도 "수정/삭제 패널 열기"에 매핑되어 있어 드래그 진입 경로가 막혀 있었다.

**CSS (`css/style.css`)**
- `.bm-folder-row, .bm-bookmark-row`: `touch-action: pan-y` + `user-select: none` — 드로어 본문 세로 스크롤은 유지하면서 가로 스와이프와 롱프레스는 JS가 소유.
- 행 내부 `<a>`/`<button>`: `-webkit-touch-callout: none` + `-webkit-user-drag: none` — iOS 링크 미리보기 / 네이티브 링크 드래그 차단.

**JS (`js/app.js` `_setupDragHandle`)**
- 터치 디바이스 롱프레스(500ms 정지) → 드래그 모드 시작(햅틱 피드백). 기존의 "롱프레스로 액션 패널 열기" 의미는 폐기.
- 액션 패널(수정/삭제) 노출은 가로 스와이프 전용으로 일원화.
- 터치에서 세로 우세 이동 → 본문 스크롤로 양보 (`mode = "abort"`).
- 마우스는 종전대로 즉시 드래그.
- `pointerup` 직후의 동기 click이 링크 navigate / 폴더 토글을 일으키지 않도록, `dragStarted` 시 다음 click을 capture-phase에서 stop+prevent.

**테스트**
- `tests/e2e/test_bookmark_swipe.py`의 롱프레스 케이스 두 개를 새 의미("롱프레스 → 드래그 시작")에 맞게 갱신.

## Test plan
- [ ] 모바일에서 북마크 행을 길게 누르면 햅틱과 함께 드래그 고스트가 떠오르고, 그대로 위/아래로 옮겨 순서 바꾸기 / 폴더 안으로 넣기가 가능한지
- [ ] 모바일에서 행을 가로로 스와이프하면 수정/삭제 패널이 그대로 열리는지
- [ ] 짧은 탭은 종전대로 해당 절로 이동하는지
- [ ] iOS Safari에서 링크 미리보기 / 링크 드래그 시트가 더 이상 뜨지 않는지
- [ ] 폴더 행과 북마크 행이 동일한 높이로 보이고, 스와이프 시 액션 패널이 행 전체 높이를 채우는지
- [ ] 데스크톱에서 마우스 드래그로 북마크/폴더 재정렬이 종전대로 동작하는지

https://claude.ai/code/session_015SsUE6PAi1Wj85EGg6wHaL