### PR TITLE
fix: 북마크 드로어 stale 좌표로 인한 잘못된 머지 권유 수정

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -4619,6 +4619,10 @@ function openBookmarkDrawer(bookId, chapter) {
 
 function closeBookmarkDrawer() {
   if ($bookmarkDrawer.hidden || $bookmarkDrawer.classList.contains("drawer-closing")) return;
+  // Clear stale chapter coords so a later save flow (e.g. verse-select bar after
+  // navigating elsewhere) doesn't fall back to the drawer's last-opened location.
+  _bookmarkDrawerBook = null;
+  _bookmarkDrawerChapter = null;
   closeSwipedRow(null);
   $bmOverflowPanel.hidden = true;
   $bmOverflowBtn.setAttribute("aria-expanded", "false");

--- a/js/app.js
+++ b/js/app.js
@@ -112,8 +112,6 @@ let _selectedVerseRefs = new Set();
 let _verseSelectDrag = null; // { startIdx, allVerses, isAdding, moved }
 let _currentBookId = null;
 let _currentChapter = null;
-let _bookmarkDrawerBook = null;
-let _bookmarkDrawerChapter = null;
 let _bookmarkDrawerTrap = null;
 let _bookmarkDrawerLastFocus = null;
 let _bmSaveModalTrap = null;
@@ -4596,8 +4594,6 @@ function openBookmarkDrawer(bookId, chapter) {
     _bookmarkDrawerCloseTimer = null;
   }
   $bookmarkDrawer.classList.remove("drawer-closing");
-  _bookmarkDrawerBook = bookId;
-  _bookmarkDrawerChapter = chapter;
   _bookmarkDrawerLastFocus = document.activeElement;
   $bookmarkScrim.hidden = false;
   $bookmarkDrawer.hidden = false;
@@ -4619,10 +4615,6 @@ function openBookmarkDrawer(bookId, chapter) {
 
 function closeBookmarkDrawer() {
   if ($bookmarkDrawer.hidden || $bookmarkDrawer.classList.contains("drawer-closing")) return;
-  // Clear stale chapter coords so a later save flow (e.g. verse-select bar after
-  // navigating elsewhere) doesn't fall back to the drawer's last-opened location.
-  _bookmarkDrawerBook = null;
-  _bookmarkDrawerChapter = null;
   closeSwipedRow(null);
   $bmOverflowPanel.hidden = true;
   $bmOverflowBtn.setAttribute("aria-expanded", "false");
@@ -5182,9 +5174,8 @@ $bookmarkDrawerBody.addEventListener("keydown", (e) => {
 // ── Save bookmark modal ──
 
 function openSaveModal(mode, opts = {}) {
-  // Drawer may not be open when entering via long-press; fall back to current context.
-  const bookId = _bookmarkDrawerBook || _currentBookId;
-  const chapter = _bookmarkDrawerChapter || _currentChapter;
+  const bookId = _currentBookId;
+  const chapter = _currentChapter;
   let verseSpec = "all";
   let existingId = opts.existingId || null;
   let existing = null;
@@ -5373,9 +5364,9 @@ function commitSaveBookmark(existingId, label, note, folderId, bookId, chapter, 
 function openMergeDialog(candidates, incomingSpec, mode, fallbackContext = null) {
   clearNode($bmMergeBody);
   const resolvedBookId =
-    (fallbackContext && fallbackContext.bookId) || _bookmarkDrawerBook || _currentBookId;
+    (fallbackContext && fallbackContext.bookId) || _currentBookId;
   const resolvedChapter =
-    (fallbackContext && fallbackContext.chapter) || _bookmarkDrawerChapter || _currentChapter;
+    (fallbackContext && fallbackContext.chapter) || _currentChapter;
 
   let target = candidates[0];
 
@@ -5638,11 +5629,8 @@ $bmSaveChapterBtn.addEventListener("click", () => {
 });
 
 $bmSelectVersesBtn.addEventListener("click", () => {
-  // Capture coords before close — closeBookmarkDrawer nulls the drawer state.
-  const bookId = _bookmarkDrawerBook;
-  const chapter = _bookmarkDrawerChapter;
   closeBookmarkDrawer();
-  enterVerseSelectMode(bookId, chapter);
+  enterVerseSelectMode(_currentBookId, _currentChapter);
 });
 
 $bmAddFolderBtn.addEventListener("click", () => {

--- a/js/app.js
+++ b/js/app.js
@@ -5638,8 +5638,11 @@ $bmSaveChapterBtn.addEventListener("click", () => {
 });
 
 $bmSelectVersesBtn.addEventListener("click", () => {
+  // Capture coords before close — closeBookmarkDrawer nulls the drawer state.
+  const bookId = _bookmarkDrawerBook;
+  const chapter = _bookmarkDrawerChapter;
   closeBookmarkDrawer();
-  enterVerseSelectMode(_bookmarkDrawerBook, _bookmarkDrawerChapter);
+  enterVerseSelectMode(bookId, chapter);
 });
 
 $bmAddFolderBtn.addEventListener("click", () => {

--- a/tests/e2e/test_bookmark.py
+++ b/tests/e2e/test_bookmark.py
@@ -115,8 +115,7 @@ def test_save_after_drawer_close_uses_current_chapter_not_stale(browser):
     }]
     page.evaluate(f"() => window.syncStoreV2.saveBookmarks({json.dumps(seed)})")
 
-    # 2) Open drawer at gen/1, then close it. This used to leave
-    #    _bookmarkDrawerBook='gen', _bookmarkDrawerChapter=1 hanging.
+    # 2) Open drawer at gen/1, then close it.
     page.locator(".title-bookmark-btn").click()
     page.wait_for_selector("#bookmark-drawer:not([hidden])")
     page.locator("#bookmark-drawer-close").click()

--- a/tests/e2e/test_bookmark.py
+++ b/tests/e2e/test_bookmark.py
@@ -2,6 +2,8 @@
 
 import json
 
+from .conftest import CLEAR_APP_STORAGE
+
 BASE = "http://localhost:8080"
 
 
@@ -92,5 +94,53 @@ def test_bm_empty_msg_disappears_after_save(browser):
     # Empty state gone, bookmark item visible
     assert page.locator("li.bm-empty").count() == 0
     assert page.locator("li.bm-bookmark").count() == 1
+
+    ctx.close()
+
+
+def test_save_after_drawer_close_uses_current_chapter_not_stale(browser):
+    """Regression: opening the drawer at gen/1 then closing it must not poison
+    a later save flow for a different chapter (john/3) into asking to merge
+    with the gen/1 bookmark."""
+    ctx = browser.new_context()
+    ctx.add_init_script(CLEAR_APP_STORAGE)
+    page = ctx.new_page()
+
+    # 1) Seed an existing Genesis 1 bookmark in the v2 store.
+    _open_chapter_and_wait(page, "gen/1")
+    seed = [{
+        "type": "bookmark", "id": "bm-seed-gen1",
+        "bookId": "gen", "chapter": 1,
+        "label": "창세 1장 (시드)", "verseSpec": "all",
+    }]
+    page.evaluate(f"() => window.syncStoreV2.saveBookmarks({json.dumps(seed)})")
+
+    # 2) Open drawer at gen/1, then close it. This used to leave
+    #    _bookmarkDrawerBook='gen', _bookmarkDrawerChapter=1 hanging.
+    page.locator(".title-bookmark-btn").click()
+    page.wait_for_selector("#bookmark-drawer:not([hidden])")
+    page.locator("#bookmark-drawer-close").click()
+    page.wait_for_selector("#bookmark-drawer", state="hidden")
+
+    # 3) Navigate to a different chapter where no bookmark exists yet.
+    _open_chapter_and_wait(page, "john/3")
+
+    # 4) Enter verse-select for john/3 and pick verse 1, then tap save.
+    page.evaluate("() => enterVerseSelectMode('john', 3)")
+    page.wait_for_selector("#verse-select-bar:not([hidden])")
+    page.click("#v1")
+    assert not page.locator("#verse-select-bookmark-btn").is_disabled()
+    page.click("#verse-select-bookmark-btn")
+
+    # 5) The save modal must open directly. The merge dialog must NOT appear,
+    #    because there is no existing john/3 bookmark.
+    page.wait_for_selector("#bm-save-modal:not([hidden])", timeout=2_000)
+    assert page.locator("#bm-merge-modal").is_hidden(), \
+        "merge dialog should not appear for a chapter with no existing bookmark"
+
+    # The pre-filled label should reference John 3:1, not Genesis 1.
+    label = page.locator("#bm-label-input").input_value()
+    assert "3:1" in label or "3장" in label, \
+        f"label should reference john 3, got: {label!r}"
 
     ctx.close()

--- a/tests/e2e/test_bookmark.py
+++ b/tests/e2e/test_bookmark.py
@@ -144,3 +144,32 @@ def test_save_after_drawer_close_uses_current_chapter_not_stale(browser):
         f"label should reference john 3, got: {label!r}"
 
     ctx.close()
+
+
+def test_select_verses_button_preserves_chapter_after_drawer_close(browser):
+    """Regression: drawer's '절 선택' button closes the drawer and enters
+    verse-select mode. The drawer-close path now nulls _bookmarkDrawer{Book,Chapter},
+    so the click handler must capture coords *before* closing."""
+    ctx = browser.new_context()
+    ctx.add_init_script(CLEAR_APP_STORAGE)
+    page = ctx.new_page()
+
+    _open_chapter_and_wait(page, "gen/1")
+    page.locator(".title-bookmark-btn").click()
+    page.wait_for_selector("#bookmark-drawer:not([hidden])")
+
+    page.locator("#bm-select-verses-btn").click()
+
+    # Drawer closes, verse-select bar appears, and the bar must reflect gen/1
+    # — i.e. _currentBookId/_currentChapter are not clobbered to null.
+    page.wait_for_selector("#bookmark-drawer", state="hidden")
+    page.wait_for_selector("#verse-select-bar:not([hidden])")
+
+    state = page.evaluate(
+        "() => ({ book: _currentBookId, chapter: _currentChapter, mode: _verseSelectMode })"
+    )
+    assert state["mode"] is True, "verse-select mode should be active"
+    assert state["book"] == "gen" and state["chapter"] == 1, \
+        f"current chapter must remain gen/1, got: {state!r}"
+
+    ctx.close()


### PR DESCRIPTION
## Summary

- 사용자 보고: John 5:1을 북마크하려고 하면 가끔 "창세 1장 북마크에 합칠까요?" 같은 **완전히 다른 장**에 대한 머지 다이얼로그가 떴다.
- 원인은 `js/app.js`의 모듈 전역 `_bookmarkDrawerBook` / `_bookmarkDrawerChapter`가 드로어가 닫힐 때 초기화되지 않는 것이었다.
- `openSaveModal()` (`js/app.js:5182-5183`)이 좌표를 `_bookmarkDrawerBook || _currentBookId`로 계산하므로, **드로어를 한 번 열었다 닫은 뒤** 다른 장에서 절 선택 → 북마크 저장을 시도하면 닫힌 드로어의 마지막 좌표가 우선되어 `findExistingChapterBookmarks()`가 엉뚱한 장을 매치했다.

### 재현 시나리오

1. 창세 1장에서 헤더 북마크 아이콘 → 드로어 열기 (`_bookmarkDrawerBook="gen"`, `_bookmarkDrawerChapter=1`)
2. 드로어 닫기 → **변수 그대로 남음**
3. 요한 5장으로 이동 → 절 long-press → 절 선택 모드
4. 절 선택 바의 북마크 버튼 탭 → `bookId="gen"`, `chapter=1`로 머지 검색
5. 창세 1장 기존 북마크 매치 → 머지 다이얼로그 등장

### 수정

- `closeBookmarkDrawer()` 진입 시 `_bookmarkDrawerBook`과 `_bookmarkDrawerChapter`를 즉시 `null`로 초기화 (`js/app.js`).
- 드로어가 모달이라 열려 있는 동안에는 `_currentBookId`/`_currentChapter`와 항상 일치하므로 부수효과 없음. `commitSaveBookmark`도 `bookId`/`chapter`를 인자로 받아 변수에 의존하지 않음.

### 회귀 방지 테스트

`tests/e2e/test_bookmark.py::test_save_after_drawer_close_uses_current_chapter_not_stale`:

1. `syncStoreV2`에 `gen/1` 북마크 시드
2. `/gen/1`에서 드로어 열고 닫기
3. `/john/3`으로 이동 → `enterVerseSelectMode('john', 3)` → `#v1` 선택 → 북마크 버튼 클릭
4. **expect**: `#bm-merge-modal[hidden]`이고 `#bm-save-modal`이 `요한 3:1` 라벨로 열림

## Test plan

- [x] `node --test tests/unit/*.test.js` (98/98 통과)
- [x] `node -c js/app.js`
- [x] `python3 -m py_compile tests/e2e/test_bookmark.py`
- [ ] 로컬 e2e: `python3 scripts/serve.py 8080` + `pytest tests/e2e/test_bookmark.py -v`
- [ ] 수동 확인: 위 재현 시나리오로 머지 다이얼로그가 더 이상 뜨지 않는지

## 후속 정리 (이번 PR에 포함하지 않음)

`_bookmarkDrawerBook` / `_bookmarkDrawerChapter` 자체를 제거하고 `_currentBookId` / `_currentChapter`만 사용하도록 단순화 가능 — 드로어가 모달이라 두 쌍은 항상 동일하다. 회귀 위험 최소화를 위해 이번엔 초기화만 추가했다.

https://claude.ai/code/session_01M8RWHh3PQTyedTi1t334SR

---
_Generated by [Claude Code](https://claude.ai/code/session_01M8RWHh3PQTyedTi1t334SR)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: scopes to bookmark-drawer context tracking and adds e2e coverage; main risk is small regressions in bookmark save/verse-select flows tied to `_currentBookId/_currentChapter`.
> 
> **Overview**
> Fixes a bookmark regression where saving after closing the bookmark drawer could use **stale book/chapter coordinates**, causing incorrect merge prompts for the wrong chapter.
> 
> This removes the drawer-specific cached context (`_bookmarkDrawerBook`/`_bookmarkDrawerChapter`) and makes `openSaveModal()`/`openMergeDialog()` and the drawer’s “절 선택” action rely on the current chapter context (`_currentBookId`/`_currentChapter`). Adds new E2E regression tests ensuring saves after drawer-close don’t trigger merges against a different chapter and that “절 선택” still enters verse-select for the correct chapter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08e2836e70506ebfa042fa78856581de5e5c595a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->