### PR TITLE
fix: 롱프레스 드래그 진입 시 고스트 초기 top 위치 고정

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1473,6 +1473,10 @@ function _setupDragHandle(li, row) {
       ghost.className = "bm-drag-ghost";
       ghost.style.width = origRect.width + "px";
       ghost.style.left = origRect.left + "px";
+      // Pin to the source row's position so long-press entry (where no
+      // pointermove has fired yet) doesn't flash the ghost at the document's
+      // default position before the user starts moving.
+      ghost.style.top = origRect.top + "px";
       const rowClone = (li.querySelector(".bm-folder-row, .bm-bookmark-row") || li.firstElementChild).cloneNode(true);
       ghost.appendChild(rowClone);
       document.body.appendChild(ghost);


### PR DESCRIPTION
## Summary

PR #70(`9acbb20`)에 대한 [Cursor Bugbot 후속 지적](https://github.com/anglican-kr/common-bible/pull/70#discussion_r3206124530) 반영.

`_beginDrag()`이 `ghost.style.top`을 설정하지 않아 롱프레스 경로에서 첫 `pointermove`가 들어오기 전까지 `position: fixed` 고스트가 문서 기본 위치(주로 body 끝, 화면 밖)에 잠시 표시되고 원본 행은 0.3 opacity로 흐려진 채 비어 보이는 이상 상태가 발생.

마우스 경로(`onMove`)에서는 곧바로 `_dragState.ghost.style.top`이 갱신돼 가려졌던 버그. 롱프레스 경로에서는 `onMove`가 한참 후에 들어오므로 노출됨.

`_beginDrag()` 안에서 `origRect.top`으로 초기 위치를 고정.

## Test plan
- [ ] 모바일에서 북마크/폴더 행을 길게 누르면 고스트가 원본 행과 동일한 위치에서 떠오르는지 (점프 없이)
- [ ] 마우스 드래그 종전대로 동작하는지

https://claude.ai/code/session_015SsUE6PAi1Wj85EGg6wHaL

---
_Generated by [Claude Code](https://claude.ai/code/session_015SsUE6PAi1Wj85EGg6wHaL)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that sets the initial drag ghost position; affects only bookmark drawer long-press drag behavior with minimal surface area.
> 
> **Overview**
> Fixes a visual glitch when entering bookmark/folder reorder via *long-press* on touch devices by initializing the drag “ghost” element’s `top` position in `_beginDrag()`.
> 
> This prevents the fixed-position ghost from briefly rendering at the document default location before the first `pointermove` updates its position.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0135e4735c17d610dc5442151fec9e5ba6aa2c70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->