### PR TITLE
feat: iOS 17+ 비Safari 브라우저에서도 PWA 설치 안내 노출

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1172,6 +1172,16 @@ body {
   color: var(--text-secondary);
   margin-top: 0.75rem;
 }
+#install-modal-body .install-step-list {
+  margin: 0.75rem 0 0;
+  padding-left: 1.4rem;
+  font-size: 0.92rem;
+  line-height: 1.55;
+  color: var(--text);
+}
+#install-modal-body .install-step-list li {
+  margin-bottom: 0.4rem;
+}
 .install-never-show-row {
   display: flex;
   align-items: center;

--- a/docs/decisions/008-pwa-install-guide.md
+++ b/docs/decisions/008-pwa-install-guide.md
@@ -128,3 +128,17 @@ SHELL_FILES에는 추가하지 **않는다**. 안내 이미지는 최초 설치 
 - 실기기 스크린샷 확보 시 → SVG 플레이스홀더를 사진 기반 가이드로 교체
 - iOS 18+에서 `apple-app-site-association`/Smart App Banner 정책이 PWA까지 확장되면 → 별도 분기 추가
 - `navigator.userAgentData` 브라우저 보급률이 충분해지면 → UA 문자열 파싱 → UA-CH 전환
+
+> **개정 (2026-05-08): iOS 17+ 비Safari 브라우저 설치 지원**
+>
+> iOS 17부터 Chrome / Firefox / Edge / Opera 등의 공유 시트에 "홈 화면에 추가" 항목이 노출되며, 그렇게 추가된 아이콘은 standalone WebKit 컨테이너에서 실행된다. "iOS는 Safari에서만 설치 가능"이라는 기존 전제는 더 이상 사실이 아니다.
+>
+> 변경 사항:
+>
+> - 플랫폼 분기를 다음과 같이 세분화한다.
+>   - `ios-other` — iOS 17+ + 비Safari (CriOS/FxiOS/EdgiOS/OPiOS). 공유 메뉴 → "홈 화면에 추가" 텍스트 가이드 노출. **자동 nudge 대상에 포함**.
+>   - `ios-legacy` — iOS ≤16 + 비Safari. 기존 "Safari로 열어 주세요 + 주소 복사" 메시지 그대로 유지.
+> - iOS 메이저 버전 판정: `OS X_Y` 토큰 우선, iPad 마스킹(`MacIntel + maxTouchPoints>1`)은 `Version/X.Y` 폴백 또는 17 가정.
+> - `ios-other` 가이드는 스크린샷 대신 3단계 텍스트 + 감지된 브라우저명("Chrome / Firefox / Edge / Opera / 브라우저") 안내. 브라우저별 공유 버튼 위치가 달라 단일 스크린샷이 부정확하기 때문.
+>
+> 관련 코드: `js/app.js` `getIOSMajor()`, `detectPlatform()`, `buildInstallBody`의 `ios-other`·`ios-legacy` 분기. 테스트: `tests/e2e/test_install_guide.py`의 iOS 17 Chrome / iOS 16 Chrome 분기 케이스.

--- a/js/app.js
+++ b/js/app.js
@@ -4042,7 +4042,8 @@ function initCompactHeader() {
 // Platforms:
 //   "installed"    — already running as a standalone PWA, nothing to show
 //   "ios-safari"   — iPhone/iPad Safari; manual "Add to Home Screen" guide
-//   "ios-other"    — iOS Chrome/Firefox/etc (WebKit wrapper); prompt user to open in Safari
+//   "ios-other"    — iOS 17+ Chrome/Firefox/Edge/etc; share-menu "Add to Home Screen" guide
+//   "ios-legacy"   — iOS ≤16 non-Safari (Add-to-Home-Screen unsupported); prompt to open in Safari
 //   "android"      — Chromium-based Android; beforeinstallprompt available
 //   "desktop"      — Chromium-based desktop; beforeinstallprompt available
 //   "unsupported"  — Firefox/Safari desktop, etc; hide install entry
@@ -4062,16 +4063,37 @@ const install = (() => {
     );
   }
 
+  // Returns the iOS major version, or 0 if not iOS / version is unknown.
+  // Sources, in order of reliability:
+  //   1. "CPU iPhone OS X_Y" / "CPU OS X_Y" — present on iPhone and on iPad in
+  //      iPhone-mode UA. Reliable.
+  //   2. "Version/X.Y" — Safari's marketing version, which tracks iOS major.
+  //      Used as fallback for iPadOS desktop-class UA (masquerades as Mac).
+  //   3. iPad masquerading as Mac with no Version/ token (e.g. CriOS on iPad)
+  //      — assume modern (≥17), since older iPadOS Chrome did not mask UA.
+  function getIOSMajor() {
+    const ua = navigator.userAgent;
+    const osMatch = ua.match(/OS (\d+)_/);
+    if (osMatch) return parseInt(osMatch[1], 10);
+    const isIPadMask = navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1;
+    if (!isIPadMask) return 0;
+    const verMatch = ua.match(/Version\/(\d+)/);
+    if (verMatch) return parseInt(verMatch[1], 10);
+    return 17; // best-effort: modern iPadOS without Version/ token
+  }
+
   function detectPlatform() {
     if (isStandalone()) return "installed";
     const ua = navigator.userAgent;
     const isIOS = /iPad|iPhone|iPod/.test(ua) ||
       (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1); // iPadOS 13+
     if (isIOS) {
-      // On iOS all browsers use WebKit, but only Safari can install.
-      // Safari UA does not include CriOS/FxiOS/EdgiOS/OPiOS.
+      // All iOS browsers wrap WebKit. Safari UA omits the CriOS/FxiOS/etc tokens.
       const isSafari = !/CriOS|FxiOS|EdgiOS|OPiOS|GSA/.test(ua);
-      return isSafari ? "ios-safari" : "ios-other";
+      if (isSafari) return "ios-safari";
+      // iOS 17+ exposes "Add to Home Screen" inside Chrome/Firefox/Edge/Opera
+      // share sheets, and the resulting icon launches in standalone mode.
+      return getIOSMajor() >= 17 ? "ios-other" : "ios-legacy";
     }
     if (deferredPrompt) {
       // Android UA: "Android" token. Otherwise treat as desktop.
@@ -4277,8 +4299,29 @@ function buildInstallBody(platform) {
   }
 
   if (platform === "ios-other") {
+    const ua = navigator.userAgent;
+    const browserName =
+      /CriOS/.test(ua) ? "Chrome" :
+      /FxiOS/.test(ua) ? "Firefox" :
+      /EdgiOS/.test(ua) ? "Edge" :
+      /OPiOS/.test(ua) ? "Opera" :
+      "브라우저";
     $installModalBody.appendChild(el("p", {},
-      "iOS에서는 Safari에서만 홈 화면에 앱을 설치할 수 있습니다."));
+      `${browserName}에서 공유 메뉴를 열고 '홈 화면에 추가'를 선택하면 앱처럼 실행됩니다.`));
+    const list = el("ol", { className: "install-step-list" });
+    list.appendChild(el("li", {}, "주소창 또는 메뉴(···)에서 공유 버튼을 누릅니다."));
+    list.appendChild(el("li", {}, "공유 시트에서 '홈 화면에 추가'를 선택합니다."));
+    list.appendChild(el("li", {}, "오른쪽 위 '추가'를 누르면 홈 화면에 아이콘이 생깁니다."));
+    $installModalBody.appendChild(list);
+    $installModalBody.appendChild(el("p", { className: "install-note" },
+      "메뉴에 '홈 화면에 추가'가 없으면 브라우저를 최신 버전으로 업데이트한 뒤 다시 시도해 주세요."));
+    $installModalBody.appendChild(_buildNeverShowRow());
+    return;
+  }
+
+  if (platform === "ios-legacy") {
+    $installModalBody.appendChild(el("p", {},
+      "이 iOS 버전에서는 Safari에서만 홈 화면에 앱을 설치할 수 있습니다."));
     $installModalBody.appendChild(el("p", {},
       "이 페이지 주소를 복사해 Safari에서 열어 주세요."));
     $installModalBody.appendChild(el("p", { className: "install-bookmark-notice" },
@@ -4442,7 +4485,8 @@ function _saveNudgeState(state) {
 function maybeShowInstallNudge() {
   const platform = install.detectPlatform();
   // Only nudge platforms where installation is meaningful and possible
-  const nudgeable = platform === "ios-safari" || platform === "android";
+  const nudgeable =
+    platform === "ios-safari" || platform === "ios-other" || platform === "android";
   if (!nudgeable) return;
   if (_loadNudgeState().neverShow) return;
 

--- a/tests/e2e/test_install_guide.py
+++ b/tests/e2e/test_install_guide.py
@@ -12,6 +12,10 @@ _IOS_CHROME_UA = (
     "Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) "
     "AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/123.0.0.0 Mobile/15E148 Safari/604.1"
 )
+_IOS16_CHROME_UA = (
+    "Mozilla/5.0 (iPhone; CPU iPhone OS 16_6 like Mac OS X) "
+    "AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/118.0.0.0 Mobile/15E148 Safari/604.1"
+)
 _ANDROID_UA = (
     "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 "
     "(KHTML, like Gecko) Chrome/124.0.0.0 Mobile Safari/537.36"
@@ -51,8 +55,14 @@ def _open_modal_body(browser, ua: str) -> str | None:
             [],
         ),
         (
-            "iOS Chrome prompts to open in Safari",
+            "iOS 17 Chrome shows share-menu Add-to-Home-Screen guide",
             _IOS_CHROME_UA,
+            ["Chrome", "홈 화면에 추가"],
+            ["··· 버튼", "Safari에서만", "주소 복사"],
+        ),
+        (
+            "iOS 16 Chrome prompts to open in Safari",
+            _IOS16_CHROME_UA,
             ["Safari", "주소 복사"],
             ["··· 버튼"],
         ),


### PR DESCRIPTION
## Summary

iOS 17부터 Chrome / Firefox / Edge / Opera 공유 시트에 **"홈 화면에 추가"** 가 노출되고, 추가된 아이콘은 standalone WebKit 컨테이너에서 실행됩니다. 기존 코드의 "iOS는 Safari에서만 설치 가능" 전제(ADR-008)가 더 이상 사실이 아니므로 플랫폼 분기를 세분화했습니다.

### 분기 표

| 기존 | 변경 후 | 동작 |
|------|---------|------|
| `ios-safari` | `ios-safari` | 변경 없음 — 스크린샷 3단계 가이드 |
| `ios-other` (iOS 17+) | `ios-other` | **신규** — 공유 메뉴 텍스트 가이드 + 자동 nudge 대상 |
| `ios-other` (iOS ≤16) | `ios-legacy` | 기존 "Safari로 열어주세요 + 주소 복사" 안내 |

### 구현 포인트

- `getIOSMajor()` 헬퍼 추가: `CPU OS X_Y` 우선, iPadOS 마스킹(`MacIntel + maxTouchPoints>1`) 시 `Version/X.Y` 폴백, 그것도 없으면 17(modern)로 가정.
- `ios-other` 가이드는 스크린샷 대신 3단계 텍스트 ol + 감지된 브라우저명("Chrome / Firefox / Edge / Opera / 브라우저"). 브라우저별 공유 버튼 위치(상단 vs 하단, ··· 메뉴 vs 별도 아이콘)가 달라 단일 스크린샷이 부정확하므로 텍스트가 안전합니다.
- `maybeShowInstallNudge`의 `nudgeable`에 `ios-other` 추가 — 자동 nudge 흐름에서 빠지지 않도록.
- ADR-008에 개정 블록 추가.

## Test plan

- [x] `node --check js/app.js` (syntax OK)
- [x] `node --test tests/unit/*.test.js` (111 / 111 통과)
- [ ] **실기기 테스트 필요** — iOS 17/18 × Chrome / Firefox / Edge:
  - [ ] 설정 → 앱 설치 → 안내가 새 텍스트 가이드로 표시되는가
  - [ ] 안내대로 공유 메뉴 → 홈 화면에 추가가 실제 가능한가
  - [ ] 추가된 아이콘 실행 시 standalone(주소창 없음)으로 뜨는가
  - [ ] PKCE 리디렉션(Drive sync)이 standalone 컨테이너에서 정상 동작하는가
- [ ] iOS 16 디바이스/시뮬레이터 + Chrome → "Safari로 열어주세요 + 주소 복사" 분기 유지 확인
- [ ] e2e 회귀 (`pytest tests/e2e/test_install_guide.py`) — 새 파라미터 케이스 2개 (iOS 17 Chrome, iOS 16 Chrome) 통과 확인

## 미결 / 추가 검토

- **PKCE 리디렉션 호환성**: `transport.beginRedirectAuth`가 Chrome iOS의 standalone WebView에서 어떻게 동작하는지 실기기 검증 필요. Phase 2f가 GIS Token Client 우회를 위해 Implicit → 풀페이지 리디렉션으로 갔던 맥락이 있으니, 비Safari standalone 모드에서도 `consumeRedirectCallback`이 정상 흡수되는지 확인.
- **iPad UA 마스킹**: 데스크톱-class UA의 iPad에서는 정확한 메이저 버전 추출이 어려워 17로 가정합니다. 실기기 회귀 발견 시 보정 로직 추가 필요.

https://claude.ai/code/session_01Lkg4gzheMaFmbpr6bm7EUk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lkg4gzheMaFmbpr6bm7EUk)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates iOS platform detection and install-nudge behavior based on UA parsing, which could misclassify devices/browsers and change when install prompts appear. Functional impact is limited to the PWA install guidance UI and related localStorage nudge state.
> 
> **Overview**
> Updates the PWA install flow to recognize **iOS 17+ non‑Safari browsers** as install-capable via the share sheet, instead of always instructing users to switch to Safari.
> 
> This adds an `ios-legacy` branch for iOS ≤16 non‑Safari browsers, introduces `getIOSMajor()` for iOS version detection, and updates `buildInstallBody()` to show a browser-specific 3-step text guide for `ios-other` while keeping the existing "open in Safari + copy URL" flow for `ios-legacy`. The automatic install nudge is expanded to include `ios-other`, with styling added for the new step list, and e2e coverage updated to distinguish iOS 17 Chrome vs iOS 16 Chrome behavior; ADR-008 is amended to document the new branching.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25081b455656c7d84576f9b73b5024fc61523b05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->