### PR TITLE
feat: 오디오 플레이어에 총 재생시간 미리 표시

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -2871,15 +2871,10 @@ function showAudioPlayer(bookId, chapter) {
   currentAudio = audio;
 
   const savedTime = loadAudioTime(bookId, chapter);
-  let srcLoaded = false;
-  if (savedTime) {
-    // Eagerly load metadata to restore seek position before first play
-    srcLoaded = true;
-    audio.preload = "metadata";
-    audio.src = src;
-  } else {
-    audio.preload = "none";
-  }
+  // Always preload metadata so total duration is visible before first play.
+  // ADR-016 excludes preload accesses from LRU, so this does not pollute cache signals.
+  audio.preload = "metadata";
+  audio.src = src;
 
   // Build player UI
   const container = el("div", { className: "audio-player" });
@@ -2931,15 +2926,7 @@ function showAudioPlayer(bookId, chapter) {
   container.appendChild(progressWrap);
   container.appendChild(speedBtn);
 
-  // Play/pause toggle — load src lazily on first click (srcLoaded declared above)
   playBtn.addEventListener("click", () => {
-    if (!srcLoaded) {
-      srcLoaded = true;
-      playIcon.className = "audio-icon-loading";
-      audio.src = src;
-      audio.play().catch(() => {});
-      return;
-    }
     if (audio.paused) {
       audio.play();
     } else {
@@ -2980,7 +2967,7 @@ function showAudioPlayer(bookId, chapter) {
       updateProgressFill();
       timeDisplay.textContent = `${formatTime(savedTime)} / ${formatTime(audio.duration)}`;
     } else {
-      timeDisplay.textContent = formatTime(audio.duration);
+      timeDisplay.textContent = `${formatTime(0)} / ${formatTime(audio.duration)}`;
     }
   }, { signal });
 


### PR DESCRIPTION
## Summary

- 오디오 플레이어가 장 진입 시 총 재생시간을 미리 표시하도록 변경. 기존에는 `preload="none"`이라 사용자가 재생 버튼을 눌러야 길이를 알 수 있어 시간 표시가 `0:00`만 나왔다.
- `audio.preload`를 항상 `"metadata"`로 설정하고 src를 미리 로드해 `loadedmetadata` 이벤트 시점에 `0:00 / X:XX` 포맷으로 표시.
- src lazy-load 분기(`srcLoaded` 플래그)와 click 핸들러의 첫 클릭 src 주입 로직 제거 — 단순한 play/pause 토글로 정리.

## Notes

- ADR-016 §LRU 정책상 `preload="metadata"` 같은 자동 트래픽은 LRU 신호에서 제외되므로 오디오 캐시 정책 오염 없음.
- 오디오 파일이 404인 장은 metadata 페치 단계에서 `error` 이벤트가 즉시 발화 → 기존 `showAudioUnavailable()` 경로로 안전하게 폴백.

## Test plan

- [ ] 새 장 진입 직후 시간 표시가 `0:00 / X:XX` 형식으로 보이는지 확인
- [ ] 재생 버튼이 한 번 클릭으로 바로 재생 시작하는지 확인 (이전에는 첫 클릭이 src 로드, 두 번째 클릭이 재생이었던 게 아닌지 회귀 확인)
- [ ] 이어듣기(savedTime) 복원이 그대로 동작하는지 확인 — 시간 표시가 `M:SS / X:XX`로 표시되어야 함
- [ ] 오디오 파일이 없는 장에서 "오디오 파일을 준비 중입니다." 메시지가 정상 표출되는지 확인
- [ ] 데스크톱 + iOS Safari에서 일시정지/재생/탐색 동작 회귀 확인


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q2uHYFxGhZCFjrVZRgRhfy)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes audio loading behavior to fetch metadata on chapter entry, which may affect network usage/caching behavior and first-play UX across browsers.
> 
> **Overview**
> **Audio player now shows total duration immediately.** `showAudioPlayer` always sets `audio.preload = "metadata"` and assigns `audio.src` up front so `loadedmetadata` can render time as `0:00 / X:XX` even before the user hits play.
> 
> This removes the previous lazy `srcLoaded` first-click loading path and simplifies the play button handler to a straight play/pause toggle, while keeping resume-from-`savedTime` behavior and updating the default (no-resume) time display format.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cee604896e3b9f7d8abbee7c20a63b83224670c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->