### PR TITLE
feat: nginx BFF 보강 — Permissions-Policy 확장 + rate limit + njs body 가드 (L11+M5+M6)

### DIFF
--- a/nginx/oauth-bff-guard.example.js
+++ b/nginx/oauth-bff-guard.example.js
@@ -1,0 +1,45 @@
+// OAuth /token BFF guard (njs).
+//
+// 배포 절차:
+//   1. 이 파일 내용을 서버의 /etc/nginx/njs/oauth-bff-guard.js로 복사
+//   2. /etc/nginx/conf.d/oauth-bff-shared.conf의 `js_path` + `js_import`가
+//      이 파일을 로드 (오타 시 nginx -t 단계에서 잡힘)
+//   3. nginx -t → systemctl reload nginx
+//
+// 동작:
+//   `location = /oauth/token`이 `js_content oauth_bff_guard.guardAndForward`로
+//   이 함수에 진입. body가 buffered된 상태에서 호출되므로 `r.requestText`
+//   접근 가능. body에 클라이언트가 보낸 `client_secret=`가 있으면 400 반환,
+//   없으면 내부 named location `@oauth_token_upstream`으로 redirect → 거기서
+//   `proxy_set_body "$request_body&client_secret=<SECRET>"` + Google forward.
+//
+// Why 별도 njs?
+//   nginx stock의 `if ($request_body ~ "...")`는 REWRITE phase에 평가되는데
+//   body buffering은 CONTENT phase에서 일어나므로 if 시점엔 빈 문자열일 가능성
+//   → no-op guard가 됨. njs `js_content`는 body buffered 후 호출이 보장되므로
+//   r.requestText에 실제 body가 들어와 검사 가능.
+//
+// 위협 모델:
+//   - RFC 6749 §3.2가 token endpoint 파라미터 중복을 금지. 클라이언트가
+//     `client_secret=fake&...` 보내면 nginx가 `&client_secret=<real>` 추가 →
+//     duplicate. Google이 마지막 값(real) 채택해 secret oracle은 안 되지만
+//     표준 위배 트래픽은 early reject가 정도.
+//   - guard 미통과 시 body는 server-side에서 그대로 폐기 (nginx context 종료).
+
+function guardAndForward(r) {
+    const body = r.requestText || "";
+
+    // form-urlencoded 파라미터 키는 `&` 또는 body 시작 위치 다음에 옴.
+    // `=`로 끝나는 키 매칭으로 prefix 충돌(예: `my_client_secret_extra`) 회피.
+    if (/(?:^|&)client_secret=/i.test(body)) {
+        r.return(400, JSON.stringify({
+            error: "invalid_request",
+            error_description: "client_secret must not be sent by client"
+        }) + "\n");
+        return;
+    }
+
+    r.internalRedirect("@oauth_token_upstream");
+}
+
+export default { guardAndForward };

--- a/nginx/oauth-bff-guard.example.js
+++ b/nginx/oauth-bff-guard.example.js
@@ -29,14 +29,34 @@
 function guardAndForward(r) {
     const body = r.requestText || "";
 
-    // form-urlencoded 파라미터 키는 `&` 또는 body 시작 위치 다음에 옴.
-    // `=`로 끝나는 키 매칭으로 prefix 충돌(예: `my_client_secret_extra`) 회피.
-    if (/(?:^|&)client_secret=/i.test(body)) {
-        r.return(400, JSON.stringify({
-            error: "invalid_request",
-            error_description: "client_secret must not be sent by client"
-        }) + "\n");
-        return;
+    // application/x-www-form-urlencoded는 키도 percent-encoding/+ 인코딩을
+    // 허용하므로 raw 문자열 regex 매칭은 우회 가능 (예: `client%5Fsecret=fake`,
+    // `client+secret=fake`). Google의 form 파서는 디코드 후 매칭하므로
+    // `client%5Fsecret=fake&...&client_secret=<our>`처럼 RFC §3.2 위배 중복이
+    // 만들어진다. 각 파라미터 키를 명시적으로 디코드한 뒤 비교해 차단.
+    const params = body.split("&");
+    for (var i = 0; i < params.length; i++) {
+        var p = params[i];
+        if (!p) continue;
+        var eq = p.indexOf("=");
+        var rawKey = eq >= 0 ? p.substring(0, eq) : p;
+        var key;
+        try {
+            // form-urlencoded는 `+`를 공백으로 디코드하므로 먼저 치환,
+            // 그다음 percent-decode.
+            key = decodeURIComponent(rawKey.replace(/\+/g, "%20")).toLowerCase();
+        } catch (_) {
+            // 잘못된 percent-encoding은 nginx/Google이 어떻게 처리하든 보내고
+            // 거기서 거부받게 둠. 우리 가드 역할이 아님.
+            continue;
+        }
+        if (key === "client_secret") {
+            r.return(400, JSON.stringify({
+                error: "invalid_request",
+                error_description: "client_secret must not be sent by client"
+            }) + "\n");
+            return;
+        }
     }
 
     r.internalRedirect("@oauth_token_upstream");

--- a/nginx/oauth-bff-shared.example.conf
+++ b/nginx/oauth-bff-shared.example.conf
@@ -1,0 +1,33 @@
+# OAuth BFF http-context shared setup.
+#
+# 이 파일은 nginx http context (server { } 바깥)에서 evaluate되어야 한다.
+# Debian/Ubuntu nginx의 `/etc/nginx/conf.d/*.conf`는 자동으로 http context에
+# include되므로 거기에 두면 된다.
+#
+# 배포 절차:
+#   1. 이 파일 내용을 서버의 /etc/nginx/conf.d/oauth-bff-shared.conf로 복사
+#   2. nginx -t → systemctl reload nginx
+#
+# 두 가지를 정의한다:
+#
+# 1. **limit_req_zone (M5)** — `/oauth/token` 익명 공개 BFF 엔드포인트의
+#    brute force / abuse 방어. IP당 분당 60회 + burst 100.
+#    typical 사용 패턴: 콜드 스타트 1회 + 401 재인증 가끔 + visibility-trigger
+#    sync 가끔 = 세션당 3-5회. 60r/m + burst 100은 NAT 뒤 단체(교회·학교 등
+#    100명 동시 시작) 시나리오까지 즉시 통과시키면서 1.7r/s 지속을 확보 —
+#    abuse 측면에서도 Google /token이 valid code/refresh_token 없이는 어떤
+#    권한도 발급 안 하므로 충분한 여유선.
+#
+# 2. **njs script load (M6)** — body parameter pollution 가드.
+#    `proxy_set_body "$request_body&client_secret=..."` 패턴은 클라이언트가
+#    body에 client_secret=fake&을 포함시켜도 결과 body에 두 번 등장하게 한다.
+#    Google이 마지막 값을 채택하므로 secret oracle은 안 되지만 RFC 6749 §3.2가
+#    명시적으로 token endpoint 파라미터 중복을 금지하므로 표준 위배 트래픽은
+#    early reject가 정도. nginx의 `if ($request_body ~ ...)`는 REWRITE 단계라
+#    body 미버퍼링 상태에서 평가될 수 있어 신뢰 불가 — njs `js_content`로
+#    body buffered 시점에 검사하는 것이 정확.
+
+limit_req_zone $binary_remote_addr zone=oauth_token:10m rate=60r/m;
+
+js_path "/etc/nginx/njs/";
+js_import oauth_bff_guard from oauth-bff-guard.js;

--- a/nginx/oauth-proxy.example.conf
+++ b/nginx/oauth-proxy.example.conf
@@ -1,4 +1,4 @@
-# Same-origin proxy for Google OAuth /token endpoint.
+# Same-origin proxy for Google OAuth /token endpoint (BFF).
 #
 # 목적: Google "Web application" OAuth 클라이언트는 PKCE를 쓰더라도 /token 요청에
 # client_secret을 강제(RFC 7636 일탈). secret을 SPA 번들·git 이력·GitHub 자동
@@ -6,41 +6,84 @@
 # 이 nginx location 블록이 secret을 server-side에서 body에 주입한 뒤 Google로
 # forward한다.
 #
+# 구조 (njs 도입 후 — 두 location으로 분리):
+#   - `location = /oauth/token` (외부 진입): rate limit + njs body 가드 →
+#     pollution 검출 시 400, 정상이면 내부 named location으로 redirect
+#   - `location @oauth_token_upstream` (내부 only): client_secret 주입 후
+#     Google /token으로 proxy_pass
+#
+# 의존성:
+#   - `nginx/oauth-bff-shared.example.conf`이 /etc/nginx/conf.d/에 배포되어
+#     limit_req_zone(`oauth_token`)과 njs 모듈 import(`oauth_bff_guard`)를
+#     http context에 정의하고 있어야 한다
+#   - `nginx/oauth-bff-guard.example.js`가 /etc/nginx/njs/oauth-bff-guard.js로
+#     배포되어 있어야 한다
+#   - `libnginx-mod-http-js` 패키지 설치 + `/etc/nginx/modules-enabled/`에
+#     `50-mod-http-js.conf` 활성화
+#
 # 배포 절차:
-#   1. 이 파일 내용을 dev.anglican.kr·bible.anglican.kr 두 vhost의 server { }
-#      블록 안에 각각 복사해 넣는다.
-#   2. <CLIENT_SECRET>을 호스트별 값으로 치환:
+#   1. 두 location 블록(아래)을 dev.anglican.kr·bible.anglican.kr 두 vhost의
+#      server { } 블록 안에 각각 복사해 넣는다.
+#   2. `@oauth_token_upstream` 안의 <CLIENT_SECRET>을 호스트별 값으로 치환:
 #        dev.anglican.kr   → dev OAuth 클라이언트의 client_secret
 #        bible.anglican.kr → prod OAuth 클라이언트의 client_secret
-#      (실제 값은 Google Cloud Console "사용자 인증 정보" → 클라이언트 ID에서 확인)
 #   3. nginx -t로 syntax 검증 → systemctl reload nginx
 #
 # 동작 검증:
+#   # 정상 요청(가짜 refresh token) → secret 주입 정상이라 Google이 invalid_grant
 #   curl -X POST https://dev.anglican.kr/oauth/token \
 #     -H "Content-Type: application/x-www-form-urlencoded" \
 #     -d "grant_type=refresh_token&refresh_token=invalid&client_id=..."
-#   기대: HTTP 400 + {"error":"invalid_grant"} 응답.
-#   400 invalid_grant이 나오면 secret 주입은 정상 동작 (단지 fake refresh token이라
-#   거부된 것). 401 invalid_client 또는 400 client_secret_missing이 나오면 secret
-#   주입이 실패.
+#   기대: HTTP 400 + {"error":"invalid_grant"}
+#
+#   # body에 client_secret 주입 → njs 가드가 400으로 거부 (Google까지 안 감)
+#   curl -X POST https://dev.anglican.kr/oauth/token \
+#     -H "Content-Type: application/x-www-form-urlencoded" \
+#     -d "grant_type=refresh_token&client_secret=fake&refresh_token=invalid"
+#   기대: HTTP 400 + {"error":"invalid_request","error_description":"client_secret must not be sent by client"}
+#
+#   # rate limit 검증 (분당 60회 + burst 100)
+#   seq 1 150 | xargs -n1 -P150 -I{} curl -s -o /dev/null -w "%{http_code}\n" \
+#     -X POST https://dev.anglican.kr/oauth/token -d "x={}" \
+#     -H "Content-Type: application/x-www-form-urlencoded" | sort | uniq -c
+#   기대: 처음 ~100개는 400/401, 그 이후 503 (Service Temporarily Unavailable)
 #
 # 보안 메모:
 #   - Google /token은 유효한 code/refresh_token 없이는 어떤 권한도 발급 안 함.
-#     /oauth/token이 익명에게 열려 있어도 단순 relay 이상이 안 됨.
+#     /oauth/token이 익명에게 열려 있어도 단순 relay 이상이 안 됨. limit_req로
+#     무차별 abuse만 차단.
 #   - GET·HEAD 등 비-POST 메서드는 405로 차단.
 #   - 브라우저 Cookie / Authorization 헤더는 Google로 forward하지 않음.
+#   - njs 가드는 표준 위배(파라미터 중복) 트래픽 early reject 정도. 미통과시
+#     본 서비스 동작에 영향 없음.
 
+# 외부 진입 — 클라이언트가 직접 도달.
 location = /oauth/token {
     if ($request_method != POST) {
         return 405;
     }
 
-    # Body가 4KB를 넘으면 $request_body가 비기 때문에, 토큰 요청 크기보다
-    # 충분히 큰 버퍼를 명시. 토큰 요청은 ~300 byte라 4k면 여유.
+    # M5 — IP당 분당 60회 + burst 100. NAT 뒤 단체(교회·학교 등) 동시 시작
+    # 시나리오를 즉시 통과시키되 abuse 시엔 1.7r/s로 제한.
+    limit_req zone=oauth_token burst=100 nodelay;
+
+    # Body buffering. 토큰 요청은 ~300B, 4k 충분.
     client_body_buffer_size 4k;
     client_max_body_size 4k;
 
-    # Strip browser-side headers that don't belong upstream.
+    # M6 — body에 client-supplied client_secret이 있으면 400.
+    # njs `js_content`는 body buffered 후 호출 보장(stock if-phase 한계 우회).
+    js_content oauth_bff_guard.guardAndForward;
+}
+
+# 내부 only — njs 가드가 internalRedirect로 진입. 외부에서 직접 호출 불가.
+# named location은 proxy_pass에 URI part(/token)를 못 가지므로 rewrite로
+# URI를 /token으로 만든 뒤 URI 없는 proxy_pass.
+location @oauth_token_upstream {
+    internal;
+
+    rewrite ^ /token break;
+
     proxy_set_header Cookie "";
     proxy_set_header Authorization "";
     proxy_set_header Content-Type "application/x-www-form-urlencoded";
@@ -53,5 +96,5 @@ location = /oauth/token {
     proxy_ssl_server_name on;
     proxy_ssl_name oauth2.googleapis.com;
 
-    proxy_pass https://oauth2.googleapis.com/token;
+    proxy_pass https://oauth2.googleapis.com;
 }

--- a/nginx/security-headers.example.conf
+++ b/nginx/security-headers.example.conf
@@ -29,6 +29,9 @@
 #     cross-origin에 full path를 새는 회귀를 닫고, (b) 의도를 코드로 박제.
 #   - Permissions-Policy: SPA가 사용하지 않는 강력한 기능들 명시 거부.
 #     camera/microphone/geolocation/payment/USB/motion sensors 모두 안 씀.
+#     clipboard-read 미사용(쓰기는 사용 — `clipboard-write`은 명시 안 해 브라우저
+#     기본값 self 유지). fullscreen·display-capture 미사용. interest-cohort(FLoC)·
+#     browsing-topics(Topics API)는 ad-tech 시그널 누설 차단 차원에서 명시 거부.
 #   - Cross-Origin-Opener-Policy same-origin: 프로세스 격리. OAuth는
 #     full-page redirect라 Google을 popup·iframe으로 안 열기에 안전.
 #
@@ -42,5 +45,5 @@ add_header X-Frame-Options "SAMEORIGIN" always;
 add_header X-Content-Type-Options "nosniff" always;
 add_header X-XSS-Protection "0" always;
 add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=(), usb=(), accelerometer=(), gyroscope=()" always;
+add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=(), usb=(), accelerometer=(), gyroscope=(), clipboard-read=(), fullscreen=(), display-capture=(), interest-cohort=(), browsing-topics=()" always;
 add_header Cross-Origin-Opener-Policy "same-origin" always;


### PR DESCRIPTION
## Summary

2차 보안 감사 백로그의 L11 + M5 + M6 처리. 서버 적용 완료, 검증 통과. 저장소엔 예시 파일·문서만.

| # | 항목 | 적용 |
|---|------|------|
| L11 | Permissions-Policy 5개 directive 추가 (clipboard-read·fullscreen·display-capture·interest-cohort·browsing-topics) | 두 vhost snippet |
| M5 | /oauth/token rate limit 60r/m + burst 100 | conf.d (zone) + location (limit_req) |
| M6 | njs body 가드 — client-supplied client_secret 검출 시 400 reject | js_content + named location 분리 |

## 전제 조건

서버에 `libnginx-mod-http-js` 설치(이미 완료). `njs` CLI 패키지(이미 설치됐던)와는 별개.

## 설계 노트

**M5 — 60r/m + burst 100 선택 근거**: 사용자가 NAT 뒤 단체(교회·학교) 시나리오 우려 제기. 50명 이상 동시 시작 시 같은 public IP라 한 버킷. 60r/m + burst 100은 단체 동시 시작 100명까지 즉시 통과 + 1.7r/s 지속. Google /token이 valid code/refresh_token 없이 어떤 권한도 발급 안 하므로 abuse 측면도 충분.

**M6 — njs로 구현한 이유**: stock nginx의 `if ($request_body ~ ...)`는 REWRITE 단계 평가라 body buffering 전 시점일 수 있음 → 신뢰 불가 (no-op guard 위험). njs `js_content`는 body buffered 후 호출 보장.

**named location의 proxy_pass URI 제약**: `location @name`은 `proxy_pass https://host/path`를 못 가짐. `rewrite ^ /token break` + URI 없는 `proxy_pass https://host`로 우회.

## 검증 결과

```
$ curl -sSI https://dev.anglican.kr/ | grep -i permissions-policy
Permissions-Policy: ...12 directives...

$ # 정상 body — Google에 forward되어 invalid_grant 응답
$ curl -X POST .../oauth/token -d "grant_type=refresh_token&refresh_token=invalid&client_id=test"
{"error":"invalid_grant","error_description":"Bad Request"} HTTP 400

$ # body에 client_secret=fake — Google 도달 전 njs 가드가 차단
$ curl -X POST .../oauth/token -d "grant_type=refresh_token&client_secret=fake&..."
{"error":"invalid_request","error_description":"client_secret must not be sent by client"} HTTP 400

$ # 150 병렬 → burst 100 + 약간 sustain → 102 통과(401) + 48 × 503
$ seq 1 150 | xargs -n1 -P150 -I{} curl ... | sort | uniq -c
    102 401
     48 503
```

## Test plan
- [x] curl로 세 항목 검증 (위 참조)
- [x] `nginx -t` 통과, reload 성공
- [ ] 정상 사용자 첫 연결 + silent refresh 흐름이 깨지지 않는지 SPA 시운전
- [ ] 사용자가 의도적으로 body에 `client_secret=` 보내는 케이스 (테스트 외엔 없음) → 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the `/oauth/token` proxy path and adds request rejection/rate limiting, which could block legitimate auth flows if misconfigured or tuned too aggressively.
> 
> **Overview**
> Hardens the nginx OAuth token BFF by adding IP-based rate limiting for `/oauth/token` and splitting the proxy into an external entry location plus an internal upstream location that injects `client_secret`.
> 
> Introduces an njs `js_content` guard that inspects the buffered form body (with proper URL-decoding of keys) and returns `400` if a client-supplied `client_secret` is present, preventing parameter pollution before forwarding to Google.
> 
> Expands the `Permissions-Policy` header to explicitly disable additional browser capabilities (`clipboard-read`, `fullscreen`, `display-capture`, `interest-cohort`, `browsing-topics`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cf4bea2d3c677c16ccc1d51d60151b4c061cc98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->