### PR TITLE
style: pull-to-refresh 스피너 아이콘 개선 + 동기화 중 스크림

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -954,6 +954,32 @@ body {
 }
 
 /* ── Pull-to-refresh indicator (mobile) ── */
+#pull-refresh-scrim {
+  position: fixed;
+  inset: 0;
+  z-index: 24;
+  pointer-events: none;
+  background: rgba(0, 0, 0, 0.04);
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+[data-theme="dark"] #pull-refresh-scrim {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+#pull-refresh-scrim.ptr-scrim-visible {
+  opacity: 1;
+}
+
+@media (min-width: 769px) {
+  #pull-refresh-scrim { display: none; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  #pull-refresh-scrim { transition: none; }
+}
+
 #pull-refresh-indicator {
   position: fixed;
   top: env(safe-area-inset-top, 0);

--- a/js/app.js
+++ b/js/app.js
@@ -256,6 +256,8 @@ document.addEventListener("visibilitychange", () => {
 
   /** @type {HTMLElement | null} */
   let indicator = null;
+  /** @type {HTMLElement | null} */
+  let scrim = null;
   let startY = 0;
   let delta = 0;
   let active = false;
@@ -272,12 +274,16 @@ document.addEventListener("visibilitychange", () => {
 
   function ensureIndicator() {
     if (indicator) return indicator;
+    scrim = document.createElement("div");
+    scrim.id = "pull-refresh-scrim";
+    scrim.setAttribute("aria-hidden", "true");
+    document.body.appendChild(scrim);
     indicator = document.createElement("div");
     indicator.id = "pull-refresh-indicator";
     indicator.setAttribute("aria-hidden", "true");
     indicator.innerHTML =
-      '<svg class="ptr-icon" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' +
-      '<path d="M21 12a9 9 0 1 1-3.3-7"/><polyline points="21 4 21 12 13 12"/>' +
+      '<svg class="ptr-icon" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" aria-hidden="true">' +
+      '<path d="M21 12a9 9 0 1 1-2.64-6.36"/>' +
       '</svg>';
     document.body.appendChild(indicator);
     return indicator;
@@ -311,6 +317,7 @@ document.addEventListener("visibilitychange", () => {
     ind.style.transition = smooth ? "transform .25s ease, opacity .2s ease" : "none";
     ind.style.transform = "translateX(-50%) translateY(0)";
     ind.style.opacity = "0";
+    if (scrim) scrim.classList.remove("ptr-scrim-visible");
     if (smooth) {
       resetCleanupTimer = setTimeout(() => {
         resetCleanupTimer = null;
@@ -383,6 +390,7 @@ document.addEventListener("visibilitychange", () => {
       resetCleanupTimer = null;
     }
     ind.classList.add("ptr-loading");
+    if (scrim) scrim.classList.add("ptr-scrim-visible");
     ind.style.transition = prefersReducedMotion() ? "none" : "transform .2s ease";
     ind.style.transform = `translateX(-50%) translateY(${PULL_THRESHOLD_PX}px)`;
     ind.style.opacity = "1";


### PR DESCRIPTION
## 요약

pull-to-refresh의 시각 피드백 두 가지 정리.

### 1. 스피너 아이콘 교체

`js/app.js:279-281` — `refresh-cw`(둥근 호 + 화살촉 폴리라인)에서 **iOS 3/4 원호** (`stroke-linecap: round`)로 단순화. 회전 애니메이션과 더 자연스럽게 어울림.

**Before**
```svg
<path d="M21 12a9 9 0 1 1-3.3-7"/><polyline points="21 4 21 12 13 12"/>
```

**After**
```svg
<path d="M21 12a9 9 0 1 1-2.64-6.36"/>
```

### 2. 동기화 중 스크림

`#pull-refresh-scrim` 추가. `ptr-loading` 클래스가 indicator에 붙는 시점에 함께 `ptr-scrim-visible`이 토글되며 0.2s 페이드.

| 모드 | 배경색 |
|---|---|
| Light | `rgba(0, 0, 0, 0.04)` |
| Dark (`[data-theme="dark"]`) | `rgba(255, 255, 255, 0.04)` |

거의 인지되지 않는 톤이지만 sync 동안 화면이 한 톤 가라앉아 "뭔가 진행 중"이라는 신호는 남음.

- `pointer-events: none` — 터치를 가로막지 않음
- `z-index: 24` — indicator(25) 아래
- `@media (min-width: 769px) { display: none }` — 모바일 전용
- `@media (prefers-reduced-motion: reduce) { transition: none }`

## 테스트 계획

- [ ] 모바일 브라우저(`max-width: 768px`)에서 상단 당기기 → 스피너가 부드럽게 회전, 배경 한 톤 가라앉음 확인
- [ ] 다크 모드에서 동일 테스트 → 흰 톤 4% 스크림이 같은 무게감으로 깔리는지
- [ ] sync 종료 후 스크림 페이드 아웃되며 indicator도 사라지는지
- [ ] 데스크톱(>=769px)에서는 PTR/스크림 모두 표시되지 않는지
- [ ] `prefers-reduced-motion: reduce`에서 스크림 페이드 없이 즉시 토글되는지


---
_Generated by [Claude Code](https://claude.ai/code/session_01HcX7pt7TwkWwEZDD3mCjY8)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only changes to pull-to-refresh visuals (new scrim overlay and updated SVG), with minimal behavioral impact beyond toggling a CSS class during sync.
> 
> **Overview**
> Improves pull-to-refresh feedback on mobile by adding a subtle full-screen scrim (`#pull-refresh-scrim`) that fades in while a sync is running and respects dark mode, reduced-motion, and desktop breakpoints.
> 
> Updates the pull-to-refresh indicator’s SVG to a simpler iOS-style arc and toggles the scrim visibility alongside the existing `ptr-loading` state during trigger/reset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd0af037254e705bde503c7df98b03b3e55f75a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->