### PR TITLE
chore: app.js JSDoc 도입 PR-2 — 설정 팝오버·외관·헬퍼 (ADR-012 2차)

### DIFF
--- a/docs/design/app-typescript-migration.md
+++ b/docs/design/app-typescript-migration.md
@@ -35,6 +35,7 @@ ADR-012의 1차 적용 범위(`js/sync/*`, `js/drive-sync.js`, `js/search-worker
 ### 2.1 ADR-012 1차 적용 현황 (Phase 2h 종료 시점)
 
 `// @ts-check` + JSDoc 적용 완료:
+
 - `js/sync/state-machine.js`, `transport.js`, `store-v2.js`, `debug-log.js`, `refresh-store.js`
 - `js/drive-sync.js`
 - `js/search-worker.js` (`tsconfig.worker.json`, `lib: WebWorker`)
@@ -43,49 +44,49 @@ ADR-012의 1차 적용 범위(`js/sync/*`, `js/drive-sync.js`, `js/search-worker
 
 ### 2.2 app.js 섹션 지도 (5,854줄, 41개 섹션)
 
-| 라인 | 섹션 | 줄 수 |
-|---|---|---|
-| L1-L34 | 모듈 헤드 (DOM anchor + 모듈 상태) | 34 |
-| L35-L81 | Accessibility | 47 |
-| L82-L108 | Reading position persistence | 27 |
-| L109-L188 | Bookmark state | 80 |
-| L189-L241 | Audio cache LRU helpers (ADR-016) | 53 |
-| L242-L412 | Pull-to-refresh | 171 |
-| L413-L471 | Search history helpers | 59 |
-| L472-L490 | Font size | 19 |
-| L491-L513 | Cache management | 23 |
-| L514-L893 | Settings popover | 380 |
-| L894-L961 | Icon recoloring | 68 |
-| L962-L1006 | Color scheme | 45 |
-| L1007-L1048 | Theme | 42 |
-| L1049-L1070 | Book order | 22 |
-| L1071-L1114 | Launch Screen | 44 |
-| L1115-L1136 | Helpers | 22 |
-| L1137-L1159 | Bookmark storage helpers | 23 |
-| L1160-L1270 | Verse spec utilities | 111 |
-| L1271-L1343 | Bookmark query helpers | 73 |
-| L1344-L1617 | Drag & drop helpers | 274 |
-| L1618-L1654 | Data fetching | 37 |
-| L1655-L1856 | Rendering helpers | 202 |
-| L1857-L2489 | Views | 633 |
-| L2490-L2790 | Routing | 301 |
-| L2791-L3021 | Audio Player | 231 |
-| L3022-L3277 | Search | 256 |
-| L3278-L3340 | Search input handlers | 63 |
-| L3341-L3389 | Search bottom sheet | 49 |
-| L3390-L4006 | Search history panel controller | 617 |
-| L4007-L4026 | Compact Header on Scroll | 20 |
-| L4027-L4116 | PWA install detection | 90 |
-| L4117-L4414 | Install guide modal | 298 |
-| L4415-L4453 | Install nudge auto-show | 39 |
-| L4454-L4655 | Bookmark UI | 202 |
-| L4656-L5171 | Bookmark tree rendering | 516 |
-| L5172-L5359 | Save bookmark modal | 188 |
-| L5360-L5438 | Merge dialog | 79 |
-| L5439-L5555 | Export/Import bookmarks | 117 |
-| L5556-L5607 | Verse selection mode | 52 |
-| L5608-L5754 | Drawer toolbar | 147 |
-| L5755-L5854 | Service Worker registration | 100 |
+| 라인        | 섹션                               | 줄 수 |
+| ----------- | ---------------------------------- | ----- |
+| L1-L34      | 모듈 헤드 (DOM anchor + 모듈 상태) | 34    |
+| L35-L81     | Accessibility                      | 47    |
+| L82-L108    | Reading position persistence       | 27    |
+| L109-L188   | Bookmark state                     | 80    |
+| L189-L241   | Audio cache LRU helpers (ADR-016)  | 53    |
+| L242-L412   | Pull-to-refresh                    | 171   |
+| L413-L471   | Search history helpers             | 59    |
+| L472-L490   | Font size                          | 19    |
+| L491-L513   | Cache management                   | 23    |
+| L514-L893   | Settings popover                   | 380   |
+| L894-L961   | Icon recoloring                    | 68    |
+| L962-L1006  | Color scheme                       | 45    |
+| L1007-L1048 | Theme                              | 42    |
+| L1049-L1070 | Book order                         | 22    |
+| L1071-L1114 | Launch Screen                      | 44    |
+| L1115-L1136 | Helpers                            | 22    |
+| L1137-L1159 | Bookmark storage helpers           | 23    |
+| L1160-L1270 | Verse spec utilities               | 111   |
+| L1271-L1343 | Bookmark query helpers             | 73    |
+| L1344-L1617 | Drag & drop helpers                | 274   |
+| L1618-L1654 | Data fetching                      | 37    |
+| L1655-L1856 | Rendering helpers                  | 202   |
+| L1857-L2489 | Views                              | 633   |
+| L2490-L2790 | Routing                            | 301   |
+| L2791-L3021 | Audio Player                       | 231   |
+| L3022-L3277 | Search                             | 256   |
+| L3278-L3340 | Search input handlers              | 63    |
+| L3341-L3389 | Search bottom sheet                | 49    |
+| L3390-L4006 | Search history panel controller    | 617   |
+| L4007-L4026 | Compact Header on Scroll           | 20    |
+| L4027-L4116 | PWA install detection              | 90    |
+| L4117-L4414 | Install guide modal                | 298   |
+| L4415-L4453 | Install nudge auto-show            | 39    |
+| L4454-L4655 | Bookmark UI                        | 202   |
+| L4656-L5171 | Bookmark tree rendering            | 516   |
+| L5172-L5359 | Save bookmark modal                | 188   |
+| L5360-L5438 | Merge dialog                       | 79    |
+| L5439-L5555 | Export/Import bookmarks            | 117   |
+| L5556-L5607 | Verse selection mode               | 52    |
+| L5608-L5754 | Drawer toolbar                     | 147   |
+| L5755-L5854 | Service Worker registration        | 100   |
 
 ### 2.3 핫스팟 분포
 
@@ -105,15 +106,15 @@ ADR-012의 1차 적용 범위(`js/sync/*`, `js/drive-sync.js`, `js/search-worker
 
 ### 진행 매트릭스
 
-| PR | 영역 | 라인 범위 | 상태 | 머지 PR |
-|---|---|---|---|---|
-| PR-1 | 헤드 + 접근성 + 읽기위치 + 오디오 LRU + PTR + 검색 히스토리 + 폰트 + 캐시 | L1-L513 | 작성 완료 (커밋 대기) | — |
-| PR-2 | 설정 팝오버 + 아이콘 + 컬러 스킴 + 테마 + 책 순서 + 런치 스크린 + 헬퍼 + 북마크 스토리지 | L514-L1159 | 대기 | — |
-| PR-3 | 절 스펙 + 북마크 쿼리 + 드래그앤드롭 + 데이터 페칭 + 렌더링 헬퍼 + Views | L1160-L2489 | 대기 | — |
-| PR-4 | 라우팅 + 오디오 플레이어 | L2490-L3021 | 대기 | — |
-| PR-5 | 검색 + 검색 시트 + 검색 히스토리 패널 | L3022-L4006 | 대기 | — |
-| PR-6 | 컴팩트 헤더 + PWA 감지 + 설치 안내 + 북마크 UI + 트리 렌더링 + 저장/병합 모달 | L4007-L5438 | 대기 | — |
-| PR-7 | 내보내기/가져오기 + 절 선택 + 드로어 + SW 등록 + 최종 통합 (`// @ts-check` 영구화, `tsconfig.app.json` 삭제) | L5439-L5854 | 대기 | — |
+| PR   | 영역                                                                                                         | 라인 범위   | 상태                  | 머지 PR |
+| ---- | ------------------------------------------------------------------------------------------------------------ | ----------- | --------------------- | ------- |
+| PR-1 | 헤드 + 접근성 + 읽기위치 + 오디오 LRU + PTR + 검색 히스토리 + 폰트 + 캐시                                    | L1-L513     | 머지 완료             | [#81](https://github.com/anglican-kr/common-bible/pull/81) |
+| PR-2 | 설정 팝오버 + 아이콘 + 컬러 스킴 + 테마 + 책 순서 + 런치 스크린 + 헬퍼 + 북마크 스토리지                     | L595-L1273 (PR-1 머지 후 라인) | 작성 완료 (커밋 대기) | —       |
+| PR-3 | 절 스펙 + 북마크 쿼리 + 드래그앤드롭 + 데이터 페칭 + 렌더링 헬퍼 + Views                                     | L1160-L2489 | 대기                  | —       |
+| PR-4 | 라우팅 + 오디오 플레이어                                                                                     | L2490-L3021 | 대기                  | —       |
+| PR-5 | 검색 + 검색 시트 + 검색 히스토리 패널                                                                        | L3022-L4006 | 대기                  | —       |
+| PR-6 | 컴팩트 헤더 + PWA 감지 + 설치 안내 + 북마크 UI + 트리 렌더링 + 저장/병합 모달                                | L4007-L5438 | 대기                  | —       |
+| PR-7 | 내보내기/가져오기 + 절 선택 + 드로어 + SW 등록 + 최종 통합 (`// @ts-check` 영구화, `tsconfig.app.json` 삭제) | L5439-L5854 | 대기                  | —       |
 
 ---
 
@@ -126,10 +127,10 @@ ADR-012의 1차 적용 범위(`js/sync/*`, `js/drive-sync.js`, `js/search-worker
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "checkJs": true,
-    "noImplicitAny": false   // PR-7에서 true로 전환 후 파일 자체 삭제
+    "noImplicitAny": false, // PR-7에서 true로 전환 후 파일 자체 삭제
   },
   "include": ["js/app.js", "js/types.d.ts"],
-  "exclude": ["js/search-worker.js"]
+  "exclude": ["js/search-worker.js"],
 }
 ```
 
@@ -212,7 +213,9 @@ CLAUDE.md `tests/e2e/` 절차를 따라 사용자가 수동 실행:
 
 ## 8. 진행 일지
 
-| 일자 | 단계 | 내용 |
-|---|---|---|
-| 2026-05-09 | PR-1 시작 | 본 설계 문서 초안 작성, `feat/app-jsdoc-pr1` 브랜치 분기 |
+| 일자       | 단계           | 내용                                                                                                                                                                                                                                                                                                        |
+| ---------- | -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-05-09 | PR-1 시작      | 본 설계 문서 초안 작성, `feat/app-jsdoc-pr1` 브랜치 분기                                                                                                                                                                                                                                                    |
 | 2026-05-09 | PR-1 작성 완료 | `tsconfig.app.json` 신설, `js/types.d.ts`에 5종(`ReadingPosition`, `AudioPosition`, `SearchHistoryList`, `VerseSelectDrag`, `DragState`) 추가, `js/app.js` L1-L513 JSDoc 보강. baseline 428 → 잔여 282 (PR-1 영역 0). main `tsconfig.json`/`tsconfig.worker.json` 0 error 회귀 없음, 유닛 테스트 111건 통과 |
+| 2026-05-09 | PR-1 머지 (#81) | CI Unit tests + Cursor Bugbot 모두 green, main 통합 |
+| 2026-05-09 | PR-2 작성 완료 | `js/types.d.ts`에 4종(`ColorSchemeId`, `ThemeMode`, `BookOrderKind`, `ColorSchemeEntry`) 추가, `js/app.js` L595-L1273 JSDoc 보강. baseline 282 → 잔여 294. PR-2 영역 0 에러. **`el()` generic narrow의 부작용으로 PR-3+ 영역(L1515-L2686)에 잠재 결함 22건 신규 노출** — 후속 PR에서 흡수 (이전엔 implicit any에 묻혀있던 strictNullChecks 위반). main + worker tsc 0 error, 유닛 111건 통과 |

--- a/js/app.js
+++ b/js/app.js
@@ -6,6 +6,10 @@
 /** @typedef {import("./types").SearchHistoryList} SearchHistoryList */
 /** @typedef {import("./types").VerseSelectDrag} VerseSelectDrag */
 /** @typedef {import("./types").DragState} DragState */
+/** @typedef {import("./types").ColorSchemeId} ColorSchemeId */
+/** @typedef {import("./types").ThemeMode} ThemeMode */
+/** @typedef {import("./types").BookOrderKind} BookOrderKind */
+/** @typedef {import("./types").ColorSchemeEntry} ColorSchemeEntry */
 
 const DATA_DIR = "/data";
 // Psalms use "편" instead of "장" as the chapter unit
@@ -123,6 +127,7 @@ const SEARCH_HISTORY_MAX = 30;       // storage cap (LRU)
 const SEARCH_HISTORY_VISIBLE = 10;   // visible by default; rest behind "더 보기"
 const FONT_SIZES = [16, 18, 20, 22, 24];
 
+/** @type {ReadonlyArray<ColorSchemeEntry>} */
 const COLOR_SCHEMES = [
   { id: "navy",       name: "네이비",   swatch: "#1e3a5f", iconBg: "#1a1a2e" },
   { id: "terracotta", name: "버건디",   swatch: "#6b3a2a", iconBg: "#6b3a2a" },
@@ -594,7 +599,7 @@ async function clearAllCaches() {
 
 // ── Settings popover ──
 
-const $settingsAnchor = document.getElementById("settings-anchor");
+const $settingsAnchor = _$("settings-anchor");
 
 function initSettings() {
   clearNode($settingsAnchor);
@@ -932,6 +937,7 @@ function initSettings() {
     popover.style.right = `${window.innerWidth - rect.right}px`;
   }
 
+  /** @type {(() => void) | null} */
   let cleanupTrap = null;
 
   btn.addEventListener("click", (e) => {
@@ -946,7 +952,7 @@ function initSettings() {
       // pointer activation, focus the popover container itself to avoid a
       // stray :focus-visible ring on the first button (iOS Safari).
       if (e.detail === 0) {
-        const first = popover.querySelector('button, a[href], input');
+        const first = /** @type {HTMLElement | null} */ (popover.querySelector('button, a[href], input'));
         if (first) first.focus();
       } else {
         popover.focus();
@@ -957,7 +963,8 @@ function initSettings() {
   });
 
   document.addEventListener("click", (e) => {
-    if (!popover.hidden && !wrapper.contains(e.target) && !popover.contains(e.target)) {
+    const t = e.target;
+    if (!popover.hidden && t instanceof Node && !wrapper.contains(t) && !popover.contains(t)) {
       popover.hidden = true;
       btn.setAttribute("aria-expanded", "false");
       if (cleanupTrap) { cleanupTrap(); cleanupTrap = null; }
@@ -974,6 +981,7 @@ function initSettings() {
 
 // ── Icon recoloring ──
 
+/** @param {string} hex @returns {[number, number, number]} */
 function hexToRgb(hex) {
   return [parseInt(hex.slice(1, 3), 16), parseInt(hex.slice(3, 5), 16), parseInt(hex.slice(5, 7), 16)];
 }
@@ -989,6 +997,7 @@ let _iconGeneration = 0;
 // Loads the source icon's pixel data. Not cached: a decoded 512×512 ImageData is
 // ~1 MB and color-scheme changes are rare; releasing it after use keeps idle
 // memory low. The asset is served from the SW cache, so re-reads are cheap.
+/** @returns {Promise<ImageData>} */
 function loadOrigIcon() {
   return new Promise((resolve, reject) => {
     const img = new Image();
@@ -997,6 +1006,7 @@ function loadOrigIcon() {
       canvas.width = img.naturalWidth;
       canvas.height = img.naturalHeight;
       const ctx = canvas.getContext("2d");
+      if (!ctx) { reject(new Error("Canvas 2D context unavailable")); return; }
       ctx.drawImage(img, 0, 0);
       resolve(ctx.getImageData(0, 0, canvas.width, canvas.height));
     };
@@ -1005,6 +1015,7 @@ function loadOrigIcon() {
   });
 }
 
+/** @param {ColorSchemeEntry} scheme */
 function updateAppIcons(scheme) {
   // Capture the generation at dispatch time; discard the result if a newer
   // applyColorScheme call has already superseded this one.
@@ -1021,6 +1032,7 @@ function updateAppIcons(scheme) {
       canvas.width = origData.width;
       canvas.height = origData.height;
       const ctx = canvas.getContext("2d");
+      if (!ctx) return;
       const d = origData.data;
       for (let i = 0; i < d.length; i += 4) {
         // Normalize luminance: 0 = original bg, 1 = white cross
@@ -1032,9 +1044,9 @@ function updateAppIcons(scheme) {
       }
       ctx.putImageData(origData, 0, 0);
       const dataUrl = canvas.toDataURL("image/png");
-      const faviconLink = document.querySelector("link[rel='icon']");
+      const faviconLink = /** @type {HTMLLinkElement | null} */ (document.querySelector("link[rel='icon']"));
       if (faviconLink) faviconLink.href = dataUrl;
-      const appleLink = document.querySelector("link[rel='apple-touch-icon']");
+      const appleLink = /** @type {HTMLLinkElement | null} */ (document.querySelector("link[rel='apple-touch-icon']"));
       if (appleLink) appleLink.href = dataUrl;
     }).catch(() => { /* non-critical */ });
   });
@@ -1042,14 +1054,17 @@ function updateAppIcons(scheme) {
 
 // ── Color scheme ──
 
+/** @returns {ColorSchemeId} */
 function loadColorScheme() {
   try {
     const v = localStorage.getItem(COLOR_SCHEME_KEY);
-    if (COLOR_SCHEMES.some(s => s.id === v)) return v;
+    const found = COLOR_SCHEMES.find((s) => s.id === v);
+    if (found) return found.id;
   } catch (_) {}
   return "navy";
 }
 
+/** @param {ColorSchemeId} scheme */
 function saveColorScheme(scheme) {
   try { localStorage.setItem(COLOR_SCHEME_KEY, scheme); window.syncStoreV2?.saveSetting("colorScheme", scheme); if (window.driveSync) window.driveSync.scheduleUpload(); } catch (_) {}
 }
@@ -1060,21 +1075,22 @@ function saveColorScheme(scheme) {
 const DEFAULT_FAVICON_HREF = "/favicon.ico";
 const DEFAULT_APPLE_ICON_HREF = "/assets/icons/icon-512-maskable.png";
 
+/** @param {string} schemeName */
 function applyColorScheme(schemeName) {
   // Invalidate any in-flight updateAppIcons call from a previous scheme.
   _iconGeneration++;
-  const scheme = COLOR_SCHEMES.find(s => s.id === schemeName) || COLOR_SCHEMES[0];
+  const scheme = COLOR_SCHEMES.find((s) => s.id === schemeName) || COLOR_SCHEMES[0];
   if (schemeName === "navy") {
     document.documentElement.removeAttribute("data-color-scheme");
     updateThemeMetaColor();
     // Default scheme: shipped favicon/apple-touch-icon already match. Skipping
     // the canvas recolor saves ~1 MB ImageData on every launch. If a previous
     // session left a recolored data: URL on these <link>s, restore the originals.
-    const faviconLink = document.querySelector("link[rel='icon']");
+    const faviconLink = /** @type {HTMLLinkElement | null} */ (document.querySelector("link[rel='icon']"));
     if (faviconLink && faviconLink.href !== new URL(DEFAULT_FAVICON_HREF, location.href).href) {
       faviconLink.href = DEFAULT_FAVICON_HREF;
     }
-    const appleLink = document.querySelector("link[rel='apple-touch-icon']");
+    const appleLink = /** @type {HTMLLinkElement | null} */ (document.querySelector("link[rel='apple-touch-icon']"));
     if (appleLink && appleLink.href !== new URL(DEFAULT_APPLE_ICON_HREF, location.href).href) {
       appleLink.href = DEFAULT_APPLE_ICON_HREF;
     }
@@ -1087,6 +1103,7 @@ function applyColorScheme(schemeName) {
 
 // ── Theme ──
 
+/** @returns {ThemeMode} */
 function loadTheme() {
   try {
     const saved = localStorage.getItem(THEME_KEY);
@@ -1095,10 +1112,12 @@ function loadTheme() {
   return "system";
 }
 
+/** @param {string} theme */
 function saveTheme(theme) {
   try { localStorage.setItem(THEME_KEY, theme); window.syncStoreV2?.saveSetting("theme", theme); if (window.driveSync) window.driveSync.scheduleUpload(); } catch (_) {}
 }
 
+/** @type {((e: MediaQueryListEvent) => void) | null} */
 let _systemThemeListener = null;
 const _darkMQ = window.matchMedia("(prefers-color-scheme: dark)");
 
@@ -1110,6 +1129,7 @@ function updateThemeMetaColor() {
   });
 }
 
+/** @param {string} theme */
 function applyTheme(theme) {
   if (_systemThemeListener) {
     _darkMQ.removeEventListener("change", _systemThemeListener);
@@ -1129,6 +1149,7 @@ function applyTheme(theme) {
 
 // ── Book order ──
 
+/** @returns {BookOrderKind} */
 function loadBookOrder() {
   try {
     const v = localStorage.getItem(BOOK_ORDER_KEY);
@@ -1137,6 +1158,7 @@ function loadBookOrder() {
   return "canonical";
 }
 
+/** @param {string} order */
 function saveBookOrder(order) {
   try { localStorage.setItem(BOOK_ORDER_KEY, order); window.syncStoreV2?.saveSetting("bookOrder", order); if (window.driveSync) window.driveSync.scheduleUpload(); } catch (_) {}
 }
@@ -1195,6 +1217,17 @@ function dismissLaunchScreen() {
 
 // ── Helpers ──
 
+/**
+ * Generic narrow: `el("button", ...)` returns HTMLButtonElement, `el("input", ...)`
+ * returns HTMLInputElement, etc. — so call sites can read .value/.disabled/.files
+ * without per-call casts. `attrs` accepts mixed values (booleans for readOnly,
+ * strings for aria-*, numbers for rows) since the DOM coerces in setAttribute.
+ * @template {keyof HTMLElementTagNameMap} K
+ * @param {K} tag
+ * @param {Record<string, any> | null} [attrs]
+ * @param {...(Node | string | null | undefined)} children
+ * @returns {HTMLElementTagNameMap[K]}
+ */
 function el(tag, attrs, ...children) {
   const node = document.createElement(tag);
   if (attrs) {
@@ -1211,16 +1244,21 @@ function el(tag, attrs, ...children) {
   return node;
 }
 
+/** @param {Node} node */
 function clearNode(node) {
   while (node.firstChild) node.removeChild(node.firstChild);
 }
 
 // ── Bookmark storage helpers ──
 
+/** @returns {string} */
 function generateId() {
   return Date.now().toString(36) + Math.random().toString(36).slice(2);
 }
 
+/**
+ * @returns {import("./types").BookmarkTreeNode[]}
+ */
 function loadBookmarks() {
   if (window.syncStoreV2) return window.syncStoreV2.loadBookmarks();
   try {
@@ -1229,6 +1267,7 @@ function loadBookmarks() {
   } catch (_) { return []; }
 }
 
+/** @param {import("./types").BookmarkTreeNode[]} store */
 function saveBookmarks(store) {
   try {
     localStorage.setItem(BOOKMARK_KEY, JSON.stringify(store));

--- a/js/types.d.ts
+++ b/js/types.d.ts
@@ -397,6 +397,29 @@ export interface DragState {
   origTop: number;
 }
 
+// `COLOR_SCHEME_KEY`. Drives both data-color-scheme attribute and recolored
+// favicon/apple-touch-icon. The COLOR_SCHEMES array's `id` field is the
+// authoritative source — keep these in sync if a scheme is added/removed.
+export type ColorSchemeId = "navy" | "terracotta" | "green" | "purple";
+
+// `THEME_KEY`. "system" defers to prefers-color-scheme; light/dark are
+// explicit overrides.
+export type ThemeMode = "dark" | "light" | "system";
+
+// `BOOK_ORDER_KEY`. Whether deuterocanonical books are shown in their own
+// (canonical/Korean Anglican Communion) division or interleaved with the OT
+// (vulgate/Catholic ordering).
+export type BookOrderKind = "canonical" | "vulgate";
+
+// One entry of the COLOR_SCHEMES module-level array (app.js). `iconBg` drives
+// the runtime canvas recolor of the favicon/apple-touch-icon.
+export interface ColorSchemeEntry {
+  id: ColorSchemeId;
+  name: string;
+  swatch: string;
+  iconBg: string;
+}
+
 // ── Window augmentation ──────────────────────────────────────────────────────
 
 declare global {


### PR DESCRIPTION
## Summary

ADR-012 2차 적용 7단계 분할의 **2번째 PR**. PR-1([#81](https://github.com/anglican-kr/common-bible/pull/81)) 머지 후 라인 기준 **L595-L1273** — 설정 팝오버, 아이콘 리컬러, 컬러 스킴, 테마, 책 순서, 런치 스크린, `el`/`clearNode`, 북마크 스토리지 헬퍼.

- `js/types.d.ts`에 도메인 타입 4종 추가: `ColorSchemeId`, `ThemeMode`, `BookOrderKind`, `ColorSchemeEntry`
- `js/app.js` JSDoc + 타입 가드
  - `$settingsAnchor`를 PR-1의 `_$` 헬퍼로 통합 (anchor null 노이즈 제거)
  - `canvas.getContext("2d")` → `if (!ctx) return/reject` 가드 (`loadOrigIcon`, `updateAppIcons`)
  - `link[rel='icon']` / `link[rel='apple-touch-icon']` → `HTMLLinkElement` cast (4곳)
  - `COLOR_SCHEMES`를 `ReadonlyArray<ColorSchemeEntry>`로 narrow → `scheme.id`가 `ColorSchemeId`로 자동 추론
  - `cleanupTrap`(`(() => void) \| null`), `_systemThemeListener`(`((e: MediaQueryListEvent) => void) \| null`) 모듈 상태 narrow
  - `el()` generic narrow: `el(\"button\", ...)` → `HTMLButtonElement`, `el(\"input\", ...)` → `HTMLInputElement` 등으로 호출 측에서 per-call cast 없이 `.value` / `.disabled` / `.files` 접근 가능
  - 함수 시그니처 + 반환 타입 JSDoc
- `docs/design/app-typescript-migration.md` 진행 일지 갱신

## 알려진 부작용 (의도된 노출)

`el()` generic narrow의 부작용으로 **PR-3+ 영역(L1515-L2686)에 잠재 결함 22건**이 신규 노출됨. 이전엔 `el()` 반환이 implicit any였기 때문에 strictNullChecks 위반이 묻혀있었던 것. 후속 PR에서 자연스럽게 흡수.

| 분류 | 개수 | 예시 |
|---|---|---|
| `e.target` EventTarget narrow 누락 | ~8 | L1822, L1830, L1884, L1892, L2368, L2384, L2394 |
| `Element`에서 `.dataset` / `.focus` / `.contains` 접근 | ~6 | L1515, L1703, L1815, L1877, L2499 |
| `string \| null` parseInt/contains 인자 | ~4 | L2515, L2522, L2532, L2623 |
| 기타 (booksPromise, 빈 객체 destructure 등) | ~4 | L1743, L2045, L2686 |

## Test plan

- [x] `npx tsc -p tsconfig.app.json --noEmit` — baseline 282 → 잔여 294 (PR-2 영역 L595-L1273 **0 error**)
- [x] `npx tsc -p tsconfig.json --noEmit` — 0 error (회귀 없음)
- [x] `npx tsc -p tsconfig.worker.json --noEmit` — 0 error
- [x] `node --test tests/unit/*.test.js` — 111/111 pass
- [ ] e2e 회귀는 PR-7 머지 후 일괄 (CLAUDE.md 표준 — 코드 동작 변경 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly adds JSDoc/types to enable stricter TypeScript checking, with only small behavioral tweaks (extra null/instance guards) in DOM/canvas code paths.
> 
> **Overview**
> Continues the ADR-012 `app.js` TypeScript migration by adding JSDoc typings across the settings popover and appearance-related helpers (color scheme, theme, book order), including a generic-typed `el()` helper and tighter typing for module state/listeners.
> 
> Introduces new shared domain types in `js/types.d.ts` (`ColorSchemeId`, `ThemeMode`, `BookOrderKind`, `ColorSchemeEntry`) and updates `COLOR_SCHEMES`/setting loaders to use them, plus adds defensive guards/casts around `canvas.getContext`, `e.target`, and icon `<link>` lookups.
> 
> Updates the migration design doc progress tables/log to mark PR-1 merged and PR-2 completed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a924c08aa8b02ca405511e405c14cade0fa9b17c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->