### PR TITLE
chore: app.js JSDoc 도입 PR-3 — 절 스펙·북마크·드래그·렌더링·Views (ADR-012 2차)

### DIFF
--- a/docs/design/app-typescript-migration.md
+++ b/docs/design/app-typescript-migration.md
@@ -109,8 +109,8 @@ ADR-012의 1차 적용 범위(`js/sync/*`, `js/drive-sync.js`, `js/search-worker
 | PR   | 영역                                                                                                         | 라인 범위   | 상태                  | 머지 PR |
 | ---- | ------------------------------------------------------------------------------------------------------------ | ----------- | --------------------- | ------- |
 | PR-1 | 헤드 + 접근성 + 읽기위치 + 오디오 LRU + PTR + 검색 히스토리 + 폰트 + 캐시                                    | L1-L513     | 머지 완료             | [#81](https://github.com/anglican-kr/common-bible/pull/81) |
-| PR-2 | 설정 팝오버 + 아이콘 + 컬러 스킴 + 테마 + 책 순서 + 런치 스크린 + 헬퍼 + 북마크 스토리지                     | L595-L1273 (PR-1 머지 후 라인) | 작성 완료 (커밋 대기) | —       |
-| PR-3 | 절 스펙 + 북마크 쿼리 + 드래그앤드롭 + 데이터 페칭 + 렌더링 헬퍼 + Views                                     | L1160-L2489 | 대기                  | —       |
+| PR-2 | 설정 팝오버 + 아이콘 + 컬러 스킴 + 테마 + 책 순서 + 런치 스크린 + 헬퍼 + 북마크 스토리지                     | L595-L1273 | 머지 완료             | [#82](https://github.com/anglican-kr/common-bible/pull/82) |
+| PR-3 | 절 스펙 + 북마크 쿼리 + 드래그앤드롭 + 데이터 페칭 + 렌더링 헬퍼 + Views                                     | L1280-L2630 (PR-2 머지 후 라인) | 작성 완료 (커밋 대기) | —       |
 | PR-4 | 라우팅 + 오디오 플레이어                                                                                     | L2490-L3021 | 대기                  | —       |
 | PR-5 | 검색 + 검색 시트 + 검색 히스토리 패널                                                                        | L3022-L4006 | 대기                  | —       |
 | PR-6 | 컴팩트 헤더 + PWA 감지 + 설치 안내 + 북마크 UI + 트리 렌더링 + 저장/병합 모달                                | L4007-L5438 | 대기                  | —       |
@@ -219,3 +219,5 @@ CLAUDE.md `tests/e2e/` 절차를 따라 사용자가 수동 실행:
 | 2026-05-09 | PR-1 작성 완료 | `tsconfig.app.json` 신설, `js/types.d.ts`에 5종(`ReadingPosition`, `AudioPosition`, `SearchHistoryList`, `VerseSelectDrag`, `DragState`) 추가, `js/app.js` L1-L513 JSDoc 보강. baseline 428 → 잔여 282 (PR-1 영역 0). main `tsconfig.json`/`tsconfig.worker.json` 0 error 회귀 없음, 유닛 테스트 111건 통과 |
 | 2026-05-09 | PR-1 머지 (#81) | CI Unit tests + Cursor Bugbot 모두 green, main 통합 |
 | 2026-05-09 | PR-2 작성 완료 | `js/types.d.ts`에 4종(`ColorSchemeId`, `ThemeMode`, `BookOrderKind`, `ColorSchemeEntry`) 추가, `js/app.js` L595-L1273 JSDoc 보강. baseline 282 → 잔여 294. PR-2 영역 0 에러. **`el()` generic narrow의 부작용으로 PR-3+ 영역(L1515-L2686)에 잠재 결함 22건 신규 노출** — 후속 PR에서 흡수 (이전엔 implicit any에 묻혀있던 strictNullChecks 위반). main + worker tsc 0 error, 유닛 111건 통과 |
+| 2026-05-09 | PR-2 머지 (#82) | CI Unit tests + Cursor Bugbot 모두 green, main 통합 |
+| 2026-05-09 | PR-3 작성 완료 | `js/types.d.ts`에 5종(`BookEntry`, `BooksData`, `BibleChapter`, `BibleVerse`, `BiblePrologue`) 추가 + `window.booksPromise` 선언 + `ReadingPosition.chapter` `number \| "prologue"` narrow. `js/app.js` L1280-L2630 JSDoc 보강 — Drag/drop dataset narrow, popover handler `e.target` instance 가드, Views의 `closest`/`textContent`/`clipboardData` narrow. PR-2가 노출한 PR-3 영역 22건 모두 해소. baseline 294 → 잔여 280 (PR-3 영역 0). `BookmarkTreeNode` 글로벌 typedef는 store-v2.js가 이미 정의하고 있어 alias 머지가 막힘 — `tsconfig.app.json` include를 `js/**/*.js`로 확장해 store-v2의 글로벌 alias를 app.js에서 참조하도록 통일 (이름 변경 없이). main + worker tsc 0 error, 유닛 111건 통과 |

--- a/js/app.js
+++ b/js/app.js
@@ -10,6 +10,18 @@
 /** @typedef {import("./types").ThemeMode} ThemeMode */
 /** @typedef {import("./types").BookOrderKind} BookOrderKind */
 /** @typedef {import("./types").ColorSchemeEntry} ColorSchemeEntry */
+/** @typedef {import("./types").BookEntry} BookEntry */
+/** @typedef {import("./types").BooksData} BooksData */
+/** @typedef {import("./types").BibleChapter} BibleChapter */
+/** @typedef {import("./types").BiblePrologue} BiblePrologue */
+/** @typedef {import("./types").BibleVerse} BibleVerse */
+// `BookmarkTreeNode` is already declared as a file-global typedef in
+// js/sync/store-v2.js (type aliases don't merge, so re-typedef'ing here
+// would trip TS2300). We reuse that global alias directly. The sub-types
+// `BookmarkTreeBookmark` / `BookmarkTreeFolder` are app.js-only — store-v2
+// only needs the union form.
+/** @typedef {import("./types").BookmarkTreeBookmark} BookmarkTreeBookmark */
+/** @typedef {import("./types").BookmarkTreeFolder} BookmarkTreeFolder */
 
 const DATA_DIR = "/data";
 // Psalms use "편" instead of "장" as the chapter unit
@@ -1280,8 +1292,14 @@ function saveBookmarks(store) {
 // ── Verse spec utilities ──
 
 // "1-5,10-15,3a,3b" → [{start:1,end:5},{start:10,end:15},{start:3,end:3,part:"a"},...]
+/**
+ * @param {string} spec
+ * @returns {Array<{start: number, end: number, part?: string}>}
+ */
 function parseVerseSpec(spec) {
   if (!spec || spec === "all") return [];
+  /** @type {Array<{start: number, end: number, part?: string}>} */
+  const init = [];
   return spec.split(",").reduce((acc, seg) => {
     const trimmed = seg.trim();
     const alphaMatch = trimmed.match(/^(\d+)([a-z])$/);
@@ -1297,11 +1315,16 @@ function parseVerseSpec(spec) {
       if (s > 0) acc.push({ start: Math.min(s, e), end: Math.max(s, e) });
     }
     return acc;
-  }, []);
+  }, init);
 }
 
 // If all rendered spans of a multi-part verse are selected, collapse "3a,3b" → "3".
 // Single-part verses ("3" with no alpha suffix) are unchanged.
+/**
+ * @param {string[]} refs
+ * @param {Element | null | undefined} article
+ * @returns {string[]}
+ */
 function collapseFullVerseRefs(refs, article) {
   if (!article) return refs;
   const selected = new Set(refs);
@@ -1316,10 +1339,10 @@ function collapseFullVerseRefs(refs, article) {
   for (const [n, verseRefs] of Object.entries(byVerse)) {
     // All spans rendered for this verse number
     const allSpanRefs = [...article.querySelectorAll(".verse[data-vref]")]
-      .map(s => s.getAttribute("data-vref"))
-      .filter(r => parseInt(r, 10) === Number(n));
-    const hasAlpha = allSpanRefs.some(r => /[a-z]$/.test(r));
-    const allSelected = allSpanRefs.length > 0 && allSpanRefs.every(r => selected.has(r));
+      .map((s) => s.getAttribute("data-vref") ?? "")
+      .filter((r) => r && parseInt(r, 10) === Number(n));
+    const hasAlpha = allSpanRefs.some((r) => /[a-z]$/.test(r));
+    const allSelected = allSpanRefs.length > 0 && allSpanRefs.every((r) => selected.has(r));
     if (hasAlpha && allSelected) {
       result.push(`${n}`);
     } else {
@@ -1330,6 +1353,7 @@ function collapseFullVerseRefs(refs, article) {
 }
 
 // Compare verse refs: "3" < "3a" < "3b" < "4"
+/** @param {string} a @param {string} b */
 function _compareRefs(a, b) {
   const na = parseInt(a, 10), nb = parseInt(b, 10);
   if (na !== nb) return na - nb;
@@ -1340,6 +1364,7 @@ function _compareRefs(a, b) {
 
 // Array of data-vref strings (e.g. ["3a","3b","5","6","7"]) → "3a,3b,5-7"
 // Consecutive integer-only refs are compressed into ranges; alpha refs kept individually.
+/** @param {string[]} refs @returns {string} */
 function selectedVersesToSpec(refs) {
   if (!refs.length) return "all";
   const unique = [...new Set(refs)].sort(_compareRefs);
@@ -1370,6 +1395,7 @@ function selectedVersesToSpec(refs) {
 }
 
 // Union of two verse spec strings
+/** @param {string} specA @param {string} specB @returns {string} */
 function mergeVerseSpecs(specA, specB) {
   if (specA === "all" || specB === "all") return "all";
   const intRefs = new Set();
@@ -1390,6 +1416,11 @@ function mergeVerseSpecs(specA, specB) {
 
 // ── Bookmark query helpers ──
 
+/**
+ * @param {BookmarkTreeNode[]} store
+ * @param {(item: BookmarkTreeNode, parent: BookmarkTreeNode[]) => unknown} fn
+ * @returns {boolean}
+ */
 function _walkBookmarks(store, fn) {
   for (const item of store) {
     if (fn(item, store) === false) return false;
@@ -1400,7 +1431,13 @@ function _walkBookmarks(store, fn) {
   return true;
 }
 
+/**
+ * @param {string} bookId
+ * @param {number} chapter
+ * @returns {BookmarkTreeBookmark[]}
+ */
 function findExistingChapterBookmarks(bookId, chapter) {
+  /** @type {BookmarkTreeBookmark[]} */
   const results = [];
   _walkBookmarks(loadBookmarks(), (item) => {
     if (item.type === "bookmark" && item.bookId === bookId && item.chapter === chapter) {
@@ -1410,11 +1447,17 @@ function findExistingChapterBookmarks(bookId, chapter) {
   return results;
 }
 
+/**
+ * @param {BookmarkTreeNode[]} store
+ * @param {string} id
+ * @returns {{ item: BookmarkTreeNode, parent: BookmarkTreeNode[], index: number } | null}
+ */
 function _findItemInStore(store, id) {
   for (let i = 0; i < store.length; i++) {
-    if (store[i].id === id) return { item: store[i], parent: store, index: i };
-    if (store[i].type === "folder") {
-      const found = _findItemInStore(store[i].children, id);
+    const it = store[i];
+    if (it.id === id) return { item: it, parent: store, index: i };
+    if (it.type === "folder") {
+      const found = _findItemInStore(it.children, id);
       if (found) return found;
     }
   }
@@ -1422,6 +1465,12 @@ function _findItemInStore(store, id) {
 }
 
 // Returns the parent folder's id (null = root), or undefined if not found.
+/**
+ * @param {BookmarkTreeNode[]} store
+ * @param {string} id
+ * @param {string | null} [parentId]
+ * @returns {string | null | undefined}
+ */
 function _findParentFolderId(store, id, parentId = null) {
   for (const item of store) {
     if (item.id === id) return parentId;
@@ -1433,11 +1482,17 @@ function _findParentFolderId(store, id, parentId = null) {
   return undefined;
 }
 
+/** @param {BookmarkTreeNode[]} store @param {string} id */
 function removeItemById(store, id) {
   const found = _findItemInStore(store, id);
   if (found) found.parent.splice(found.index, 1);
 }
 
+/**
+ * @param {BookmarkTreeNode[]} store
+ * @param {string | null | undefined} folderId
+ * @param {BookmarkTreeNode} item
+ */
 function insertItem(store, folderId, item) {
   if (!folderId) {
     store.push(item);
@@ -1451,6 +1506,12 @@ function insertItem(store, folderId, item) {
   }
 }
 
+/**
+ * @param {BookmarkTreeNode[]} store
+ * @param {number} [depth]
+ * @param {Array<{ id: string, name: string, depth: number }>} [options]
+ * @returns {Array<{ id: string, name: string, depth: number }>}
+ */
 function collectFolderOptions(store, depth = 0, options = []) {
   for (const item of store) {
     if (item.type === "folder") {
@@ -1487,7 +1548,7 @@ function moveBookmarkItem(draggedId, targetId, position) {
 
   if (position === "into") {
     const tf = _findItemInStore(store, targetId);
-    if (tf) tf.item.children.unshift(draggedItem);
+    if (tf && tf.item.type === "folder") tf.item.children.unshift(draggedItem);
     else store.push(draggedItem);
   } else {
     const tf = _findItemInStore(store, targetId);
@@ -1508,10 +1569,14 @@ function _clearDragIndicators() {
     .forEach(n => n.classList.remove("drag-over-before", "drag-over-after", "drag-over-into"));
 }
 
+/**
+ * @param {number} clientX
+ * @param {number} clientY
+ */
 function _updateDragIndicators(clientX, clientY) {
   _clearDragIndicators();
   const hitEl = document.elementFromPoint(clientX, clientY);
-  const target = hitEl?.closest("[data-id]");
+  const target = /** @type {HTMLElement | null} */ (hitEl?.closest("[data-id]"));
   if (!target || target.dataset.id === _dragState?.id) return;
   const rowEl = target.querySelector(".bm-folder-row, .bm-bookmark-row");
   const r = (rowEl || target).getBoundingClientRect();
@@ -1696,11 +1761,12 @@ function _setupDragHandle(li, row) {
       _dragState = null;
       ds.ghost.remove();
       ds.origLi.classList.remove("bm-dragging");
-      const overItem = document.querySelector(".drag-over-before, .drag-over-after, .drag-over-into");
+      const overItem = /** @type {HTMLElement | null} */ (document.querySelector(".drag-over-before, .drag-over-after, .drag-over-into"));
       if (overItem) {
         const pos = overItem.classList.contains("drag-over-into") ? "into"
           : overItem.classList.contains("drag-over-before") ? "before" : "after";
-        moveBookmarkItem(ds.id, overItem.dataset.id, pos);
+        const targetId = overItem.dataset.id;
+        if (targetId) moveBookmarkItem(ds.id, targetId, pos);
       }
       _clearDragIndicators();
     }
@@ -1737,10 +1803,11 @@ function _setupDragHandle(li, row) {
 
 // ── Data fetching ──
 
+/** @returns {Promise<BooksData>} */
 async function loadBooks() {
   if (booksCache) return booksCache;
   // Use pre-fetched promise if available
-  const promise = window.booksPromise || fetch(`${DATA_DIR}/books.json`).then(res => {
+  const promise = window.booksPromise || fetch(`${DATA_DIR}/books.json`).then((res) => {
     if (!res.ok) throw new Error("Failed to load books.json");
     return res.json();
   });
@@ -1748,6 +1815,7 @@ async function loadBooks() {
   return booksCache;
 }
 
+/** @returns {Promise<string>} */
 async function loadVersion() {
   if (appVersion) return appVersion;
   try {
@@ -1760,12 +1828,18 @@ async function loadVersion() {
   return appVersion;
 }
 
+/**
+ * @param {string} bookId
+ * @param {number} chapter
+ * @returns {Promise<BibleChapter>}
+ */
 async function loadChapter(bookId, chapter) {
   const res = await fetch(`${DATA_DIR}/bible/${bookId}-${chapter}.json`);
   if (!res.ok) throw new Error(`Failed to load ${bookId}-${chapter}.json`);
   return res.json();
 }
 
+/** @param {string} bookId @returns {Promise<BiblePrologue>} */
 async function loadPrologue(bookId) {
   const res = await fetch(`${DATA_DIR}/bible/${bookId}-prologue.json`);
   if (!res.ok) throw new Error(`Failed to load ${bookId}-prologue.json`);
@@ -1803,6 +1877,7 @@ function setTitleWithDivisionPicker(activeDivision) {
     popover.appendChild(el("li", null, el("a", { className: cls, href: `/${div}` }, labels[div])));
   }
 
+  /** @type {(() => void) | null} */
   let cleanupTrap = null;
 
   btn.addEventListener("click", () => {
@@ -1811,7 +1886,7 @@ function setTitleWithDivisionPicker(activeDivision) {
     btn.setAttribute("aria-expanded", String(!open));
     if (!open) {
       cleanupTrap = trapFocus(popover);
-      const first = popover.querySelector('a[href]');
+      const first = /** @type {HTMLElement | null} */ (popover.querySelector('a[href]'));
       if (first) first.focus();
     } else if (cleanupTrap) {
       cleanupTrap(); cleanupTrap = null;
@@ -1819,7 +1894,8 @@ function setTitleWithDivisionPicker(activeDivision) {
   });
 
   document.addEventListener("click", (e) => {
-    if (!popover.hidden && !$title.contains(e.target)) {
+    const t = e.target;
+    if (!popover.hidden && t instanceof Node && !$title.contains(t)) {
       popover.hidden = true;
       btn.setAttribute("aria-expanded", "false");
       if (cleanupTrap) { cleanupTrap(); cleanupTrap = null; }
@@ -1827,7 +1903,8 @@ function setTitleWithDivisionPicker(activeDivision) {
   });
 
   popover.addEventListener("click", (e) => {
-    if (e.target.tagName === "A") {
+    const t = e.target;
+    if (t instanceof Element && t.tagName === "A") {
       popover.hidden = true;
       btn.setAttribute("aria-expanded", "false");
       if (cleanupTrap) { cleanupTrap(); cleanupTrap = null; }
@@ -1838,6 +1915,10 @@ function setTitleWithDivisionPicker(activeDivision) {
   $title.appendChild(popover);
 }
 
+/**
+ * @param {BookEntry} book
+ * @param {number} currentCh
+ */
 function setTitleWithChapterPicker(book, currentCh) {
   clearNode($title);
   const unit = chUnit(book.id);
@@ -1865,6 +1946,7 @@ function setTitleWithChapterPicker(book, currentCh) {
   }
   popover.appendChild(grid);
 
+  /** @type {(() => void) | null} */
   let cleanupTrap = null;
 
   btn.addEventListener("click", () => {
@@ -1873,7 +1955,7 @@ function setTitleWithChapterPicker(book, currentCh) {
     btn.setAttribute("aria-expanded", String(!open));
     if (!open) {
       cleanupTrap = trapFocus(popover);
-      const first = popover.querySelector('a[href]');
+      const first = /** @type {HTMLElement | null} */ (popover.querySelector('a[href]'));
       if (first) first.focus();
     } else if (cleanupTrap) {
       cleanupTrap(); cleanupTrap = null;
@@ -1881,7 +1963,8 @@ function setTitleWithChapterPicker(book, currentCh) {
   });
 
   document.addEventListener("click", (e) => {
-    if (!popover.hidden && !$title.contains(e.target)) {
+    const t = e.target;
+    if (!popover.hidden && t instanceof Node && !$title.contains(t)) {
       popover.hidden = true;
       btn.setAttribute("aria-expanded", "false");
       if (cleanupTrap) { cleanupTrap(); cleanupTrap = null; }
@@ -1889,7 +1972,8 @@ function setTitleWithChapterPicker(book, currentCh) {
   });
 
   popover.addEventListener("click", (e) => {
-    if (e.target.tagName === "A") {
+    const t = e.target;
+    if (t instanceof Element && t.tagName === "A") {
       popover.hidden = true;
       btn.setAttribute("aria-expanded", "false");
       if (cleanupTrap) { cleanupTrap(); cleanupTrap = null; }
@@ -2365,7 +2449,9 @@ function renderChapter(data, book, opts) {
   // Announce verse number on click/tap for screen reader users,
   // or toggle verse selection when in select mode.
   article.addEventListener("click", (e) => {
-    const vs = e.target.closest(".verse[data-vref]");
+    const t = e.target;
+    if (!(t instanceof Element)) return;
+    const vs = t.closest(".verse[data-vref]");
     if (!vs) return;
     if (_verseSelectMode) {
       e.stopPropagation(); // selection is handled by pointer events
@@ -2376,22 +2462,25 @@ function renderChapter(data, book, opts) {
 
   // Long-press (300ms) to enter verse selection mode.
   // pointermove only cancels after >10px of movement to tolerate natural finger drift.
+  /** @type {ReturnType<typeof setTimeout> | null} */
   let _longPressTimer = null;
   let _longPressStartX = 0;
   let _longPressStartY = 0;
   article.addEventListener("pointerdown", (e) => {
+    const t = e.target;
+    if (!(t instanceof Element)) return;
     if (_verseSelectMode) {
-      const vs = e.target.closest(".verse[data-vref]");
+      const vs = t.closest(".verse[data-vref]");
       if (!vs) return;
       e.preventDefault(); // prevent text selection during drag
-      const allVerses = [...article.querySelectorAll(".verse[data-vref]")];
-      const startIdx = allVerses.indexOf(vs);
-      const isAdding = !_selectedVerseRefs.has(vs.getAttribute("data-vref"));
+      const allVerses = /** @type {HTMLElement[]} */ ([...article.querySelectorAll(".verse[data-vref]")]);
+      const startIdx = allVerses.indexOf(/** @type {HTMLElement} */ (vs));
+      const isAdding = !_selectedVerseRefs.has(vs.getAttribute("data-vref") ?? "");
       _verseSelectDrag = { startIdx, allVerses, isAdding, moved: false, snapshot: new Set(_selectedVerseRefs) };
       article.setPointerCapture(e.pointerId);
       return;
     }
-    const vs = e.target.closest(".verse[data-vref]");
+    const vs = t.closest(".verse[data-vref]");
     if (!vs) return;
     _longPressStartX = e.clientX;
     _longPressStartY = e.clientY;
@@ -2492,7 +2581,7 @@ function renderChapter(data, book, opts) {
         lastVerse = v;
       }
     }
-    if (!firstVerse) return;
+    if (!firstVerse || !lastVerse) return;
 
     const expanded = document.createRange();
     expanded.setStartBefore(firstVerse);
@@ -2509,17 +2598,19 @@ function renderChapter(data, book, opts) {
     work.querySelectorAll(".stanza-break, .paragraph-break, .pilcrow").forEach((n) => { n.textContent = "\n\n"; });
     work.querySelectorAll(".hemistich-break").forEach((n) => { n.textContent = "\n"; });
 
+    /** @type {number | null} */
     let firstNum = null;
+    /** @type {number | null} */
     let lastNum = null;
     for (const vs of work.querySelectorAll(".verse[data-vref]")) {
-      const n = parseInt(vs.getAttribute("data-vref"), 10);
+      const n = parseInt(vs.getAttribute("data-vref") ?? "", 10);
       if (!Number.isFinite(n)) continue;
       if (firstNum === null) firstNum = n;
       lastNum = n;
     }
     if (firstNum === null) return;
 
-    const plainText = work.textContent
+    const plainText = (work.textContent ?? "")
       .replace(/\u2060/g, "")
       .replace(/[ \t]+\n/g, "\n")
       .replace(/\n{3,}/g, "\n\n")
@@ -2529,6 +2620,7 @@ function renderChapter(data, book, opts) {
       ? `${book.name_ko} ${ch}:${firstNum}`
       : `${book.name_ko} ${ch}:${firstNum}-${lastNum}`;
 
+    if (!e.clipboardData) return;
     e.clipboardData.setData("text/plain", `${plainText}\n\n— ${ref} (공동번역성서)`);
     e.preventDefault();
   });

--- a/js/types.d.ts
+++ b/js/types.d.ts
@@ -362,9 +362,11 @@ export interface DriveSyncFacade {
 // shape uses `verseSpec?: string`) — here `verse` is a single integer
 // populated by the scroll-tracking heuristic. Both shapes are intentional:
 // app.js consumes the local form, the sync layer carries the synced form.
+// `chapter` may be the literal string "prologue" for books that have one
+// (e.g. Sirach prologue) — see ADR-002.
 export interface ReadingPosition {
   bookId: string;
-  chapter: number;
+  chapter: number | "prologue";
   verse: number | null;
 }
 
@@ -420,6 +422,55 @@ export interface ColorSchemeEntry {
   iconBg: string;
 }
 
+// `data/books.json` parse shape. 73 entries; `division` partitions OT/NT/DC,
+// while `OT_SUBCATEGORY` (app.js) further subdivides OT into pentateuch /
+// history / wisdom / prophets. `has_prologue` is true only for sir.
+export interface BookEntry {
+  id: string;
+  name_ko: string;
+  short_name_ko: string;
+  name_en: string;
+  division: "old_testament" | "new_testament" | "deuterocanon";
+  chapter_count: number;
+  has_prologue: boolean;
+}
+
+export type BooksData = ReadonlyArray<BookEntry>;
+
+// `data/bible/{book_id}-{chapter}.json` parse shape. `verses` is the rendered
+// unit; segments hold prose/poetry mix and inter-verse stanza/paragraph cues.
+export interface BibleVerseSegment {
+  type: "prose" | "poetry";
+  text: string;
+  paragraph_break?: boolean;
+}
+
+export interface BibleVerse {
+  number: number;
+  part?: string;
+  range_end?: number;
+  alt_ref?: number | null;
+  chapter_ref?: string;
+  stanza_break?: boolean;
+  text?: string;
+  segments?: BibleVerseSegment[];
+}
+
+export interface BibleChapter {
+  book_id: string;
+  book_name_ko: string;
+  book_name_en: string;
+  chapter: number;
+  has_dual_numbering?: boolean;
+  verses: BibleVerse[];
+}
+
+export interface BiblePrologue {
+  book_id: string;
+  book_name_ko: string;
+  paragraphs: string[];
+}
+
 // ── Window augmentation ──────────────────────────────────────────────────────
 
 declare global {
@@ -443,6 +494,10 @@ declare global {
     // by initDriveSync().
     __pendingRedirectCode?: { code: string; verifier: string };
     __pendingRedirectError?: string;
+
+    // Pre-fetched data/books.json promise (js/pre-fetch.js). app.js's
+    // loadBooks() awaits this when present rather than re-issuing the fetch.
+    booksPromise?: Promise<BooksData>;
 
     // UI side-effects defined in app.js. Optional because state-machine.js
     // guards each call with `typeof ... === "function"`.

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -2,12 +2,18 @@
 // // @ts-check + JSDoc in stages (see docs/design/app-typescript-migration.md).
 // Removed in PR-7 when `// @ts-check` is added to the head of app.js and the
 // main tsconfig.json picks it up via its existing `js/**/*.js` include.
+//
+// `include` matches the main tsconfig because js/sync/store-v2.js declares a
+// file-global `BookmarkTreeNode` @typedef that app.js participates in. With
+// app.js alone in `include`, that alias is invisible and TS reports it as
+// missing across PR-3+ signatures. `noImplicitAny: false` keeps progress
+// gated on null/domain checks only — flipped to `true` in PR-7.
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "checkJs": true,
     "noImplicitAny": false
   },
-  "include": ["js/app.js", "js/types.d.ts"],
+  "include": ["js/**/*.js", "js/types.d.ts"],
   "exclude": ["js/search-worker.js"]
 }


### PR DESCRIPTION
## Summary

ADR-012 2차 적용 7단계 분할의 **3번째 PR**. PR-2([#82](https://github.com/anglican-kr/common-bible/pull/82)) 머지 후 라인 기준 **L1280-L2630** — 절 스펙 유틸, 북마크 쿼리, 드래그앤드롭, 데이터 페칭, 렌더링 헬퍼, Views.

가장 큰 단일 PR (~1,330줄). PR-2가 `el()` generic narrow로 노출했던 PR-3 영역 22건 잠재 결함 모두 해소.

- `js/types.d.ts` 확장
  - 5종 추가: `BookEntry`, `BooksData`, `BibleChapter`, `BibleVerse`, `BiblePrologue`
  - `window.booksPromise` 글로벌 선언 (pre-fetch.js와 app.js 간 핸드오프 타입화)
  - `ReadingPosition.chapter` 를 `number \| \"prologue\"` 로 narrow (Sirach 머리말 케이스, ADR-002)
- `js/app.js` JSDoc + 타입 가드
  - **e.target 가드 패턴**: article click/pointerdown, popover document/popover click 핸들러에 `e.target instanceof Element/Node` 가드 (5곳)
  - **HTMLElement cast**: `closest(\"[data-id]\")` 두 곳, `popover.querySelector('a[href]')` 두 곳
  - **null 가드**: copy 핸들러의 `lastVerse`/`e.clipboardData`, `parseInt(getAttribute(...) ?? \"\", 10)` 두 곳, `work.textContent ?? \"\"`
  - **시그니처 JSDoc**: Verse spec utilities 5개, Bookmark query helpers 7개, Data fetching 4개, 일부 Rendering helpers
  - `_findItemInStore`/`moveBookmarkItem`에서 `BookmarkTreeFolder.children` narrow (`it.type === \"folder\"` 변수 narrow)
- `tsconfig.app.json` include 확장
  - `BookmarkTreeNode` 글로벌 typedef는 store-v2.js에 이미 있고 TS는 type alias 머지가 없음(`Duplicate identifier`). app.js에서 같은 이름을 다시 typedef하지 않고, store-v2의 글로벌 alias를 그대로 참조하도록 `include`를 `js/**/*.js`로 확장. 사용자 의견대로 이름을 통일(=`BookmarkTreeNode` 그대로) — alias 두 개 운영(`BmNode`)은 회피
  - `noImplicitAny: false`는 PR-7까지 유지

## 알려진 부작용 (의도된 노출)

새 시그니처 narrow 효과로 PR-4+ 영역에 잠재 결함 ~8건 추가 노출. 후속 PR에서 자연스럽게 흡수.

## Test plan

- [x] \`npx tsc -p tsconfig.app.json --noEmit\` — baseline 294 → 잔여 280 (PR-3 영역 L1280-L2630 **0 error**)
- [x] \`npx tsc -p tsconfig.json --noEmit\` — 0 error (회귀 없음, BookmarkTreeNode 글로벌 단일화 후)
- [x] \`npx tsc -p tsconfig.worker.json --noEmit\` — 0 error
- [x] \`node --test tests/unit/*.test.js\` — 111/111 pass
- [ ] e2e 회귀는 PR-7 머지 후 일괄 (CLAUDE.md 표준 — 코드 동작 변경 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily adds JSDoc typing and defensive null/instance guards; functional impact should be limited to safer no-op behavior in a few edge cases (e.g., missing `dataset.id`/`clipboardData`).
> 
> **Overview**
> Continues the staged `app.js` TypeScript migration (PR-3 scope) by adding new domain types (`BookEntry`/`BooksData`/`BibleChapter`/`BibleVerse`/`BiblePrologue`), typing `window.booksPromise`, and widening `ReadingPosition.chapter` to `number | "prologue"`.
> 
> Updates `app.js` with JSDoc signatures plus stricter null/instance narrowing around DOM/event handling (e.g., `e.target` guards, `closest()`/`querySelector()` casts, `getAttribute()`/`textContent` fallbacks), and tightens bookmark drag/drop mutations to only treat targets as folders when `type === "folder"`.
> 
> Adjusts `tsconfig.app.json` `include` to `js/**/*.js` so `app.js` can reuse the existing file-global `BookmarkTreeNode` typedef from `js/sync/store-v2.js` during temporary `checkJs` validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9ec88fd286f50f766eb511f0c708d220d39bc2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->