### PR TITLE
chore: app.js JSDoc 도입 PR-7 — 1라운드 종료 (ADR-012 2차)

### DIFF
--- a/docs/decisions/012-typescript-incremental-adoption.md
+++ b/docs/decisions/012-typescript-incremental-adoption.md
@@ -102,3 +102,17 @@ ADR-001은 "프레임워크 없는 Vanilla JS"를 선언하고 있고 ADR-005·0
 - ADR-001: SPA 아키텍처 — 빌드 단계 회피의 출발점
 - ADR-011: 북마크 동기화 — 도메인 타입의 주요 소비자
 - ADR-013: 클라이언트 JS 유닛 테스트 전략 — 같은 사이클에 도입
+
+---
+
+> **개정 (2026-05-09): `js/app.js` 2차 적용 1라운드 완료**
+>
+> 1차 적용에서 보류했던 `js/app.js`(~5,800줄)에 7단계 분할 PR(#81~#87)로 JSDoc + null/도메인 타입 가드를 도입. 살아있는 설계 문서: `docs/design/app-typescript-migration.md`.
+>
+> **추가된 도메인 타입 (`js/types.d.ts`)**: `ReadingPosition`, `AudioPosition`, `SearchHistoryList`, `VerseSelectDrag`, `DragState`, `ColorSchemeId`, `ThemeMode`, `BookOrderKind`, `ColorSchemeEntry`, `BookEntry`, `BooksData`, `BibleVerseSegment`, `BibleVerse`, `BibleChapter`, `BiblePrologue`, `Window.booksPromise`. `ReadingPosition.chapter`는 `number | "prologue"` union으로 narrow.
+>
+> **운영 패턴**: `_$` 헬퍼(L20)로 모든 모듈-수준 anchor를 `getElementById` 결과로 통일(HTMLElement non-null cast). input/button/file input은 사용 측에서 더 narrow한 cast(`HTMLInputElement`, `HTMLButtonElement`).
+>
+> **임시 인프라**: `tsconfig.app.json`(`checkJs: true`, `noImplicitAny: false`)을 두어 단계별 검증. `js/app.js` 헤드의 `// @ts-check` 영구 활성화와 `tsconfig.app.json` 삭제는 **`js/app.js` 파일 분할(modularization) 리팩터링과 결합한 별도 의제로 보류** — 5,800줄 단일 파일에 `noImplicitAny: true`를 일거에 적용하면 ~262 implicit any가 발생하는데, 이를 모듈 단위로 옵트인해 정리하는 게 자연스럽기 때문.
+>
+> **다음 라운드 트리거**: `js/app.js` 분할 리팩터링 의제 시작 시점. 본 ADR 본문의 검토한 대안 표에 "`.ts` 파일 + tsc 빌드 산출물 배포: ❌ ADR-001 SPA 단순성 훼손" 결정은 그대로 유효.

--- a/docs/design/app-typescript-migration.md
+++ b/docs/design/app-typescript-migration.md
@@ -4,7 +4,7 @@
 > 시점 고정 결정 기록은 ADR-012 본문 + 머지 시 추가될 `> **개정 (날짜):**` 블록 참조.
 
 - 작성: 2026-05-09
-- 상태: PR-1 진행 중
+- 상태: **1라운드 종료** (PR-1~7 머지 완료). `// @ts-check` 영구 활성화 + `tsconfig.app.json` 삭제는 **app.js 파일 분할 리팩터링과 결합한 별도 의제**로 보류
 - 관련 ADR: ADR-001(SPA), ADR-012(TS 점진 도입), ADR-013(유닛 테스트)
 
 ---
@@ -113,8 +113,8 @@ ADR-012의 1차 적용 범위(`js/sync/*`, `js/drive-sync.js`, `js/search-worker
 | PR-3 | 절 스펙 + 북마크 쿼리 + 드래그앤드롭 + 데이터 페칭 + 렌더링 헬퍼 + Views                                     | L1280-L2630 | 머지 완료             | [#83](https://github.com/anglican-kr/common-bible/pull/83) |
 | PR-4 | 라우팅 + 오디오 플레이어                                                                                     | L2702-L3233 | 머지 완료             | [#84](https://github.com/anglican-kr/common-bible/pull/84) |
 | PR-5 | 검색 + 검색 시트 + 검색 히스토리 패널                                                                        | L3245-L4229 | 머지 완료             | [#85](https://github.com/anglican-kr/common-bible/pull/85) |
-| PR-6 | 컴팩트 헤더 + PWA 감지 + 설치 안내 + 북마크 UI + 트리 렌더링 + 저장/병합 모달                                | L4235-L5666 (PR-5 머지 후 라인) | 작성 완료 (커밋 대기) | —       |
-| PR-7 | 내보내기/가져오기 + 절 선택 + 드로어 + SW 등록 + 최종 통합 (`// @ts-check` 영구화, `tsconfig.app.json` 삭제) | L5439-L5854 | 대기                  | —       |
+| PR-6 | 컴팩트 헤더 + PWA 감지 + 설치 안내 + 북마크 UI + 트리 렌더링 + 저장/병합 모달                                | L4235-L5666 | 머지 완료             | [#86](https://github.com/anglican-kr/common-bible/pull/86) |
+| PR-7 | 내보내기/가져오기 + 절 선택 + 드로어 + SW 등록 + 모듈 상태 narrow ([§9](#9-pr-7-마무리-방식-변경) 참조)        | L5670-L6082 (PR-6 머지 후 라인) | 작성 완료 (커밋 대기) | —       |
 
 ---
 
@@ -205,9 +205,27 @@ CLAUDE.md `tests/e2e/` 절차를 따라 사용자가 수동 실행:
 
 ## 7. ADR 갱신 정책
 
-- PR-7 머지 시 ADR-012에 `> **개정 (날짜):**` 블록 추가 — 2차 적용 완료, 적용 범위에 `js/app.js` 명시.
-- 본 설계 문서는 PR-7 머지 후 "마이그레이션 완료" 상태로 표기. 이후에도 도메인 타입 갱신 이력 추적용으로 유지.
-- 메모리 `project_inflight_work.md` "추후 점진 확장 후보"에서 `js/app.js` 항목 제거.
+- PR-7 머지 시 ADR-012에 `> **개정 (2026-05-09):**` 블록 추가 — 2차 적용 1라운드 완료, `js/app.js` JSDoc + null·도메인 타입 가드 도입. `// @ts-check` 영구 활성화는 분할 리팩터링 결합 의제로 보류 표기.
+- 본 설계 문서는 PR-7 머지 후 "1라운드 종료" 상태로 표기. 후속 라운드(파일 분할 + ts-check 영구화)는 별도 의제로 시작 시 본 문서에 §10 등으로 이어쓰기.
+- 메모리 `project_inflight_work.md` "추후 점진 확장 후보"에서 `js/app.js` 항목을 "1라운드 완료, 2라운드(분할 + ts-check)는 별도 의제"로 갱신.
+
+---
+
+## 9. PR-7 마무리 방식 변경
+
+### 9.1 변경 사유
+
+PR-7 시작 시 main `tsconfig.json` 검사 환경에서 `// @ts-check`를 `js/app.js`에 추가했더니 **312개 implicit any 에러**가 발생. 함수 매개변수 ~150개 + 모듈 상태 ~30개 + index access ~17개를 단일 PR에서 정리하려면 거대한 변경량이 필요한데, 이는 ADR-001의 SPA 단순성과 무관한 코드 형태 갱신이라 PR 단위로 추적·리뷰가 어려움. 그리고 5,800줄 단일 파일에 strict 타입을 입히는 작업은 **파일 분할(modularization)과 함께 진행하는 게 자연스럽다** — 각 모듈에 `// @ts-check`를 옵트인하면서 그 모듈의 타입을 정확히 정리할 수 있음.
+
+### 9.2 PR-7 실제 산출물
+
+- 잔여 11 fix (PR-7 영역 L5670-L6082): 모듈 헤드 button/input/file input narrow, `e.target instanceof Element` 가드, FileReader result 타입 narrow, `_$` 헬퍼로 `bookmark-drawer-toolbar` 통일
+- **모듈 상태 변수 일괄 narrow** — `let booksCache = null;` 같은 모든 모듈 수준 `let` 변수에 `/** @type {Foo | null} */` 부착 (~30개). PR-2의 `el()` generic 사례처럼 narrow 부작용으로 노출되는 잠재 결함이 있어, 발생한 strict null 위반(loadBooks 반환, audio save timer null guard, getAttribute ?? "" 패턴 ~10곳)은 같은 PR에서 정리
+- `tsconfig.app.json`은 **유지** (`noImplicitAny: false` 그대로). `js/app.js` 헤드의 `// @ts-check`는 추가하지 않음
+
+### 9.3 보류된 작업 (별도 의제)
+
+`js/app.js` 파일 분할 리팩터링 + 각 모듈의 `// @ts-check` 영구 활성화 + `tsconfig.app.json` 최종 삭제. 시작 시점에 본 문서 §10으로 이어쓰기.
 
 ---
 
@@ -228,3 +246,6 @@ CLAUDE.md `tests/e2e/` 절차를 따라 사용자가 수동 실행:
 | 2026-05-09 | PR-5 머지 (#85) | CI Unit tests + Cursor Bugbot 모두 green, main 통합 (rebase) |
 | 2026-05-09 | PR-6 시작 | `feat/app-jsdoc-pr6` 브랜치 분기. 영역: 컴팩트 헤더 + PWA 감지 + 설치 안내 모달 + 설치 nudge + 북마크 UI + 트리 렌더링 + 저장/병합 모달 (L4235-L5666, ~1,432줄, PR-3 다음으로 큼) |
 | 2026-05-09 | PR-6 작성 완료 | **모든 모듈-수준 anchor를 PR-1의 `_$` 헬퍼로 일괄 통일** (sed 단일 치환으로 48개 변환) — baseline 223 → 잔여 47 (-176!). PR-1~5에서 점진 변환했던 anchor 외에 PR-6/7 영역의 anchor도 모두 정합. 잔여 fix: button (`$bmSaveChapterBtn`/`$bmSelectVersesBtn` `HTMLButtonElement`) + input (`$bmImportInput`/`$bmNewFolderInput` `HTMLInputElement`) + checkbox (`#install-never-show` `HTMLInputElement`) narrow, `navigator.standalone` `any` cast, install carousel `timer` `ReturnType<typeof setInterval>` narrow + `clearInterval` 가드, `dataset.scrollY = String(scrollY)`, JSDoc 매개변수 이름 정정 (`_buildBookmarkTypeIcon`), modal expando `_bmClose` `HTMLElement & { _bmClose? }` cast 4곳, `e.target instanceof Element` 가드 3곳, `BookmarkTreeNode` 타입 narrow (folder vs bookmark) 3곳, `BookmarkTreeBookmark` 객체 리터럴 cast (`commitSaveBookmark`), `openMergeDialog` JSDoc, `target.bookId/verseSpec` nullish 처리, `link.click()` `HTMLElement` cast. baseline 223 → 잔여 11 (PR-6 영역 0). main + worker tsc 0 error, 유닛 111건 통과 |
+| 2026-05-09 | PR-6 머지 (#86) | CI Unit tests + Cursor Bugbot 모두 green, main 통합 (rebase) |
+| 2026-05-09 | PR-7 시작 | `feat/app-jsdoc-pr7` 브랜치 분기. 영역: 내보내기/가져오기 + 절 선택 + 드로어 + SW 등록 (L5670-L6082, ~412줄) — 마지막 PR |
+| 2026-05-09 | PR-7 마무리 | **마이그레이션 1라운드 종료**. PR-7 영역 잔여 11 fix(button/input narrow, FileReader result narrow, `_$` 통일) + 모듈 상태 변수 ~30개 일괄 narrow(`booksCache: BooksData \| null`, `_audioSaveTimer: ReturnType<typeof setTimeout> \| null` 등) + narrow 부작용 정리(`loadBooks`/`loadVersion` 반환 흐름, `_audioSaveTimer` null guard, `getAttribute(...) ?? ""` 패턴 ~10곳, `_bookmarkDrawerLastFocus` `HTMLElement` narrow). `// @ts-check` 영구 활성화 + `tsconfig.app.json` 삭제는 **app.js 파일 분할 리팩터링과 결합한 별도 의제로 보류** ([§9](#9-pr-7-마무리-방식-변경)). 검증: tsconfig.app.json 잔여 3 (gtag-init.js 외부), main tsc 0, worker tsc 0, 유닛 111건 통과 |

--- a/js/app.js
+++ b/js/app.js
@@ -59,10 +59,15 @@ const $searchSheetClose = _$("search-sheet-close");
 const $searchSheetChips = _$("search-sheet-chips");
 const $searchSheetResults = _$("search-sheet-results");
 
+/** @type {BooksData | null} */
 let booksCache = null;
+/** @type {string | null} */
 let appVersion = null;
+/** @type {HTMLAudioElement | null} */
 let currentAudio = null;
+/** @type {AbortController | null} */
 let _audioController = null;
+/** @type {ReturnType<typeof setTimeout> | null} */
 let _audioSaveTimer = null;
 
 // ── Accessibility ──
@@ -148,23 +153,36 @@ const COLOR_SCHEMES = [
 ];
 const DEFAULT_FONT_SIZE = 18;
 
+/** @type {(() => void) | null} */
 let _scrollTrackCleanup = null;
 let _isInitialLoad = true;
 
 // ── Bookmark state ──
 let _verseSelectMode = false;
+/** @type {Set<string>} */
 let _selectedVerseRefs = new Set();
+/** @type {(VerseSelectDrag & { snapshot?: Set<string> }) | null} */
 let _verseSelectDrag = null; // { startIdx, allVerses, isAdding, moved }
+/** @type {string | null} */
 let _currentBookId = null;
+/** @type {number | null} */
 let _currentChapter = null;
+/** @type {(() => void) | null} */
 let _bookmarkDrawerTrap = null;
+/** @type {HTMLElement | null} */
 let _bookmarkDrawerLastFocus = null;
+/** @type {(() => void) | null} */
 let _bmSaveModalTrap = null;
+/** @type {(() => void) | null} */
 let _bmMergeModalTrap = null;
+/** @type {(() => void) | null} */
 let _bmNewFolderTrap = null;
+/** @type {((id: string) => void) | null} */
 let _bmNewFolderCallback = null;
 let _bookmarkDrawerCloseSeq = 0;
+/** @type {ReturnType<typeof setTimeout> | null} */
 let _bookmarkDrawerCloseTimer = null;
+/** @type {DragState | null} */
 let _dragState = null; // { id, ghost, origLi, startY, origTop }
 
 /**
@@ -1811,8 +1829,9 @@ async function loadBooks() {
     if (!res.ok) throw new Error("Failed to load books.json");
     return res.json();
   });
-  booksCache = await promise;
-  return booksCache;
+  const data = await promise;
+  booksCache = data;
+  return data;
 }
 
 /** @returns {Promise<string>} */
@@ -1825,7 +1844,7 @@ async function loadVersion() {
   } catch {
     appVersion = "";
   }
-  return appVersion;
+  return appVersion ?? "";
 }
 
 /**
@@ -2490,8 +2509,8 @@ function renderChapter(data, book, opts) {
       const vref = vs.getAttribute("data-vref");
       if (vref) {
         _selectedVerseRefs.add(vref);
-        article.querySelectorAll(".verse[data-vref]").forEach(v => {
-          v.classList.toggle("verse-selected", _selectedVerseRefs.has(v.getAttribute("data-vref")));
+        article.querySelectorAll(".verse[data-vref]").forEach((v) => {
+          v.classList.toggle("verse-selected", _selectedVerseRefs.has(v.getAttribute("data-vref") ?? ""));
         });
         updateVerseSelectionBoundaries(article);
         updateVerseSelectBar();
@@ -2512,7 +2531,7 @@ function renderChapter(data, book, opts) {
   article.addEventListener("pointermove", (e) => {
     if (_verseSelectDrag) {
       const target = document.elementFromPoint(e.clientX, e.clientY);
-      const vs = target && target.closest(".verse[data-vref]");
+      const vs = /** @type {HTMLElement | null} */ (target && target.closest(".verse[data-vref]"));
       if (!vs) return;
       const { startIdx, allVerses, isAdding, snapshot } = _verseSelectDrag;
       const currentIdx = allVerses.indexOf(vs);
@@ -2522,7 +2541,7 @@ function renderChapter(data, book, opts) {
       const [lo, hi] = startIdx <= currentIdx ? [startIdx, currentIdx] : [currentIdx, startIdx];
       _selectedVerseRefs = new Set(snapshot);
       allVerses.forEach((v, i) => {
-        const vref = v.getAttribute("data-vref");
+        const vref = v.getAttribute("data-vref") ?? "";
         if (i >= lo && i <= hi) {
           if (isAdding) _selectedVerseRefs.add(vref);
           else _selectedVerseRefs.delete(vref);
@@ -2542,11 +2561,11 @@ function renderChapter(data, book, opts) {
         // Simple tap: toggle start verse
         const vs = _verseSelectDrag.allVerses[_verseSelectDrag.startIdx];
         if (vs) {
-          const vref = vs.getAttribute("data-vref");
+          const vref = vs.getAttribute("data-vref") ?? "";
           if (_verseSelectDrag.isAdding) _selectedVerseRefs.add(vref);
           else _selectedVerseRefs.delete(vref);
-          _verseSelectDrag.allVerses.forEach(v => {
-            v.classList.toggle("verse-selected", _selectedVerseRefs.has(v.getAttribute("data-vref")));
+          _verseSelectDrag.allVerses.forEach((v) => {
+            v.classList.toggle("verse-selected", _selectedVerseRefs.has(v.getAttribute("data-vref") ?? ""));
           });
           updateVerseSelectionBoundaries(article);
           updateVerseSelectBar();
@@ -3071,7 +3090,7 @@ function observeFabLift() {
 
 function _teardownAudio() {
   if (_audioController) { _audioController.abort(); _audioController = null; }
-  clearTimeout(_audioSaveTimer); _audioSaveTimer = null;
+  if (_audioSaveTimer !== null) { clearTimeout(_audioSaveTimer); _audioSaveTimer = null; }
   if (currentAudio) { currentAudio.pause(); currentAudio = null; }
 }
 
@@ -3200,7 +3219,7 @@ function showAudioPlayer(bookId, chapter) {
     }
     updateProgressFill();
     timeDisplay.textContent = `${formatTime(audio.currentTime)} / ${formatTime(audio.duration)}`;
-    clearTimeout(_audioSaveTimer);
+    if (_audioSaveTimer !== null) clearTimeout(_audioSaveTimer);
     _audioSaveTimer = setTimeout(() => {
       if (audio.currentTime > 0 && !audio.ended) saveAudioTime(bookId, chapter, Math.floor(audio.currentTime));
     }, 1000);
@@ -4688,7 +4707,7 @@ const $bookmarkDrawerClose = _$("bookmark-drawer-close");
 const $bookmarkDrawerBody = _$("bookmark-drawer-body");
 const $bmSaveChapterBtn = /** @type {HTMLButtonElement} */ (_$("bm-save-chapter-btn"));
 const $bmSelectVersesBtn = /** @type {HTMLButtonElement} */ (_$("bm-select-verses-btn"));
-const $bmAddFolderBtn = _$("bm-add-folder-btn");
+const $bmAddFolderBtn = /** @type {HTMLButtonElement} */ (_$("bm-add-folder-btn"));
 const $bmOverflowBtn = _$("bm-overflow-btn");
 const $bmOverflowPanel = _$("bm-overflow-panel");
 const $bmExportBtn = _$("bm-export-btn");
@@ -4756,7 +4775,7 @@ const $bmMergeNo = _$("bm-merge-no");
 const $bmMergeCancel = _$("bm-merge-cancel");
 const $verseSelectBar = _$("verse-select-bar");
 const $verseSelectCount = _$("verse-select-count");
-const $verseSelectBookmarkBtn = _$("verse-select-bookmark-btn");
+const $verseSelectBookmarkBtn = /** @type {HTMLButtonElement} */ (_$("verse-select-bookmark-btn"));
 const $verseSelectCancelBtn = _$("verse-select-cancel-btn");
 
 // Build the chevron-left back button for page title headers
@@ -4821,7 +4840,7 @@ function openBookmarkDrawer(bookId, chapter) {
     _bookmarkDrawerCloseTimer = null;
   }
   $bookmarkDrawer.classList.remove("drawer-closing");
-  _bookmarkDrawerLastFocus = document.activeElement;
+  _bookmarkDrawerLastFocus = /** @type {HTMLElement | null} */ (document.activeElement);
   $bookmarkScrim.hidden = false;
   $bookmarkDrawer.hidden = false;
   // Update toolbar visibility based on whether we're in a chapter
@@ -5873,7 +5892,7 @@ $bmSelectVersesBtn.addEventListener("click", () => {
 });
 
 $bmAddFolderBtn.addEventListener("click", () => {
-  const toolbar = document.getElementById("bookmark-drawer-toolbar");
+  const toolbar = _$("bookmark-drawer-toolbar");
   if (toolbar.querySelector(".bm-new-folder-form")) return; // already open
   $bmAddFolderBtn.disabled = true;
 
@@ -5932,13 +5951,14 @@ $bmImportBtn.addEventListener("click", () => {
 });
 
 $bmImportInput.addEventListener("change", () => {
-  const file = $bmImportInput.files[0];
+  const file = $bmImportInput.files?.[0];
   if (!file) return;
   const reader = new FileReader();
   reader.onload = (e) => {
     let data;
     try {
-      data = JSON.parse(e.target.result);
+      const result = /** @type {FileReader} */ (e.target).result;
+      data = JSON.parse(typeof result === "string" ? result : "");
     } catch (_) {
       announce("파일을 읽을 수 없습니다. 올바른 JSON 파일인지 확인해 주세요.");
       $bmImportInput.value = "";

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,13 +1,19 @@
-// Temporary tsconfig used only while js/app.js is being migrated to
-// // @ts-check + JSDoc in stages (see docs/design/app-typescript-migration.md).
-// Removed in PR-7 when `// @ts-check` is added to the head of app.js and the
-// main tsconfig.json picks it up via its existing `js/**/*.js` include.
+// Temporary tsconfig used while js/app.js is migrated to // @ts-check
+// + JSDoc in stages (see docs/design/app-typescript-migration.md).
 //
-// `include` matches the main tsconfig because js/sync/store-v2.js declares a
-// file-global `BookmarkTreeNode` @typedef that app.js participates in. With
-// app.js alone in `include`, that alias is invisible and TS reports it as
-// missing across PR-3+ signatures. `noImplicitAny: false` keeps progress
-// gated on null/domain checks only — flipped to `true` in PR-7.
+// As of PR-7 (2026-05-09): the app-typescript-migration's first round
+// completed (PR-1~7). This file is **kept** rather than deleted because
+// the planned PR-7 step "add `// @ts-check` to app.js head + delete this
+// file" is deferred to a follow-up agenda combined with **app.js file
+// split (modularization)**. With the current 6,000-line single file, the
+// remaining ~262 implicit any sites would have to be fixed in a single
+// commit; splitting into modules first lets each module land its own
+// `// @ts-check` cleanly.
+//
+// `include` matches the main tsconfig because js/sync/store-v2.js declares
+// a file-global `BookmarkTreeNode` @typedef that app.js participates in.
+// `noImplicitAny: false` keeps validation gated on null/domain checks only;
+// strictNullChecks remains true.
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {


### PR DESCRIPTION
## Summary

ADR-012 2차 적용 7단계 분할의 **마지막 PR**. PR-6([#86](https://github.com/anglican-kr/common-bible/pull/86)) 머지 후 라인 기준 **L5670-L6082** — 내보내기/가져오기 + 절 선택 + 드로어 + SW 등록.

이 PR로 **마이그레이션 1라운드 종료**. 단, 원래 PR-7 plan의 \`// @ts-check\` 영구 활성화 + \`tsconfig.app.json\` 삭제는 **app.js 파일 분할 리팩터링과 결합한 별도 의제**로 보류. 사유: 5,800줄 단일 파일에 \`noImplicitAny: true\` 일괄 적용 시 ~262 implicit any가 발생해 단일 PR로 정리하면 거대한 변경량이 되고, 분할(modularization) 후 각 모듈이 자체 \`// @ts-check\`를 옵트인하는 게 자연스러움.

## 변경 내용

- **PR-7 영역 잔여 11 fix** (L5670-L6082)
  - button (\`$bmAddFolderBtn\`/\`$verseSelectBookmarkBtn\`) → \`HTMLButtonElement\`
  - file input \`$bmImportInput.files?.[0]\` 옵셔널 체이닝
  - \`e.target instanceof Element\` 가드
  - FileReader \`result\` (\`string | ArrayBuffer | null\`) → string narrow
  - \`bookmark-drawer-toolbar\` getElementById를 \`_$\` 헬퍼로 통일
- **모듈 상태 변수 ~30개 일괄 narrow** (\`/** @type {Foo | null} */\`)
  - \`booksCache: BooksData | null\`, \`appVersion: string | null\`, \`currentAudio: HTMLAudioElement | null\`, \`_audioController: AbortController | null\`, \`_audioSaveTimer: ReturnType<typeof setTimeout> | null\`
  - \`_scrollTrackCleanup: (() => void) | null\`, \`_selectedVerseRefs: Set<string>\`, \`_verseSelectDrag\`, \`_currentBookId/_currentChapter\`, 4개 \`*Trap\`, \`_bmNewFolderCallback\`, \`_bookmarkDrawerCloseTimer\`, \`_dragState\`
- **narrow 부작용 정리**
  - \`loadBooks\`: \`await promise\` 결과를 별도 변수로 받아 반환 흐름 narrow
  - \`loadVersion\` 반환 \`appVersion ?? ""\`
  - \`_audioSaveTimer\` clearTimeout null guard 2곳
  - \`getAttribute(...) ?? ""\` 패턴 ~10곳 (verse selection drag/tap 핸들러)
  - \`_bookmarkDrawerLastFocus = document.activeElement\` \`HTMLElement\` cast
- **tsconfig.app.json**: 헤더 주석 갱신 — 1라운드 완료 후에도 **유지** 사유 명시
- **docs/design/app-typescript-migration.md**: 상태 "1라운드 종료" + §9 PR-7 마무리 방식 변경 + 진행 일지 마무리
- **docs/decisions/012-typescript-incremental-adoption.md**: \`> **개정 (2026-05-09):**\` 블록 추가 — 1라운드 완료, 추가된 도메인 타입 16종, 운영 패턴, 다음 라운드 트리거

## 마이그레이션 1라운드 정리

| 단계 | PR | baseline | 잔여 | net |
|---|---|---|---|---|
| PR-1 | #81 | 428 | 282 | -146 |
| PR-2 | #82 | 282 | 294 | +12 |
| PR-3 | #83 | 294 | 280 | -14 |
| PR-4 | #84 | 280 | 262 | -18 |
| PR-5 | #85 | 262 | 223 | -39 |
| PR-6 | #86 | 223 | 11 | **-212** |
| PR-7 | (본 PR) | 11 | 3 | -8 |

최종 잔여 3개는 \`gtag-init.js\` (Google Analytics dataLayer global) — ADR-012 미적용 외부 파일.

## 후속 의제 (별도)

\`js/app.js\` 파일 분할 리팩터링 + 각 모듈의 \`// @ts-check\` 영구 활성화 + \`tsconfig.app.json\` 최종 삭제. 시작 시점에 \`docs/design/app-typescript-migration.md\` §10 등으로 이어쓰기.

## Test plan

- [x] \`npx tsc -p tsconfig.app.json --noEmit\` — 잔여 3 (gtag-init.js 외부)
- [x] \`npx tsc -p tsconfig.json --noEmit\` — 0 error
- [x] \`npx tsc -p tsconfig.worker.json --noEmit\` — 0 error
- [x] \`node --test tests/unit/*.test.js\` — 111/111 pass
- [ ] e2e 회귀는 본 PR 머지 후 일괄 (CLAUDE.md 표준 — 코드 동작 변경 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly type-safety/JSDoc-only changes with small defensive runtime guards (e.g., null checks around timers, FileReader parsing), so behavior impact should be minimal but touches widely-used `app.js` flows.
> 
> **Overview**
> Closes out **ADR-012 `js/app.js` 2차 적용 1라운드** by further narrowing module-level state in `js/app.js` with JSDoc types and tightening a handful of DOM/file/timer interactions (e.g., safer `FileReader` parsing, `getAttribute(...) ?? ""`, and `clearTimeout` null guards).
> 
> Updates `tsconfig.app.json` comments and the ADR/design docs to reflect that **`// @ts-check` is not yet enabled at the `app.js` head and `tsconfig.app.json` is intentionally kept** until a follow-up `app.js` modularization effort.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7074575df0c03a975dbbbd6e4628c91dcec0bc4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->