### PR TITLE
feat: app.js 모듈 분할 Phase 1 — helpers.js 추출 (ADR-018)

### DIFF
--- a/docs/decisions/018-app-modularization.md
+++ b/docs/decisions/018-app-modularization.md
@@ -1,0 +1,107 @@
+# ADR-018: app.js 모듈 분할 (modularization)
+
+- 일시: 2026-05-09
+- 상태: 승인됨 (Phase 1 진행 예정)
+- 관련 설계 문서: `docs/design/app-modularization.md`
+
+## 결정
+
+`js/app.js`(현재 6,082줄)를 도메인별 모듈로 분할한다. 각 모듈은 `js/app/<name>.js` 파일에 두고, IIFE 패턴으로 `window.app<X>` 객체에 export한다. `index.html`에 `<script defer>` 태그로 의존 순서대로 로드. 모듈마다 `// @ts-check` 영구 활성화 + 함수 매개변수 JSDoc + ADR-012 1라운드의 도메인 타입 가드 유지.
+
+목표는 ADR-012 1라운드 종료 시 보류한 "`// @ts-check` 영구화 + `tsconfig.app.json` 삭제"를 모듈 단위로 옵트인해 자연스럽게 달성하는 것.
+
+분할 단계 (8 PR):
+
+1. `helpers.js` (~70줄) — `el`, `clearNode`, `_$`, `announce`, `trapFocus`, `chUnit`. 모든 후속 모듈의 의존 대상
+2. `storage.js` (~250줄) — localStorage 헬퍼 묶음
+3. `settings-ui.js` (~600줄) — 설정 팝오버 + 외관 적용
+4. `install.js` (~430줄) — PWA 감지 + 설치 안내 모달
+5. `search.js` (~990줄) — 검색 전체 (sheet + 히스토리 패널 포함)
+6. `bookmark.js` (~1,800줄) + `state.js` — 북마크 전체 + 공유 상태(`_currentBookId`/`_currentChapter`/`_verseSelectMode`/`_selectedVerseRefs`) 분리
+7. `views-routing.js` (~1,400줄) — 라우팅 + Views + 오디오 + PTR + Compact header
+8. `app-main.js` 부트스트랩 + `tsconfig.app.json` 최종 삭제 (Phase 8)
+
+## 맥락
+
+ADR-012 1라운드(PR-1~7, 2026-05-09 머지)에서 `js/app.js`에 JSDoc + null/도메인 타입 가드를 도입했다. 그 시점에 main `tsconfig.json` 검사 환경에서 `// @ts-check`를 추가해 보면 **약 262 implicit any**가 발생함을 확인했다(함수 매개변수 ~150 + 모듈 상태 ~30 + index access ~17 등). 단일 PR로 정리하기엔 변경 폭이 거대하고, 5,800줄 단일 파일에 strict 타입을 입히는 작업은 모듈 분할과 결합하는 게 자연스럽다.
+
+또한 본 의제는 미래 monorepo split의 기반이기도 하다(일정 미정). 분할 계획:
+
+- **앱 저장소**(root): `index.html`, `js/**`, `css/**`, `sw.js`, 빌드/배포 스크립트
+  - **데이터(성서) 서브모듈**: `data/source/`(현재 이미 `anglican-kr/common-bible-text` private submodule), parser 출력 JSON 포함
+  - **데이터(오디오) 서브모듈**: `data/audio/` MP3 ~수백 MB
+- **서버(nginx) 저장소**(별도): prod nginx config, BFF `/oauth/token` location 블록 — 운영 인프라라 코드 라이프사이클이 다름
+
+데이터 두 저장소는 git submodule로 앱에 포함되므로 clone 시 `git submodule update --init`만으로 함께 보인다. 따라서 앱 저장소가 자기 완결적이려면 내부 모듈 경계가 명확해야 함 — 본 모듈화가 그 선행 작업.
+
+## 검토한 대안
+
+| 방식 | 빌드 변화 | 진입 비용 | 채택 |
+| --- | --- | --- | --- |
+| 단일 거대 PR (`// @ts-check` + ~262 implicit any 일괄 정리) | 없음 | 매우 큼, 리뷰 어려움 | ❌ |
+| **Multi-script + `defer` 모듈 분할** | 없음 | 단계별 분할 가능 | ✅ |
+| ESM (`<script type="module">`) | 없음 | 동기 초기화 보장 부족, 모듈 헤드 anchor 캡처 + side-effect 의존 패턴과 충돌 | ❌ — `gtag-init.js` 같은 외부 스크립트와 정합 부담 |
+| `.ts` + tsc 빌드 | 큼 | ADR-001 SPA 단순성 위배 | ❌ |
+| 그대로 유지 (`// @ts-check` 영구화 보류) | 없음 | 0 | ❌ — 1라운드 산출물의 검증 흐름이 임시 인프라(`tsconfig.app.json`)에 영구 의존하게 됨 |
+
+## 채택 방식
+
+### 모듈 패턴 (IIFE + `window.appXxx`)
+
+각 모듈은 IIFE로 감싸 한 객체에 export. 1차 적용된 sync 레이어(`window.driveSync`, `window.syncTransport` 등)와 동일.
+
+```js
+// js/app/storage.js
+"use strict";
+// @ts-check
+window.appStorage = (() => {
+  /** @returns {ReadingPosition | null} */
+  function loadReadingPosition() { /* ... */ }
+  // ...
+  return { loadReadingPosition, saveReadingPosition, /* ... */ };
+})();
+```
+
+호출 측은 `window.appStorage.loadReadingPosition()` 또는 IIFE 직후 `const { loadReadingPosition } = window.appStorage;`로 받음.
+
+### 공유 상태 (Phase 6)
+
+`_currentBookId` / `_currentChapter` / `_verseSelectMode` / `_selectedVerseRefs`는 4~6개 섹션이 접근. 별도 `js/app/state.js` 모듈이 owns + getter/setter export (설계 문서 §5.1 Option A).
+
+### 임시 인프라 처리
+
+- `tsconfig.app.json`은 Phase 1~7 동안 유지 (`checkJs: true`, `noImplicitAny: false`)
+- 각 모듈에 `// @ts-check` 추가 시점부터 그 모듈은 strict (메인 `tsconfig.json` 의 `noImplicitAny: true`) 적용
+- Phase 8에서 `tsconfig.app.json` 삭제
+
+### `index.html` / `sw.js` 영향
+
+`index.html`에 `<script defer>` 태그 추가. `sw.js`의 셸 캐시 매니페스트에 신규 모듈 파일들 추가 + `CACHE_NAME` 증분.
+
+## 검증
+
+- 단계별 PR마다: `tsc -p tsconfig.app.json --noEmit` + `tsc -p tsconfig.json --noEmit` 모두 0 error
+- 회귀: `tsc -p tsconfig.worker.json --noEmit` + `node --test tests/unit/*.test.js`
+- **브라우저 동작 확인**: 매 단계 PR마다 로컬 SPA 서버에서 콘솔 0 오류 확인 (1라운드와 다름 — 분할은 코드 위치 이동이라 로드 순서 누락이 런타임 깨짐으로 즉시 드러남)
+- Phase 8 머지 후 e2e (`tests/e2e/*.py`) 일괄
+
+## 채택 이유 요약
+
+- **분할 단위로 implicit any 정리** — 단일 거대 PR 회피 (~262건을 8개 PR로 분산)
+- **ADR-001 SPA 단순성 유지** — 빌드 단계 0
+- **sync 레이어와 일관 패턴** — IIFE + `window.appXxx`로 노출, `defer`로 순서 보장
+- **미래 monorepo split 기반** — 앱 저장소 자기 완결성을 위해 내부 모듈 경계 명확화 선행 필요
+- **부수 효과**: 셸 캐시 입자 개선(한 모듈 변경 시 그 파일만 재다운), 인지적 부담 감소, 단위 테스트 도입 기회 (설계 문서 §10 참조)
+
+## 결과
+
+- ADR-012 2차 적용 2라운드 완료(Phase 8 머지) 시 ADR-012에 `> 개정` 블록 추가
+- `tsconfig.app.json` 삭제 → 메인 `tsconfig.json` 단일 출처
+- 향후 lazy load / tree-shaking 등 추가 최적화 옵션 열림 (별도 의제)
+
+## 관련 ADR
+
+- ADR-001: SPA 아키텍처 — 빌드 단계 회피의 출발점
+- ADR-012: TypeScript 점진 도입 — 1라운드 완료 + 본 ADR이 2라운드 시작점
+- ADR-013: 클라이언트 JS 유닛 테스트 전략 — 분할 후 unit test 추가 기회 (storage / verse spec / search worker wire-up 등 순수 로직 영역)
+- ADR-016: 오디오 캐시 LRU — `views-routing.js`의 audio player 영역 분할 시 audio cache 의존성 정합 유지

--- a/docs/design/app-modularization.md
+++ b/docs/design/app-modularization.md
@@ -1,0 +1,380 @@
+# app.js 분할 리팩터링 — 설계 문서
+
+> 이 문서는 `js/app.js`(현재 6,082줄)를 모듈 단위로 분할하는 다단계 작업의 진행 상황을 함께 추적한다. 각 단계 머지 후 갱신한다.
+> 시점 고정 결정 기록은 ADR-018 + 본 문서의 진행 일지 참조.
+
+- 작성: 2026-05-09
+- 상태: **결정 확정** — Phase 1 진행 예정
+- 관련 ADR: ADR-001(SPA), ADR-012(TS 점진 도입, 2차 1라운드 완료), ADR-013(유닛 테스트), ADR-016(오디오 캐시), ADR-018(본 의제)
+- 1라운드 문서: `docs/design/app-typescript-migration.md`
+
+---
+
+## 1. 개요
+
+### 1.1 목적
+
+ADR-012 2차 적용의 **2라운드**. 1라운드에서는 `js/app.js`에 JSDoc + null/도메인 타입 가드를 도입했지만 `// @ts-check` 영구 활성화는 보류했다 — 5,800줄 단일 파일에 `noImplicitAny: true`를 일거에 적용하면 ~262 implicit any가 발생해 단일 PR로 정리하기 어려웠기 때문. 본 라운드는 그 보류 사유를 풀기 위한 작업으로, **모듈 분할(modularization)을 거치며 각 모듈에 `// @ts-check`를 옵트인**한다. 결과적으로:
+
+- `js/app.js` → `js/app/<module>.js` 다수로 분할
+- 각 모듈에 `// @ts-check` + JSDoc 시그니처 (함수 매개변수 implicit any 정리)
+- 임시 `tsconfig.app.json` **삭제**, 메인 `tsconfig.json`만으로 검증 통일
+
+### 1.2 대상 범위
+
+- `js/app.js` (단일 파일) → `js/app/*.js` (다중 파일)로 점진 추출
+- `js/types.d.ts` — 분할 시 모듈 간 공유되는 새 도메인 타입 추가 가능
+- `index.html` — `<script>` 태그 갱신 (modular 패턴은 §5 참조)
+- `sw.js` — 신규 모듈 파일을 셸 캐시에 추가, `CACHE_NAME` 증분
+- `tsconfig.json` — 변경 없음 (이미 `js/**/*.js` include + `checkJs: false` opt-in)
+- `tsconfig.app.json` — **마지막 단계에서 삭제**
+
+### 1.3 비대상
+
+- 빌드 단계 추가 (번들러/트랜스파일러 도입) — ADR-001 SPA 단순성 유지
+- 동작 변경 — 본 작업은 코드 형태 갱신만, 런타임 동작 무변동
+- sync 레이어 (`js/sync/*`, `js/drive-sync.js`, `js/search-worker.js`) — 1차 적용 완료, 변경 없음
+
+---
+
+## 2. 1라운드 종료 시점 출발점
+
+- `js/app.js` 6,082줄, 41개 섹션
+- 모듈 헤드 자산:
+  - `// @typedef` 라인 12개 (L4-L18) — `js/types.d.ts`에서 import한 도메인 타입 alias
+  - `_$` 헬퍼 (L37) — 모든 모듈 anchor의 `getElementById` cast
+  - 모듈 수준 anchor ~60개 (L6-L60대)
+  - 상수 (`COLOR_SCHEMES`, `FONT_SIZES`, storage key, division map 등)
+  - `let` 모듈 상태 변수 ~30개 (1라운드에서 narrow 됨)
+- 임시 검증 인프라: `tsconfig.app.json` (`checkJs: true`, `noImplicitAny: false`)
+- 잔여 implicit any: 2라운드 시작 시 main `tsconfig.json`에 `// @ts-check` 추가하면 ~262건 발생
+
+---
+
+## 3. 의존 그래프 (Explore 조사 결과)
+
+### 3.1 41 섹션 cross-section 호출 매트릭스 (top 15)
+
+| 호출 수 | 호출처 → 정의처                               | 의미                  |
+| ------- | --------------------------------------------- | --------------------- |
+| 55      | Settings popover → Helpers                    | `el`/`clearNode` 호출 |
+| 54      | Views → Helpers                               | 렌더링 재사용         |
+| 39      | Bookmark tree rendering → Helpers             |                       |
+| 22      | Install guide modal → Helpers                 |                       |
+| 22      | Search → Helpers                              |                       |
+| 22      | Views → Rendering helpers                     | `setTitle*` 등        |
+| 21      | Search history panel controller → Helpers     |                       |
+| 16      | Rendering helpers → Helpers (재귀)            |                       |
+| 12      | Save bookmark modal → Helpers                 |                       |
+| 11      | Audio Player → Helpers                        |                       |
+| 11      | Drag & drop → Search history panel            | UI 동기화             |
+| 10      | Bookmark tree → Bookmark storage helpers      |                       |
+| 10      | Routing → Views                               | 페이지 전환           |
+| 9       | Bookmark tree → Drag & drop                   | 위치 계산             |
+| 9       | Search history panel → Search history helpers |                       |
+
+**핵심 관찰**:
+
+- **`Helpers` 섹션(34줄)이 병목** — `el`/`clearNode`/`_$`/`announce`/`trapFocus`/`chUnit` 때문에 거의 모든 모듈이 의존. 이 섹션을 *공통 모듈*로 별도 추출하면 모든 후속 분할이 단순해진다.
+- **순환 의존 없음** — DAG. 분할 순서를 결합도 낮은 쪽부터 잡으면 자연스러움.
+- **결합 high spot**: Bookmark tree(S35) ↔ Drag & drop(S20) ↔ Bookmark storage(S17) 영역. 한 모듈로 묶어야 할 후보.
+
+### 3.2 모듈 상태 변수 공유
+
+| 변수                                                  | 접근 섹션 수                     | 결정                                          |
+| ----------------------------------------------------- | -------------------------------- | --------------------------------------------- |
+| `_currentBookId`                                      | 6 (S23, S34, S36, S37, S39, S40) | 공용 state 모듈 또는 events                   |
+| `_currentChapter`                                     | 6 (동일)                         | 동일                                          |
+| `_verseSelectMode`                                    | 4 (S23, S24, S39, S40)           | 동일                                          |
+| `_selectedVerseRefs`                                  | 3 (S23, S36, S39)                | 동일                                          |
+| `_dragState`                                          | 1 (S20만)                        | bookmark 모듈 내부로                          |
+| `currentAudio`, `_audioController`, `_audioSaveTimer` | Audio Player 내부                | audio 모듈 내부                               |
+| `_swipedRow`                                          | 1 (S20)                          | bookmark 모듈 내부                            |
+| anchor 상수 (~60개)                                   | 모듈별 분산                      | 각 모듈이 자기 anchor를 import 또는 자체 정의 |
+
+`_currentBookId`/`_currentChapter` 등 광범위 공유 상태는 별도 `state.js` 모듈에 두거나 `app-main.js`에 남기는 게 낫다 — 분할 작업의 리스크가 가장 큰 부분.
+
+### 3.3 자연 분할 후보 (Explore 권장)
+
+| 모듈                 | 영역                                                                                                                                                         | 줄 수  | 결합도                                   | 단계 후보 |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------ | ---------------------------------------- | --------- |
+| **A. helpers**       | `el`, `clearNode`, `_$`, `announce`, `trapFocus`, `chUnit`                                                                                                   | ~70    | 의존 없음 (가장 먼저)                    | Phase 1   |
+| **B. storage**       | Reading pos, Audio time, Search history, Font, Theme, Color, Book order, Bookmark storage, Install nudge                                                     | ~250   | 매우 낮음 (localStorage만)               | Phase 2   |
+| **C. settings-ui**   | Settings popover, Icon recoloring, Color scheme apply, Theme apply, Book order apply, Launch screen                                                          | ~600   | 중간 (helpers + storage 의존)            | Phase 3   |
+| **D. install**       | PWA detection, Install guide modal, Install nudge auto-show                                                                                                  | ~430   | 낮음 (자기 완결)                         | Phase 4   |
+| **E. search**        | Search, Search input handlers, Search bottom sheet, Search history panel controller, search worker wire-up                                                   | ~990   | 중간                                     | Phase 5   |
+| **F. bookmark**      | Verse spec, Bookmark query, Drag & drop, Bookmark UI, Bookmark tree rendering, Save modal, Merge dialog, Export/Import, Verse selection mode, Drawer toolbar | ~1,800 | **가장 높음** (내부 응집 + Views와 상호) | Phase 6   |
+| **G. views-routing** | Views, Routing, Audio Player, Pull-to-refresh, Compact header, Verse spec utilities (일부), Rendering helpers, Data fetching                                 | ~1,400 | **가장 높음** (라우팅 허브)              | Phase 7   |
+| **H. app-main**      | 모듈 헤드 typedef, anchor 정의, 공유 state 변수, 부트스트랩, SW 등록                                                                                         | ~250   | —                                        | (잔류)    |
+
+총 ~5,790줄을 8개 파일로 분할. 잔여 ~290줄은 `js/app.js` 또는 `js/app/main.js`에 남는 부트스트랩 + 공유 state.
+
+---
+
+## 4. 모듈 시스템 결정 (검토)
+
+### 4.1 옵션 비교
+
+| 옵션                               | 빌드 변화 | 동기 초기화 보장                    | CSP 영향       | 글로벌 노출          | 비고                        |
+| ---------------------------------- | --------- | ----------------------------------- | -------------- | -------------------- | --------------------------- |
+| **Multi-script + `defer`**         | 없음      | 가능 (`defer` + `<script>` 순서)    | 각 파일 추가   | `window.X` 패턴 유지 | 현재 sync layer 패턴과 호환 |
+| **ESM (`<script type="module">`)** | 없음      | 모듈 로드 순서가 import에 의해 결정 | entry script만 | import/export        | 의존 그래프 명확            |
+| `.ts` + tsc 빌드                   | 큼        | —                                   | —              | —                    | ❌ ADR-001 위배             |
+
+### 4.2 권장 — **Multi-script + `defer`**
+
+이유:
+
+- ADR-001 SPA 단순성 유지 (빌드 단계 0)
+- 현재 sync 레이어가 동일 패턴 (`window.driveSync`, `window.syncTransport` 등) — 일관성
+- `defer` 속성으로 DOM 파싱 후 순서 보장 — 모듈 헤드의 anchor 캡처와 호환
+- iOS Safari + 구형 브라우저 호환성 추가 보강 불필요
+
+ESM은 매력적이지만 두 가지 부담:
+
+1. 모든 모듈 헤드 anchor를 `_$` 호출로 즉시 캡처하는 현 패턴이 import 순서 + side effect 의존 → 디버깅 어려움
+2. `index.html`의 ` <script defer src="/js/gtag-init.js">` + Google Analytics global 등 외부 스크립트와 `type="module"` 혼재 시 추가 정합 필요
+
+### 4.3 모듈 namespacing 제안
+
+각 모듈은 IIFE로 감싸 `window.appXxx` 한 객체에 export:
+
+```js
+// js/app/storage.js
+"use strict";
+// @ts-check
+window.appStorage = (() => {
+  /** @returns {ReadingPosition | null} */
+  function loadReadingPosition() { ... }
+  // ...
+  return { loadReadingPosition, saveReadingPosition, ... };
+})();
+```
+
+호출 측은 `window.appStorage.loadReadingPosition()` 또는 IIFE 직후 `const { loadReadingPosition } = window.appStorage;`로 받음. 이는 `js/sync/*`의 1차 적용 패턴과 동일.
+
+대안: `helpers`만 글로벌, 나머지는 `<script>` 순서로 함수 정의 hoist만 의존하는 방식 (현재 app.js 패턴 그대로). 이 경우 namespace 오염은 늘지만 import/export 오버헤드 0. 단계마다 결정 가능.
+
+---
+
+## 5. 단계 계획 (8개 PR)
+
+각 단계는 한 모듈씩 추출 + 그 모듈에 `// @ts-check` 영구 활성화 + 모듈 내부 implicit any 정리. 기본 흐름:
+
+1. 추출할 영역의 함수/변수 식별
+2. `js/app/<name>.js` 신규 파일에 코드 이전 (anchor + state + 함수)
+3. 호출 측을 `window.appXxx.fn()`으로 갱신 또는 export 패턴 결정
+4. `// @ts-check` 추가 + 함수 매개변수 JSDoc 추가
+5. `index.html`에 `<script defer>` 추가
+6. `sw.js` 캐시 매니페스트에 추가, `CACHE_NAME` 증분
+7. `tsconfig.app.json` + 메인 `tsconfig.json` 모두 0 error 확인
+
+### 진행 매트릭스 (예정)
+
+| 단계    | 모듈               | 영역                                                                                                          | 라인 추정 | 핵심 위험                                                                                                 |
+| ------- | ------------------ | ------------------------------------------------------------------------------------------------------------- | --------- | --------------------------------------------------------------------------------------------------------- |
+| Phase 1 | `helpers.js`       | `el`, `clearNode`, `_$`, `announce`, `trapFocus`, `chUnit`                                                    | ~70       | 모든 모듈이 의존 — 인터페이스 변경 시 광범위 영향. 가장 먼저 해서 후속 단계가 깨끗                        |
+| Phase 2 | `storage.js`       | localStorage 헬퍼 묶음                                                                                        | ~250      | 거의 없음 (순수 함수)                                                                                     |
+| Phase 3 | `settings-ui.js`   | Settings popover + 외관 (Color/Theme/Book order/Icon/Launch screen)                                           | ~600      | DOM 의존, 호출 측 갱신                                                                                    |
+| Phase 4 | `install.js`       | PWA + 설치 안내 모달 + nudge                                                                                  | ~430      | 자기 완결                                                                                                 |
+| Phase 5 | `search.js`        | 검색 + 시트 + 히스토리 패널 + 워커 wire-up                                                                    | ~990      | 워커 메시지 정합 (이미 1라운드에서 정리)                                                                  |
+| Phase 6 | `bookmark.js`      | 북마크 전체 (UI + 트리 + 모달 + 드래그 + 절 선택)                                                             | ~1,800    | 가장 큰 단일 모듈. 공유 상태 (`_currentBookId` 등)가 Views와 얽힘 — 별도 `state.js` 또는 events 도입 검토 |
+| Phase 7 | `views-routing.js` | Views + Routing + Audio Player + PTR + Compact header + Rendering helpers + Data fetching                     | ~1,400    | 라우팅 허브, 라우팅 변경 시 회귀 위험 가장 큼                                                             |
+| Phase 8 | 최종 통합          | `app-main.js` 부트스트랩 + 공유 state + SW 등록. `tsconfig.app.json` 삭제. main `tsconfig.json` 0 error 확정. | ~250      | `tsconfig.app.json` 제거 검증                                                                             |
+
+각 단계는 하나의 PR. 1라운드와 동일한 분할 정밀도.
+
+### 5.1 공유 상태 처리 옵션 (Phase 6 핵심 결정)
+
+`_currentBookId`/`_currentChapter`/`_verseSelectMode`/`_selectedVerseRefs`는 4~6개 섹션이 접근. 분할 시 두 옵션:
+
+**Option A — 공유 state 모듈 `js/app/state.js`**
+
+- 단일 module이 변수를 owns + getter/setter export
+- 호출 측 `appState.getCurrentBookId()` / `appState.setCurrentBookId(x)`
+- 장점: 명시적, 추적 가능
+- 단점: 추가 boilerplate
+
+**Option B — `app-main.js`에 잔류 + 글로벌 export**
+
+- 현재 패턴 유지 (`window._currentBookId` 등)
+- 장점: 변경 폭 작음
+- 단점: namespace 오염
+
+**Option C — 이벤트 기반**
+
+- `_currentBookId` 변경을 `CustomEvent('chapter-change', { detail: { bookId, chapter } })`로 발행
+- bookmark 모듈은 listener로 받음
+- 장점: 모듈 결합도 낮음
+- 단점: 제어 흐름 추적 어려움, runtime overhead
+
+권장: **Option A**. Phase 6 시점에 결정.
+
+---
+
+## 6. service worker / index.html 영향
+
+### 6.1 sw.js
+
+현재 `sw.js`의 셸 캐시 매니페스트에 `/js/app.js` 명시. 분할 후 신규 모듈 파일들을 모두 추가하고 `CACHE_NAME`을 증분해 기존 사용자 캐시 무효화. 각 단계 PR에서:
+
+```js
+// sw.js (단계마다 갱신)
+const CACHE_NAME = "common-bible-shell-vX.Y.Z+app-modulN"; // 단계 식별자 추가
+const SHELL_URLS = [
+  "/index.html",
+  "/css/style.css",
+  "/js/app/helpers.js", // Phase 1 추가
+  "/js/app/storage.js", // Phase 2 추가
+  // ...
+  "/js/app.js", // Phase 8까지 점진 축소, 마지막에 제거
+];
+```
+
+### 6.2 index.html
+
+각 단계마다 `<script defer src="/js/app/<name>.js"></script>`를 추가. 의존 순서대로:
+
+```html
+<!-- 1라운드 -->
+<script defer src="/js/sync/debug-log.js"></script>
+<script defer src="/js/sync/refresh-store.js"></script>
+<script defer src="/js/sync/transport.js"></script>
+<script defer src="/js/sync/store-v2.js"></script>
+<script defer src="/js/sync/state-machine.js"></script>
+<script defer src="/js/drive-sync.js"></script>
+<script defer src="/js/pre-fetch.js"></script>
+<script defer src="/js/gtag-init.js"></script>
+
+<!-- 2라운드: 의존 순서대로 추가 -->
+<script defer src="/js/app/helpers.js"></script>
+<!-- Phase 1 -->
+<script defer src="/js/app/storage.js"></script>
+<!-- Phase 2 -->
+<script defer src="/js/app/settings-ui.js"></script>
+<!-- Phase 3 -->
+<script defer src="/js/app/install.js"></script>
+<!-- Phase 4 -->
+<script defer src="/js/app/search.js"></script>
+<!-- Phase 5 -->
+<script defer src="/js/app/bookmark.js"></script>
+<!-- Phase 6 -->
+<script defer src="/js/app/views-routing.js"></script>
+<!-- Phase 7 -->
+
+<script defer src="/js/app.js"></script>
+<!-- Phase 8까지: 점진 축소, 마지막에 app-main.js로 변경 -->
+```
+
+`defer` 속성은 DOM 파싱 후 등장 순서대로 실행. 각 모듈 헤드의 anchor 캡처는 DOM 준비 후 OK.
+
+---
+
+## 7. 검증 절차
+
+### 7.1 각 PR
+
+```bash
+npx tsc -p tsconfig.app.json --noEmit       # 단계별 검증 (1라운드와 동일)
+npx tsc -p tsconfig.json --noEmit           # 그 모듈만 // @ts-check 켜진 상태에서 main 검증
+npx tsc -p tsconfig.worker.json --noEmit    # 회귀
+node --test tests/unit/*.test.js            # 회귀 (영향 없음 예상)
+python3 scripts/serve.py 8080 &              # 로컬 SPA 서버
+# 브라우저에서 / 접속 → 콘솔 오류 0 확인
+```
+
+브라우저 동작 확인이 PR마다 필수 (1라운드와 다름) — 분할은 코드 위치 이동이라 import/export 누락이 런타임 깨짐으로 나타남.
+
+### 7.2 Phase 8 머지 후 (전체 회귀)
+
+CLAUDE.md `tests/e2e/` 절차를 따라 사용자 수동 실행:
+
+- `test_search.py`, `test_navigation.py`, `test_copy.py`, `test_install_guide.py`, `test_features.py`, `test_drive_sync.py`, `test_drive_sync_ios.py`
+
+---
+
+## 8. ADR 갱신 정책
+
+- **Phase 8 머지 시** ADR-012에 `> **개정 (날짜): 2차 적용 2라운드 완료**` 블록 추가 — `// @ts-check` 영구 활성화 + `tsconfig.app.json` 삭제 명시.
+- **ADR-018 신설 완료** (2026-05-09): `docs/decisions/018-app-modularization.md` — 모듈 분할 결정·맥락·검토한 대안·채택 방식.
+- 메모리 `project_inflight_work.md` "추후 점진 확장 후보"의 `js/app.js` 2라운드 항목을 "진행 중" → 단계마다 갱신.
+
+---
+
+## 9. 결정 사항 (2026-05-09 확정)
+
+| #   | 결정                                       | 비고                                                        |
+| --- | ------------------------------------------ | ----------------------------------------------------------- |
+| 1   | **모듈 시스템**: Multi-script + `defer`    | sync 레이어 패턴과 일관, ADR-001 SPA 단순성 유지            |
+| 2   | **공유 state** (Phase 6): Option A `state.js` 모듈 | 사용자 명시                                                 |
+| 3   | **모듈 namespacing**: IIFE + `window.appXxx` | sync 레이어와 동일 패턴                                     |
+| 4   | **신규 ADR**: ADR-018 작성                   | `docs/decisions/018-app-modularization.md` 신설            |
+| 5   | **단계 분할 입자**: 8개 PR                   | helpers / storage / settings-ui / install / search / bookmark / views-routing / final |
+| 6   | **시작 시점**: 즉시 Phase 1                 | 사용자 명시                                                 |
+
+---
+
+## 10. 모듈화의 부수 효과 (성능)
+
+본 작업의 일차 동기는 ADR-012 2차 적용 2라운드 완료(`// @ts-check` 영구화)이지만, 분할은 다음 부수 효과를 가져온다.
+
+### 10.1 즉각 이점 (단계 머지 시점부터)
+
+- **셸 캐시 입자 개선** — 현재 6,082줄 단일 파일은 한 줄만 변경해도 사용자 브라우저가 전체를 재다운로드. 분할 후엔 변경된 모듈만 재다운(SW 셸 캐시 + HTTP 캐시 양쪽). 평균 변경 크기가 ~1/8로 감소
+- **HTTP/2 다중 스트림** — `defer`된 작은 파일들이 병렬 다운로드. 첫 콜드 캐시 로드도 약간 빨라질 가능성
+- **인지적 부담 감소** — 6,000줄 단일 파일의 mental model 비용 ↓. 모듈별 ~1,000줄 미만 단위로 reasoning
+- **단위 테스트 도입 기회** — 1라운드까지 app.js는 unit test 부재(DOM 의존도 높음). 분할 후 순수 로직 모듈(예: `storage.js`, verse spec utilities, search worker wire-up)에는 ADR-013 패턴(Node `--test` + vm 하네스)으로 unit test 추가 가능
+
+### 10.2 미래 옵션
+
+- **Lazy load** — `install.js`처럼 사용자가 메뉴를 누를 때만 필요한 모듈을 동적으로 로드해 첫 로드 무게 감소 (별도 의제)
+- **Tree-shaking** — 미래에 번들러 도입 시(ADR-001 재검토 필요) 사용 안 하는 export 자동 제거. 본 라운드는 빌드 단계 안 추가하므로 즉각 이점 없음
+- **모듈별 독립 deprecation** — 한 영역(예: install nudge)을 통째로 제거할 때 한 파일만 삭제 + index.html / sw.js에서 항목 제거
+
+### 10.3 비용 (정직)
+
+- 첫 로드 시 작은 파일 N개 만큼 HTTP request 추가. HTTP/2 멀티플렉싱으로 완화되지만 0은 아님
+- `<script>` 태그 N개로 index.html이 길어짐 (~10줄 증가)
+- 모듈 간 인터페이스를 `window.appXxx`로 노출하므로 **글로벌 namespace 오염**이 N개 추가
+
+부수 효과로서 가치 있으나 본 작업의 정당화 사유는 아님. 정당화는 ADR-012 2차 라운드 완료 + 미래 저장소 분할 기반(§11).
+
+---
+
+## 11. 미래 저장소 분할 컨텍스트
+
+본 작업은 미래 monorepo split의 **앱 코드 저장소** 자기 완결성 기반.
+
+### 11.1 분할 계획 (별도 의제, 일정 미정)
+
+```
+앱 (root 저장소)
+├─ index.html, js/**, css/**, sw.js, manifest.webmanifest, 빌드/배포 스크립트
+├─ data/source/         ← 서브모듈: 데이터(성서) — 마크다운 원본 + parser 출력 JSON
+└─ data/audio/          ← 서브모듈: 데이터(오디오) — MP3 ~수백 MB
+
+서버(nginx)             ← 별도 저장소: prod nginx config, BFF location 블록
+```
+
+**핵심**: 데이터(성서)·데이터(오디오)는 **앱의 git submodule**로 포함된다. 즉 앱 저장소를 clone하면 `git submodule update --init` 한 번으로 데이터까지 함께 보임. 현재 `data/source/`가 이미 private submodule(`anglican-kr/common-bible-text`)인 패턴의 확장.
+
+서버(nginx)만 별도 저장소 — 운영 인프라라 코드 라이프사이클이 다름.
+
+### 11.2 본 모듈화와의 관계
+
+**앱 저장소가 자기 완결적이려면**:
+
+- 데이터 서브모듈과는 **fetch (`/data/...` URL) 인터페이스**만 — 본 모듈화는 fetch 호출을 `storage.js`/`data-fetching` 영역에 집중시켜 의존 경계를 명확히 함
+- nginx 저장소와는 **`/oauth/token` BFF endpoint 계약**만 — sync 레이어가 이미 격리 (1차 ADR-012 적용 시)
+- 앱 코드 모듈 경계가 명확하면 future split 시 코드 이동·서브모듈 정합이 단순해짐
+
+따라서 본 모듈화는 monorepo split의 직접적 선행 작업.
+
+---
+
+## 12. 진행 일지
+
+| 일자       | 단계           | 내용                                                                                                                                                                                                                                                                                                                                  |
+| ---------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-05-09 | 설계 초안 작성 | Explore agent로 41 섹션 cross-reference 매트릭스 + 모듈 상태 공유 분석 + 자연 분할 후보 도출. 본 문서 §1-§9 작성                                                                                                                                                                                                                       |
+| 2026-05-09 | 결정 확정      | 사용자 review 완료 (Phase 6 Option A 명시 + ADR-018 작성 명시 + 즉시 시작 + 데이터는 앱의 서브모듈로 future split 예정). 미언급 항목은 권장 채택. §9 결정 사항으로 갱신, §10 성능 부수 효과 + §11 미래 저장소 분할 컨텍스트 추가, §12 진행 일지로 번호 이동. ADR-018(`docs/decisions/018-app-modularization.md`) 신설 |

--- a/index.html
+++ b/index.html
@@ -280,6 +280,7 @@
   <script defer src="/js/drive-sync.js"></script>
   <script defer src="/js/audio-cache.js"></script>
   <script defer src="/js/gtag-init.js"></script>
+  <script defer src="/js/app/helpers.js"></script>
   <script defer src="/js/app.js"></script>
 </body>
 </html>

--- a/js/app.js
+++ b/js/app.js
@@ -24,17 +24,11 @@
 /** @typedef {import("./types").BookmarkTreeFolder} BookmarkTreeFolder */
 
 const DATA_DIR = "/data";
-// Psalms use "편" instead of "장" as the chapter unit
-/** @param {string} bookId */
-function chUnit(bookId) { return bookId === "ps" ? "편" : "장"; }
 
-// All anchors below correspond to required ids in index.html and are present
-// at module load. `_$` casts the result so downstream code can use
-// HTMLElement methods without per-call null checks. Anchors that are
-// `<input>` elements get narrowed at the call sites that read .value /
-// .files (PR-2 onward as those code paths are visited).
-/** @param {string} id @returns {HTMLElement} */
-function _$(id) { return /** @type {HTMLElement} */ (document.getElementById(id)); }
+// Common DOM helpers live in js/app/helpers.js (ADR-018 Phase 1). `defer`
+// load order in index.html guarantees window.appHelpers is populated by
+// the time this script runs.
+const { _$, chUnit, el, clearNode, trapFocus } = window.appHelpers;
 
 const $app = _$("app");
 const $title = _$("page-title");
@@ -78,33 +72,7 @@ function announce(msg) {
   requestAnimationFrame(() => { $announce.textContent = msg; });
 }
 
-// Focus trap: keeps Tab cycling within a container while it is open.
-// Returns a cleanup function to remove the listener.
-/**
- * @param {HTMLElement} container
- * @returns {() => void}
- */
-function trapFocus(container) {
-  /** @param {KeyboardEvent} e */
-  function handler(e) {
-    if (e.key !== "Tab") return;
-    const focusable = /** @type {NodeListOf<HTMLElement>} */ (
-      container.querySelectorAll('a[href], button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])')
-    );
-    if (!focusable.length) return;
-    const first = focusable[0];
-    const last = focusable[focusable.length - 1];
-    if (e.shiftKey && (document.activeElement === first || document.activeElement === container)) {
-      e.preventDefault();
-      last.focus();
-    } else if (!e.shiftKey && document.activeElement === last) {
-      e.preventDefault();
-      first.focus();
-    }
-  }
-  container.addEventListener("keydown", handler);
-  return () => container.removeEventListener("keydown", handler);
-}
+// `trapFocus` was extracted to js/app/helpers.js (ADR-018 Phase 1).
 
 document.addEventListener("keydown", (e) => {
   if (e.key === "Escape") {
@@ -1246,38 +1214,8 @@ function dismissLaunchScreen() {
 }
 
 // ── Helpers ──
-
-/**
- * Generic narrow: `el("button", ...)` returns HTMLButtonElement, `el("input", ...)`
- * returns HTMLInputElement, etc. — so call sites can read .value/.disabled/.files
- * without per-call casts. `attrs` accepts mixed values (booleans for readOnly,
- * strings for aria-*, numbers for rows) since the DOM coerces in setAttribute.
- * @template {keyof HTMLElementTagNameMap} K
- * @param {K} tag
- * @param {Record<string, any> | null} [attrs]
- * @param {...(Node | string | null | undefined)} children
- * @returns {HTMLElementTagNameMap[K]}
- */
-function el(tag, attrs, ...children) {
-  const node = document.createElement(tag);
-  if (attrs) {
-    for (const [k, v] of Object.entries(attrs)) {
-      if (k === "className") node.className = v;
-      else if (k === "textContent") node.textContent = v;
-      else node.setAttribute(k, v);
-    }
-  }
-  for (const child of children) {
-    if (typeof child === "string") node.appendChild(document.createTextNode(child));
-    else if (child) node.appendChild(child);
-  }
-  return node;
-}
-
-/** @param {Node} node */
-function clearNode(node) {
-  while (node.firstChild) node.removeChild(node.firstChild);
-}
+// `el`, `clearNode`, `_$`, `chUnit`, `trapFocus` were extracted to
+// js/app/helpers.js (ADR-018 Phase 1). Imported via destructure at module head.
 
 // ── Bookmark storage helpers ──
 

--- a/js/app/helpers.js
+++ b/js/app/helpers.js
@@ -1,0 +1,96 @@
+"use strict";
+// @ts-check
+
+// Common DOM helpers used by all app modules. Anchored to `window.appHelpers`
+// so other modules can `const { el } = window.appHelpers;` after defer load.
+//
+// Module pattern: IIFE + window namespace, mirrors the sync layer
+// (`window.driveSync`/`window.syncTransport`). See ADR-018 + design doc
+// `docs/design/app-modularization.md`.
+//
+// Note: `announce(msg)` stays in app.js (Phase 8 owner) because it depends
+// on the `$announce` anchor; that anchor will move once app.js anchor
+// declarations are themselves modularized.
+
+window.appHelpers = (() => {
+  /**
+   * Get the element by ID. Casts to HTMLElement non-null on the assumption
+   * that the id is required by index.html. Anchors that are <input>/<button>
+   * elements still require explicit narrowing at the call site (.value /
+   * .disabled).
+   * @param {string} id
+   * @returns {HTMLElement}
+   */
+  function _$(id) {
+    return /** @type {HTMLElement} */ (document.getElementById(id));
+  }
+
+  // Psalms use "편" instead of "장" as the chapter unit.
+  /** @param {string} bookId */
+  function chUnit(bookId) {
+    return bookId === "ps" ? "편" : "장";
+  }
+
+  /**
+   * Generic narrow: el("button", ...) returns HTMLButtonElement,
+   * el("input", ...) returns HTMLInputElement, etc. — so call sites can read
+   * .value/.disabled/.files without per-call casts. `attrs` accepts mixed
+   * values (booleans for readOnly, strings for aria-*, numbers for rows)
+   * since the DOM coerces in setAttribute.
+   * @template {keyof HTMLElementTagNameMap} K
+   * @param {K} tag
+   * @param {Record<string, any> | null} [attrs]
+   * @param {...(Node | string | null | undefined)} children
+   * @returns {HTMLElementTagNameMap[K]}
+   */
+  function el(tag, attrs, ...children) {
+    const node = document.createElement(tag);
+    if (attrs) {
+      for (const [k, v] of Object.entries(attrs)) {
+        if (k === "className") node.className = v;
+        else if (k === "textContent") node.textContent = v;
+        else node.setAttribute(k, v);
+      }
+    }
+    for (const child of children) {
+      if (typeof child === "string") node.appendChild(document.createTextNode(child));
+      else if (child) node.appendChild(child);
+    }
+    return node;
+  }
+
+  /** @param {Node} node */
+  function clearNode(node) {
+    while (node.firstChild) node.removeChild(node.firstChild);
+  }
+
+  /**
+   * Focus trap: keeps Tab cycling within a container while it is open.
+   * Returns a cleanup function to remove the listener.
+   * @param {HTMLElement} container
+   * @returns {() => void}
+   */
+  function trapFocus(container) {
+    /** @param {KeyboardEvent} e */
+    function handler(e) {
+      if (e.key !== "Tab") return;
+      const focusable = /** @type {NodeListOf<HTMLElement>} */ (
+        container.querySelectorAll('a[href], button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])')
+      );
+      if (!focusable.length) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (e.shiftKey && (document.activeElement === first || document.activeElement === container)) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+    container.addEventListener("keydown", handler);
+    return () => container.removeEventListener("keydown", handler);
+  }
+
+  return { _$, chUnit, el, clearNode, trapFocus };
+})();

--- a/js/types.d.ts
+++ b/js/types.d.ts
@@ -471,6 +471,22 @@ export interface BiblePrologue {
   paragraphs: string[];
 }
 
+// ── App helpers facade (js/app/helpers.js) ──────────────────────────────────
+// Phase 1 of the app.js modularization (ADR-018). Common DOM helpers shared
+// by all app/* modules.
+
+export interface AppHelpers {
+  _$: (id: string) => HTMLElement;
+  chUnit: (bookId: string) => string;
+  el: <K extends keyof HTMLElementTagNameMap>(
+    tag: K,
+    attrs?: Record<string, any> | null,
+    ...children: Array<Node | string | null | undefined>
+  ) => HTMLElementTagNameMap[K];
+  clearNode: (node: Node) => void;
+  trapFocus: (container: HTMLElement) => () => void;
+}
+
 // ── Window augmentation ──────────────────────────────────────────────────────
 
 declare global {
@@ -498,6 +514,9 @@ declare global {
     // Pre-fetched data/books.json promise (js/pre-fetch.js). app.js's
     // loadBooks() awaits this when present rather than re-issuing the fetch.
     booksPromise?: Promise<BooksData>;
+
+    // App-layer module facades (ADR-018, see docs/design/app-modularization.md).
+    appHelpers: AppHelpers;
 
     // UI side-effects defined in app.js. Optional because state-machine.js
     // guards each call with `typeof ... === "function"`.

--- a/sw.js
+++ b/sw.js
@@ -3,7 +3,7 @@
 // caches are preserved across shell-only releases. Bump DATA_CACHE only when
 // bible JSON or search index format changes; bump AUDIO_CACHE only when mp3
 // sources are re-encoded.
-const SHELL_CACHE = "shell-51";
+const SHELL_CACHE = "shell-52";
 const DATA_CACHE = "data-2";
 const AUDIO_CACHE = "audio-1"; // must equal js/audio-cache.js AUDIO_CACHE_NAME
 
@@ -25,6 +25,7 @@ const SHELL_FILES = [
   "/index.html",
   "/privacy.html",
   "/js/app.js",
+  "/js/app/helpers.js",
   "/js/drive-sync.js",
   "/js/audio-cache.js",
   "/js/sync/debug-log.js",


### PR DESCRIPTION
## Summary

ADR-012 2차 적용 **2라운드의 첫 단계**. \`js/app.js\`(6,082줄)를 도메인별 모듈로 분할해 각 모듈에 \`// @ts-check\`를 영구 활성화하고, 최종적으로 \`tsconfig.app.json\`을 삭제(Phase 8)하는 8단계 작업의 시작점.

## 신설 문서

- **ADR-018** [\`docs/decisions/018-app-modularization.md\`](https://github.com/anglican-kr/common-bible/blob/feat/app-modular-phase1/docs/decisions/018-app-modularization.md) — 분할 결정·맥락·검토한 대안·채택 방식. 미래 monorepo split 컨텍스트 포함 (앱 / 데이터-성서 / 데이터-오디오 / 서버-nginx; 데이터 둘은 앱의 git submodule)
- **살아있는 설계 문서** [\`docs/design/app-modularization.md\`](https://github.com/anglican-kr/common-bible/blob/feat/app-modular-phase1/docs/design/app-modularization.md) — 41 섹션 cross-reference 매트릭스, 모듈 상태 공유 분석, 8단계 PR 계획, 모듈 시스템 결정 (Multi-script + \`defer\`), 부수 효과(성능)·미래 저장소 분할 컨텍스트

## Phase 1 산출물

- \`js/app/helpers.js\` 신설 (5개 함수)
  - \`_$(id)\` — \`getElementById\` HTMLElement non-null cast
  - \`chUnit(bookId)\` — Psalms는 "편" 외엔 "장"
  - \`el<K>(tag, attrs?, ...children)\` — generic narrow (\`el(\"button\")\` → \`HTMLButtonElement\`)
  - \`clearNode(node)\` — 자식 노드 제거
  - \`trapFocus(container)\` — Tab cycling
  - **모듈 패턴**: IIFE + \`window.appHelpers\` (sync 레이어와 일관, ADR-018 §채택 방식)
  - \`// @ts-check\` 영구 활성화
- \`js/types.d.ts\`: \`AppHelpers\` 인터페이스 신규 + \`Window\` augmentation
- \`js/app.js\` 헤드: \`const { _$, chUnit, el, clearNode, trapFocus } = window.appHelpers;\` destructure. 추출된 함수 정의 제거 (6,082줄 → **6,053줄**, -29)
- \`index.html\`: \`<script defer src=\"/js/app/helpers.js\"></script>\` 추가 (app.js 앞)
- \`sw.js\`: SHELL_CACHE \`shell-51\` → \`shell-52\`, \`/js/app/helpers.js\` 셸 매니페스트 추가

\`announce(msg)\`는 \`$announce\` anchor에 의존해 app.js에 잔류 (Phase 8 owner — anchor도 모듈화될 시점에 함께 이동).

## Test plan

- [x] \`npx tsc -p tsconfig.app.json --noEmit\` — 잔여 3 (gtag-init.js 외부, ADR-012 미적용)
- [x] \`npx tsc -p tsconfig.json --noEmit\` — 0 error
- [x] \`npx tsc -p tsconfig.worker.json --noEmit\` — 0 error
- [x] \`node --test tests/unit/*.test.js\` — 111/111 pass
- [ ] 브라우저 동작 확인 — 머지 전 사용자 수동 (\`scripts/serve.py 8080\` → \`/\` 접속, 콘솔 0 오류)

## 다음 단계

Phase 2: \`storage.js\` (~250줄) — localStorage 헬퍼 묶음 (Reading position / Audio time / Search history / Font/Theme/Color/Book order / Bookmark storage / Install nudge). 의존도 가장 낮음 (순수 함수).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly a refactor, but it changes script load order and service-worker shell caching; a missing/incorrect `defer` order or cache mismatch could cause runtime failures on load.
> 
> **Overview**
> Begins ADR-018 modularization by extracting common DOM utilities from `js/app.js` into a new `js/app/helpers.js` module (IIFE exported as `window.appHelpers`) with `// @ts-check` enabled.
> 
> Updates `js/app.js` to consume these helpers via destructuring, adds the new script to `index.html` ahead of `app.js`, and bumps `sw.js` shell cache + precache list so the helper module is available offline.
> 
> Adds `AppHelpers` types and `Window.appHelpers` augmentation in `js/types.d.ts`, and introduces ADR/design docs describing the phased modularization plan.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03a82bdd195899746522281ac720375db0a051aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->