### PR TITLE
feat: app.js 모듈 분할 Phase 2 — storage.js 추출 (ADR-018)

### DIFF
--- a/docs/decisions/018-app-modularization.md
+++ b/docs/decisions/018-app-modularization.md
@@ -51,18 +51,28 @@ ADR-012 1라운드(PR-1~7, 2026-05-09 머지)에서 `js/app.js`에 JSDoc + null/
 각 모듈은 IIFE로 감싸 한 객체에 export. 1차 적용된 sync 레이어(`window.driveSync`, `window.syncTransport` 등)와 동일.
 
 ```js
-// js/app/storage.js
+// js/app/helpers.js (Phase 1)
 "use strict";
 // @ts-check
-window.appStorage = (() => {
-  /** @returns {ReadingPosition | null} */
-  function loadReadingPosition() { /* ... */ }
+window.appHelpers = (() => {
+  function _$(id) { /* ... */ }
   // ...
-  return { loadReadingPosition, saveReadingPosition, /* ... */ };
+  return { _$, chUnit, el, clearNode, trapFocus };
 })();
 ```
 
-호출 측은 `window.appStorage.loadReadingPosition()` 또는 IIFE 직후 `const { loadReadingPosition } = window.appStorage;`로 받음.
+호출 측은 `window.appHelpers._$()` 또는 IIFE 직후 `const { _$ } = window.appHelpers;`로 받음.
+
+### module-vs-script 예외 (Phase 2부터)
+
+원칙은 `<script defer>` + 글로벌 `window.X` 패턴(위)이지만, 모듈이 정의하는 `function`/`@typedef` 이름이 다른 1차 적용 파일(특히 `js/sync/store-v2.js`)의 글로벌 정의와 충돌하면 그 모듈만 ES module로 옵트인한다. 옵트인 방법:
+
+1. 파일 끝에 `export {};` 한 줄 추가 (런타임 동작 무변동, TypeScript는 그 파일을 module로 인식 → 함수/typedef가 module scope)
+2. `index.html`에서 그 파일을 `<script type="module" src="..."></script>`로 로드 (`type="module"` 은 자동 deferred + 등장 순서 실행 보장)
+
+Phase 2(`storage.js`) 시점에 `saveBookmarks`/`loadBookmarks` 이름이 `js/sync/store-v2.js`와 글로벌 충돌해 두 파일 모두 옵트인. 다른 sync 파일은 store-v2 함수를 `window.syncStoreV2.X` facade로만 호출하므로 caller 변경 불필요. ADR-001 SPA 단순성은 여전히 유효 (빌드 단계 0, import/export 의무 없음, `window.X` 글로벌 노출 그대로).
+
+향후 단계도 충돌 발생 시 모듈 단위로 같은 옵트인 적용. 모든 모듈을 일괄 ESM 전환하는 광범위 변경은 의도하지 않음.
 
 ### 공유 상태 (Phase 6)
 

--- a/docs/design/app-modularization.md
+++ b/docs/design/app-modularization.md
@@ -121,7 +121,7 @@ ADR-012 2차 적용의 **2라운드**. 1라운드에서는 `js/app.js`에 JSDoc 
 | **ESM (`<script type="module">`)** | 없음      | 모듈 로드 순서가 import에 의해 결정 | entry script만 | import/export        | 의존 그래프 명확            |
 | `.ts` + tsc 빌드                   | 큼        | —                                   | —              | —                    | ❌ ADR-001 위배             |
 
-### 4.2 권장 — **Multi-script + `defer`**
+### 4.2 채택 — **Multi-script + `defer`** (모듈별 ESM 옵트인 예외)
 
 이유:
 
@@ -378,3 +378,5 @@ CLAUDE.md `tests/e2e/` 절차를 따라 사용자 수동 실행:
 | ---------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | 2026-05-09 | 설계 초안 작성 | Explore agent로 41 섹션 cross-reference 매트릭스 + 모듈 상태 공유 분석 + 자연 분할 후보 도출. 본 문서 §1-§9 작성                                                                                                                                                                                                                       |
 | 2026-05-09 | 결정 확정      | 사용자 review 완료 (Phase 6 Option A 명시 + ADR-018 작성 명시 + 즉시 시작 + 데이터는 앱의 서브모듈로 future split 예정). 미언급 항목은 권장 채택. §9 결정 사항으로 갱신, §10 성능 부수 효과 + §11 미래 저장소 분할 컨텍스트 추가, §12 진행 일지로 번호 이동. ADR-018(`docs/decisions/018-app-modularization.md`) 신설 |
+| 2026-05-09 | Phase 1 머지 (#88) | `js/app/helpers.js` 추출 (5개 헬퍼: `_$`, `chUnit`, `el`, `clearNode`, `trapFocus`). IIFE + `window.appHelpers`. types.d.ts에 `AppHelpers` 인터페이스. app.js 6,082 → 6,053줄 |
+| 2026-05-09 | Phase 2 작성 완료 | `js/app/storage.js` 추출 (28개 함수 + 3개 상수: `FONT_SIZES`, `DEFAULT_FONT_SIZE`, `COLOR_SCHEMES`, `SEARCH_HISTORY_MAX`). Reading position / Audio time / Search history / Settings / Bookmarks / Install nudge / `_maybeRequestPersist` 통합. `js/sync/store-v2.js`의 `saveBookmarks`/`loadBookmarks`와 글로벌 함수 이름 충돌 → storage.js + store-v2.js 둘 다 ES module 옵트인 (`export {};` + `<script type="module">`). 다른 sync 파일은 `window.syncStoreV2` facade만 사용해 caller 변경 0. `tests/unit/search-history.test.js` `APP_PATH` 갱신. app.js 6,053 → 5,835줄 (-218). main + worker tsc 0 error, 유닛 111건 통과 |

--- a/index.html
+++ b/index.html
@@ -275,12 +275,17 @@
   <script defer src="/js/sync/debug-log.js"></script>
   <script defer src="/js/sync/refresh-store.js"></script>
   <script defer src="/js/sync/transport.js"></script>
-  <script defer src="/js/sync/store-v2.js"></script>
+  <!-- store-v2 is ESM-opted-in (ADR-018) so its `saveBookmarks`/`loadBookmarks`
+       names don't collide with js/app/storage.js at the global TS scope. -->
+  <script type="module" src="/js/sync/store-v2.js"></script>
   <script defer src="/js/sync/state-machine.js"></script>
   <script defer src="/js/drive-sync.js"></script>
   <script defer src="/js/audio-cache.js"></script>
   <script defer src="/js/gtag-init.js"></script>
   <script defer src="/js/app/helpers.js"></script>
+  <!-- storage.js is an ES module (see ADR-018). `type="module"` is implicitly
+       deferred and runs after defer scripts in document order. -->
+  <script type="module" src="/js/app/storage.js"></script>
   <script defer src="/js/app.js"></script>
 </body>
 </html>

--- a/js/app.js
+++ b/js/app.js
@@ -15,11 +15,12 @@
 /** @typedef {import("./types").BibleChapter} BibleChapter */
 /** @typedef {import("./types").BiblePrologue} BiblePrologue */
 /** @typedef {import("./types").BibleVerse} BibleVerse */
-// `BookmarkTreeNode` is already declared as a file-global typedef in
-// js/sync/store-v2.js (type aliases don't merge, so re-typedef'ing here
-// would trip TS2300). We reuse that global alias directly. The sub-types
-// `BookmarkTreeBookmark` / `BookmarkTreeFolder` are app.js-only — store-v2
-// only needs the union form.
+// `BookmarkTreeNode` was previously deferred to the global typedef declared
+// in js/sync/store-v2.js, but ADR-018 Phase 2 opted store-v2.js into an ES
+// module (so its `saveBookmarks`/`loadBookmarks` no longer collide with
+// js/app/storage.js). That moved the alias into module scope, so app.js now
+// declares its own typedef.
+/** @typedef {import("./types").BookmarkTreeNode} BookmarkTreeNode */
 /** @typedef {import("./types").BookmarkTreeBookmark} BookmarkTreeBookmark */
 /** @typedef {import("./types").BookmarkTreeFolder} BookmarkTreeFolder */
 
@@ -29,6 +30,24 @@ const DATA_DIR = "/data";
 // load order in index.html guarantees window.appHelpers is populated by
 // the time this script runs.
 const { _$, chUnit, el, clearNode, trapFocus } = window.appHelpers;
+
+// localStorage helpers + UI-shared constants live in js/app/storage.js
+// (ADR-018 Phase 2). All save fns also notify window.syncStoreV2 + driveSync.
+const {
+  FONT_SIZES, DEFAULT_FONT_SIZE, COLOR_SCHEMES, SEARCH_HISTORY_MAX,
+  saveReadingPosition, loadReadingPosition, clearReadingPosition,
+  saveAudioTime, loadAudioTime, clearAudioTime,
+  normalizeSearchQuery, loadSearchHistory, saveSearchHistory,
+  pushSearchHistory, removeSearchHistory, clearSearchHistory,
+  loadStartupBehavior, saveStartupBehavior,
+  loadFontSize, saveFontSize,
+  loadColorScheme, saveColorScheme,
+  loadTheme, saveTheme,
+  loadBookOrder, saveBookOrder,
+  generateId, loadBookmarks, saveBookmarks,
+  _loadNudgeState, _saveNudgeState,
+  _maybeRequestPersist,
+} = window.appStorage;
 
 const $app = _$("app");
 const $title = _$("page-title");
@@ -97,29 +116,11 @@ document.addEventListener("keydown", (e) => {
 });
 
 // ── Reading position persistence ──
-
-const STORAGE_KEY = "bible-last-read";
-const FONT_SIZE_KEY = "bible-font-size";
-const THEME_KEY = "bible-theme";
-const BOOK_ORDER_KEY = "bible-book-order";
-const COLOR_SCHEME_KEY = "bible-color-scheme";
-const STARTUP_BEHAVIOR_KEY = "bible-startup"; // "resume" | "home"
-const AUDIO_POS_KEY = "bible-audio-pos";
-const BOOKMARK_KEY = "bible-bookmarks";
-const INSTALL_NUDGE_KEY = "bible-install-nudge";
-const SEARCH_HISTORY_KEY = "bible-search-history";
-const SEARCH_HISTORY_MAX = 30;       // storage cap (LRU)
-const SEARCH_HISTORY_VISIBLE = 10;   // visible by default; rest behind "더 보기"
-const FONT_SIZES = [16, 18, 20, 22, 24];
-
-/** @type {ReadonlyArray<ColorSchemeEntry>} */
-const COLOR_SCHEMES = [
-  { id: "navy",       name: "네이비",   swatch: "#1e3a5f", iconBg: "#1a1a2e" },
-  { id: "terracotta", name: "버건디",   swatch: "#6b3a2a", iconBg: "#6b3a2a" },
-  { id: "green",      name: "초록",     swatch: "#1a6b50", iconBg: "#1a6b50" },
-  { id: "purple",     name: "보라",     swatch: "#5a2d82", iconBg: "#5a2d82" },
-];
-const DEFAULT_FONT_SIZE = 18;
+// Storage key constants + load/save helpers were extracted to
+// js/app/storage.js (ADR-018 Phase 2). `SEARCH_HISTORY_VISIBLE` is the only
+// search-history constant that stays here — it is consumed only by the
+// search history panel controller (Phase 5 owner).
+const SEARCH_HISTORY_VISIBLE = 10; // visible by default; rest behind "더 보기"
 
 /** @type {(() => void) | null} */
 let _scrollTrackCleanup = null;
@@ -153,22 +154,7 @@ let _bookmarkDrawerCloseTimer = null;
 /** @type {DragState | null} */
 let _dragState = null; // { id, ghost, origLi, startY, origTop }
 
-/**
- * @param {string} bookId
- * @param {number | "prologue"} chapter
- * @param {number | null} [verse]
- */
-function saveReadingPosition(bookId, chapter, verse = null) {
-  try {
-    const val = { bookId, chapter, verse };
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(val));
-    // Local form (verse: number|null) intentionally diverges from the synced
-    // LastReadValue (verseSpec?: string). Excess properties on a variable
-    // are not checked at the call site, so this is safe.
-    window.syncStoreV2?.saveLastRead(/** @type {import("./types").LastReadValue} */ (val));
-    if (window.driveSync) window.driveSync.scheduleUpload();
-  } catch (_) {}
-}
+// `saveReadingPosition` was extracted to js/app/storage.js (ADR-018 Phase 2).
 
 /**
  * @param {string} bookId
@@ -205,48 +191,8 @@ function startScrollTracking(bookId, chapter) {
   };
 }
 
-/** @returns {ReadingPosition | null} */
-function loadReadingPosition() {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (!raw) return null;
-    // Shape relies on saveReadingPosition writers; not validated at runtime.
-    return /** @type {ReadingPosition} */ (JSON.parse(raw));
-  } catch (_) {
-    return null;
-  }
-}
-
-/**
- * @param {string} bookId
- * @param {number} chapter
- * @param {number} time
- */
-function saveAudioTime(bookId, chapter, time) {
-  try {
-    localStorage.setItem(AUDIO_POS_KEY, JSON.stringify({ bookId, chapter, time }));
-  } catch (_) {}
-}
-
-/**
- * @param {string} bookId
- * @param {number} chapter
- * @returns {number | null}
- */
-function loadAudioTime(bookId, chapter) {
-  try {
-    const raw = localStorage.getItem(AUDIO_POS_KEY);
-    if (!raw) return null;
-    /** @type {AudioPosition} */
-    const pos = JSON.parse(raw);
-    if (pos && pos.bookId === bookId && pos.chapter === chapter && pos.time > 0) return pos.time;
-  } catch (_) {}
-  return null;
-}
-
-function clearAudioTime() {
-  try { localStorage.removeItem(AUDIO_POS_KEY); } catch (_) {}
-}
+// `loadReadingPosition`, `saveAudioTime`, `loadAudioTime`, `clearAudioTime`
+// were extracted to js/app/storage.js (ADR-018 Phase 2).
 
 // ── Audio cache LRU helpers (ADR-016) ──
 // One-shot persisted-storage request: called on the first value moment
@@ -255,17 +201,7 @@ function clearAudioTime() {
 // site has high engagement. We swallow result errors — even if denied, the
 // LRU loop in audio-cache.js still functions, just without iOS 7-day evict
 // immunity.
-let _persistAttempted = false;
-function _maybeRequestPersist() {
-  if (_persistAttempted) return;
-  _persistAttempted = true;
-  if (!navigator.storage?.persist) return;
-  navigator.storage.persist()
-    .then((granted) => {
-      window.syncDebugLog?.log({ kind: "ACTION", event: "storage-persist", granted });
-    })
-    .catch(() => {});
-}
+// `_maybeRequestPersist` was extracted to js/app/storage.js (ADR-018 Phase 2).
 
 // Soft-cap eviction. Page-driven (SW only enforces hard cap on put). Called
 // on visibilitychange→hidden so the work runs while the user is not actively
@@ -480,91 +416,14 @@ document.addEventListener("visibilitychange", () => {
   }, { passive: true });
 })();
 
-// ── BEGIN SEARCH HISTORY HELPERS ──
-// Local-only (not Drive-synced — see ADR-014). Whitespace-normalized strings,
-// LRU-deduped, capped at SEARCH_HISTORY_MAX. The block between the BEGIN/END
-// markers is sliced into tests/unit/search-history.test.js, so changes to the
-// LRU/normalization semantics need a corresponding test update.
+// Search history helpers were extracted to js/app/storage.js
+// (ADR-018 Phase 2). The BEGIN/END markers + tests/unit/search-history.test.js
+// follow the new location.
 
-/** @param {unknown} q @returns {string} */
-function normalizeSearchQuery(q) {
-  return String(q || "").trim().replace(/\s+/g, " ");
-}
-
-/** @returns {SearchHistoryList} */
-function loadSearchHistory() {
-  try {
-    const rawStr = localStorage.getItem(SEARCH_HISTORY_KEY);
-    if (!rawStr) return [];
-    const raw = JSON.parse(rawStr);
-    if (!Array.isArray(raw)) return [];
-    return raw.filter((s) => typeof s === "string" && s.length > 0).slice(0, SEARCH_HISTORY_MAX);
-  } catch (_) {
-    return [];
-  }
-}
-
-/** @param {SearchHistoryList} list */
-function saveSearchHistory(list) {
-  try {
-    localStorage.setItem(SEARCH_HISTORY_KEY, JSON.stringify(list.slice(0, SEARCH_HISTORY_MAX)));
-  } catch (_) {}
-}
-
-/** @param {string} q @returns {SearchHistoryList} */
-function pushSearchHistory(q) {
-  const norm = normalizeSearchQuery(q);
-  if (!norm) return loadSearchHistory();
-  const list = loadSearchHistory().filter((s) => s !== norm);
-  list.unshift(norm);
-  const trimmed = list.slice(0, SEARCH_HISTORY_MAX);
-  saveSearchHistory(trimmed);
-  return trimmed;
-}
-
-/** @param {string} q @returns {SearchHistoryList} */
-function removeSearchHistory(q) {
-  const norm = normalizeSearchQuery(q);
-  const list = loadSearchHistory().filter((s) => s !== norm);
-  saveSearchHistory(list);
-  return list;
-}
-
-/** @returns {SearchHistoryList} */
-function clearSearchHistory() {
-  try { localStorage.removeItem(SEARCH_HISTORY_KEY); } catch (_) {}
-  return [];
-}
-// ── END SEARCH HISTORY HELPERS ──
-
-/** @returns {string} */
-function loadStartupBehavior() {
-  return localStorage.getItem(STARTUP_BEHAVIOR_KEY) || "resume";
-}
-
-/** @param {string} val */
-function saveStartupBehavior(val) {
-  localStorage.setItem(STARTUP_BEHAVIOR_KEY, val);
-  window.syncStoreV2?.saveSetting("startupBehavior", val);
-  if (window.driveSync) window.driveSync.scheduleUpload();
-}
+// `loadStartupBehavior`, `saveStartupBehavior`, `loadFontSize`, `saveFontSize`
+// were extracted to js/app/storage.js (ADR-018 Phase 2).
 
 // ── Font size ──
-
-/** @returns {number} */
-function loadFontSize() {
-  try {
-    const v = parseInt(localStorage.getItem(FONT_SIZE_KEY) ?? "", 10);
-    return FONT_SIZES.includes(v) ? v : DEFAULT_FONT_SIZE;
-  } catch (_) {
-    return DEFAULT_FONT_SIZE;
-  }
-}
-
-/** @param {number} size */
-function saveFontSize(size) {
-  try { localStorage.setItem(FONT_SIZE_KEY, String(size)); window.syncStoreV2?.saveSetting("fontSize", size); if (window.driveSync) window.driveSync.scheduleUpload(); } catch (_) {}
-}
 
 /** @param {number | string} size */
 function applyFontSize(size) {
@@ -1051,21 +910,7 @@ function updateAppIcons(scheme) {
 }
 
 // ── Color scheme ──
-
-/** @returns {ColorSchemeId} */
-function loadColorScheme() {
-  try {
-    const v = localStorage.getItem(COLOR_SCHEME_KEY);
-    const found = COLOR_SCHEMES.find((s) => s.id === v);
-    if (found) return found.id;
-  } catch (_) {}
-  return "navy";
-}
-
-/** @param {ColorSchemeId} scheme */
-function saveColorScheme(scheme) {
-  try { localStorage.setItem(COLOR_SCHEME_KEY, scheme); window.syncStoreV2?.saveSetting("colorScheme", scheme); if (window.driveSync) window.driveSync.scheduleUpload(); } catch (_) {}
-}
+// `loadColorScheme`/`saveColorScheme` were extracted to js/app/storage.js.
 
 // Default favicon/apple-touch-icon URLs as shipped in index.html.
 // Captured once so we can restore them when reverting to the navy scheme
@@ -1100,20 +945,7 @@ function applyColorScheme(schemeName) {
 }
 
 // ── Theme ──
-
-/** @returns {ThemeMode} */
-function loadTheme() {
-  try {
-    const saved = localStorage.getItem(THEME_KEY);
-    if (saved === "dark" || saved === "light" || saved === "system") return saved;
-  } catch (_) {}
-  return "system";
-}
-
-/** @param {string} theme */
-function saveTheme(theme) {
-  try { localStorage.setItem(THEME_KEY, theme); window.syncStoreV2?.saveSetting("theme", theme); if (window.driveSync) window.driveSync.scheduleUpload(); } catch (_) {}
-}
+// `loadTheme`/`saveTheme` were extracted to js/app/storage.js.
 
 /** @type {((e: MediaQueryListEvent) => void) | null} */
 let _systemThemeListener = null;
@@ -1146,20 +978,7 @@ function applyTheme(theme) {
 }
 
 // ── Book order ──
-
-/** @returns {BookOrderKind} */
-function loadBookOrder() {
-  try {
-    const v = localStorage.getItem(BOOK_ORDER_KEY);
-    if (v === "canonical" || v === "vulgate") return v;
-  } catch (_) {}
-  return "canonical";
-}
-
-/** @param {string} order */
-function saveBookOrder(order) {
-  try { localStorage.setItem(BOOK_ORDER_KEY, order); window.syncStoreV2?.saveSetting("bookOrder", order); if (window.driveSync) window.driveSync.scheduleUpload(); } catch (_) {}
-}
+// `loadBookOrder`/`saveBookOrder` were extracted to js/app/storage.js.
 
 // Apply saved settings on load
 window.syncStoreV2?.migrateLegacyIfNeeded();
@@ -1218,32 +1037,9 @@ function dismissLaunchScreen() {
 // js/app/helpers.js (ADR-018 Phase 1). Imported via destructure at module head.
 
 // ── Bookmark storage helpers ──
-
-/** @returns {string} */
-function generateId() {
-  return Date.now().toString(36) + Math.random().toString(36).slice(2);
-}
-
-/**
- * @returns {import("./types").BookmarkTreeNode[]}
- */
-function loadBookmarks() {
-  if (window.syncStoreV2) return window.syncStoreV2.loadBookmarks();
-  try {
-    const raw = localStorage.getItem(BOOKMARK_KEY);
-    return raw ? JSON.parse(raw) : [];
-  } catch (_) { return []; }
-}
-
-/** @param {import("./types").BookmarkTreeNode[]} store */
-function saveBookmarks(store) {
-  try {
-    localStorage.setItem(BOOKMARK_KEY, JSON.stringify(store));
-    window.syncStoreV2?.saveBookmarks(store);
-    if (window.driveSync) window.driveSync.scheduleUpload();
-    _maybeRequestPersist();
-  } catch (_) {}
-}
+// `generateId`, `loadBookmarks`, `saveBookmarks` were extracted to
+// js/app/storage.js (ADR-018 Phase 2). saveBookmarks calls
+// _maybeRequestPersist internally now.
 
 // ── Verse spec utilities ──
 
@@ -2072,11 +1868,7 @@ function renderBookList(books) {
   }
 }
 
-function clearReadingPosition() {
-  try {
-    localStorage.removeItem(STORAGE_KEY);
-  } catch (_) {}
-}
+// `clearReadingPosition` was extracted to js/app/storage.js (ADR-018 Phase 2).
 
 function renderResumeBanner(books) {
   const pos = loadReadingPosition();
@@ -4599,18 +4391,9 @@ document.addEventListener("keydown", (e) => {
 });
 
 // ── Install nudge (auto-show) ──
-
-function _loadNudgeState() {
-  try {
-    const raw = localStorage.getItem(INSTALL_NUDGE_KEY);
-    if (raw) return JSON.parse(raw);
-  } catch (_) {}
-  return { visits: 0, nextShow: 1, neverShow: false };
-}
-
-function _saveNudgeState(state) {
-  try { localStorage.setItem(INSTALL_NUDGE_KEY, JSON.stringify(state)); } catch (_) {}
-}
+// `_loadNudgeState`/`_saveNudgeState` were extracted to js/app/storage.js
+// (ADR-018 Phase 2). `maybeShowInstallNudge` will move to js/app/install.js
+// in Phase 4.
 
 function maybeShowInstallNudge() {
   const platform = install.detectPlatform();

--- a/js/app/storage.js
+++ b/js/app/storage.js
@@ -1,0 +1,350 @@
+// @ts-check
+
+// All localStorage-backed load/save helpers. Each save also notifies the
+// sync layer (window.syncStoreV2 + window.driveSync) when applicable, so
+// settings/bookmarks/reading-position changes propagate to Drive.
+//
+// Module pattern: ES module + window.appStorage assignment. Phase 2 of the
+// app.js modularization (ADR-018). This file is loaded as
+// `<script type="module">` (rather than the multi-script `defer` baseline
+// used by helpers.js) so its function declarations and `@typedef`s are
+// confined to module scope — without this, names like `saveBookmarks` /
+// `loadBookmarks` collide with store-v2.js (sync layer) at the TypeScript
+// global level. See ADR-018 §"채택 방식 — module-vs-script 예외".
+
+window.appStorage = (() => {
+  /** @typedef {import("../types").ReadingPosition} ReadingPosition */
+  /** @typedef {import("../types").AudioPosition} AudioPosition */
+  /** @typedef {import("../types").SearchHistoryList} SearchHistoryList */
+  /** @typedef {import("../types").ColorSchemeId} ColorSchemeId */
+  /** @typedef {import("../types").ColorSchemeEntry} ColorSchemeEntry */
+  /** @typedef {import("../types").ThemeMode} ThemeMode */
+  /** @typedef {import("../types").BookOrderKind} BookOrderKind */
+  /** @typedef {import("../types").BookmarkTreeNode} BookmarkTreeNode */
+  /** @typedef {import("../types").InstallNudgeState} InstallNudgeState */
+  // ── Storage keys (private to this module) ──
+  const STORAGE_KEY = "bible-last-read";
+  const FONT_SIZE_KEY = "bible-font-size";
+  const THEME_KEY = "bible-theme";
+  const BOOK_ORDER_KEY = "bible-book-order";
+  const COLOR_SCHEME_KEY = "bible-color-scheme";
+  const STARTUP_BEHAVIOR_KEY = "bible-startup"; // "resume" | "home"
+  const AUDIO_POS_KEY = "bible-audio-pos";
+  const BOOKMARK_KEY = "bible-bookmarks";
+  const INSTALL_NUDGE_KEY = "bible-install-nudge";
+  const SEARCH_HISTORY_KEY = "bible-search-history";
+  const SEARCH_HISTORY_MAX = 30; // storage cap (LRU)
+
+  // ── UI-shared constants (consumed by settings-ui in Phase 3) ──
+  const FONT_SIZES = [16, 18, 20, 22, 24];
+  const DEFAULT_FONT_SIZE = 18;
+  /** @type {ReadonlyArray<ColorSchemeEntry>} */
+  const COLOR_SCHEMES = [
+    { id: "navy",       name: "네이비",   swatch: "#1e3a5f", iconBg: "#1a1a2e" },
+    { id: "terracotta", name: "버건디",   swatch: "#6b3a2a", iconBg: "#6b3a2a" },
+    { id: "green",      name: "초록",     swatch: "#1a6b50", iconBg: "#1a6b50" },
+    { id: "purple",     name: "보라",     swatch: "#5a2d82", iconBg: "#5a2d82" },
+  ];
+
+  // ── Reading position ──
+
+  /**
+   * @param {string} bookId
+   * @param {number | "prologue"} chapter
+   * @param {number | null} [verse]
+   */
+  function saveReadingPosition(bookId, chapter, verse = null) {
+    try {
+      const val = { bookId, chapter, verse };
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(val));
+      // Local form (verse: number|null) intentionally diverges from the synced
+      // LastReadValue (verseSpec?: string). Excess properties on a variable
+      // are not checked at the call site, so this is safe.
+      window.syncStoreV2?.saveLastRead(/** @type {import("../types").LastReadValue} */ (val));
+      if (window.driveSync) window.driveSync.scheduleUpload();
+    } catch (_) {}
+  }
+
+  /** @returns {ReadingPosition | null} */
+  function loadReadingPosition() {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) return null;
+      // Shape relies on saveReadingPosition writers; not validated at runtime.
+      return /** @type {ReadingPosition} */ (JSON.parse(raw));
+    } catch (_) {
+      return null;
+    }
+  }
+
+  function clearReadingPosition() {
+    try { localStorage.removeItem(STORAGE_KEY); } catch (_) {}
+  }
+
+  // ── Audio time ──
+
+  /**
+   * @param {string} bookId
+   * @param {number} chapter
+   * @param {number} time
+   */
+  function saveAudioTime(bookId, chapter, time) {
+    try {
+      localStorage.setItem(AUDIO_POS_KEY, JSON.stringify({ bookId, chapter, time }));
+    } catch (_) {}
+  }
+
+  /**
+   * @param {string} bookId
+   * @param {number} chapter
+   * @returns {number | null}
+   */
+  function loadAudioTime(bookId, chapter) {
+    try {
+      const raw = localStorage.getItem(AUDIO_POS_KEY);
+      if (!raw) return null;
+      /** @type {AudioPosition} */
+      const pos = JSON.parse(raw);
+      if (pos && pos.bookId === bookId && pos.chapter === chapter && pos.time > 0) return pos.time;
+    } catch (_) {}
+    return null;
+  }
+
+  function clearAudioTime() {
+    try { localStorage.removeItem(AUDIO_POS_KEY); } catch (_) {}
+  }
+
+  // ── BEGIN SEARCH HISTORY HELPERS ──
+  // Local-only (not Drive-synced — see ADR-014). Whitespace-normalized strings,
+  // LRU-deduped, capped at SEARCH_HISTORY_MAX. The block between the BEGIN/END
+  // markers is sliced into tests/unit/search-history.test.js, so changes to the
+  // LRU/normalization semantics need a corresponding test update.
+
+  /** @param {unknown} q @returns {string} */
+  function normalizeSearchQuery(q) {
+    return String(q || "").trim().replace(/\s+/g, " ");
+  }
+
+  /** @returns {SearchHistoryList} */
+  function loadSearchHistory() {
+    try {
+      const rawStr = localStorage.getItem(SEARCH_HISTORY_KEY);
+      if (!rawStr) return [];
+      const raw = JSON.parse(rawStr);
+      if (!Array.isArray(raw)) return [];
+      return raw.filter((s) => typeof s === "string" && s.length > 0).slice(0, SEARCH_HISTORY_MAX);
+    } catch (_) {
+      return [];
+    }
+  }
+
+  /** @param {SearchHistoryList} list */
+  function saveSearchHistory(list) {
+    try {
+      localStorage.setItem(SEARCH_HISTORY_KEY, JSON.stringify(list.slice(0, SEARCH_HISTORY_MAX)));
+    } catch (_) {}
+  }
+
+  /** @param {string} q @returns {SearchHistoryList} */
+  function pushSearchHistory(q) {
+    const norm = normalizeSearchQuery(q);
+    if (!norm) return loadSearchHistory();
+    const list = loadSearchHistory().filter((s) => s !== norm);
+    list.unshift(norm);
+    const trimmed = list.slice(0, SEARCH_HISTORY_MAX);
+    saveSearchHistory(trimmed);
+    return trimmed;
+  }
+
+  /** @param {string} q @returns {SearchHistoryList} */
+  function removeSearchHistory(q) {
+    const norm = normalizeSearchQuery(q);
+    const list = loadSearchHistory().filter((s) => s !== norm);
+    saveSearchHistory(list);
+    return list;
+  }
+
+  /** @returns {SearchHistoryList} */
+  function clearSearchHistory() {
+    try { localStorage.removeItem(SEARCH_HISTORY_KEY); } catch (_) {}
+    return [];
+  }
+  // ── END SEARCH HISTORY HELPERS ──
+
+  // ── Startup behavior ──
+
+  /** @returns {string} */
+  function loadStartupBehavior() {
+    return localStorage.getItem(STARTUP_BEHAVIOR_KEY) || "resume";
+  }
+
+  /** @param {string} val */
+  function saveStartupBehavior(val) {
+    localStorage.setItem(STARTUP_BEHAVIOR_KEY, val);
+    window.syncStoreV2?.saveSetting("startupBehavior", val);
+    if (window.driveSync) window.driveSync.scheduleUpload();
+  }
+
+  // ── Font size ──
+
+  /** @returns {number} */
+  function loadFontSize() {
+    try {
+      const v = parseInt(localStorage.getItem(FONT_SIZE_KEY) ?? "", 10);
+      return FONT_SIZES.includes(v) ? v : DEFAULT_FONT_SIZE;
+    } catch (_) {
+      return DEFAULT_FONT_SIZE;
+    }
+  }
+
+  /** @param {number} size */
+  function saveFontSize(size) {
+    try {
+      localStorage.setItem(FONT_SIZE_KEY, String(size));
+      window.syncStoreV2?.saveSetting("fontSize", size);
+      if (window.driveSync) window.driveSync.scheduleUpload();
+    } catch (_) {}
+  }
+
+  // ── Color scheme ──
+
+  /** @returns {ColorSchemeId} */
+  function loadColorScheme() {
+    try {
+      const v = localStorage.getItem(COLOR_SCHEME_KEY);
+      const found = COLOR_SCHEMES.find((s) => s.id === v);
+      if (found) return found.id;
+    } catch (_) {}
+    return "navy";
+  }
+
+  /** @param {ColorSchemeId} scheme */
+  function saveColorScheme(scheme) {
+    try {
+      localStorage.setItem(COLOR_SCHEME_KEY, scheme);
+      window.syncStoreV2?.saveSetting("colorScheme", scheme);
+      if (window.driveSync) window.driveSync.scheduleUpload();
+    } catch (_) {}
+  }
+
+  // ── Theme ──
+
+  /** @returns {ThemeMode} */
+  function loadTheme() {
+    try {
+      const saved = localStorage.getItem(THEME_KEY);
+      if (saved === "dark" || saved === "light" || saved === "system") return saved;
+    } catch (_) {}
+    return "system";
+  }
+
+  /** @param {string} theme */
+  function saveTheme(theme) {
+    try {
+      localStorage.setItem(THEME_KEY, theme);
+      window.syncStoreV2?.saveSetting("theme", theme);
+      if (window.driveSync) window.driveSync.scheduleUpload();
+    } catch (_) {}
+  }
+
+  // ── Book order ──
+
+  /** @returns {BookOrderKind} */
+  function loadBookOrder() {
+    try {
+      const v = localStorage.getItem(BOOK_ORDER_KEY);
+      if (v === "canonical" || v === "vulgate") return v;
+    } catch (_) {}
+    return "canonical";
+  }
+
+  /** @param {string} order */
+  function saveBookOrder(order) {
+    try {
+      localStorage.setItem(BOOK_ORDER_KEY, order);
+      window.syncStoreV2?.saveSetting("bookOrder", order);
+      if (window.driveSync) window.driveSync.scheduleUpload();
+    } catch (_) {}
+  }
+
+  // ── Bookmarks ──
+
+  /** @returns {string} */
+  function generateId() {
+    return Date.now().toString(36) + Math.random().toString(36).slice(2);
+  }
+
+  /** @returns {BookmarkTreeNode[]} */
+  function loadBookmarks() {
+    if (window.syncStoreV2) return window.syncStoreV2.loadBookmarks();
+    try {
+      const raw = localStorage.getItem(BOOKMARK_KEY);
+      return raw ? JSON.parse(raw) : [];
+    } catch (_) { return []; }
+  }
+
+  /** @param {BookmarkTreeNode[]} store */
+  function saveBookmarks(store) {
+    try {
+      localStorage.setItem(BOOKMARK_KEY, JSON.stringify(store));
+      window.syncStoreV2?.saveBookmarks(store);
+      if (window.driveSync) window.driveSync.scheduleUpload();
+      _maybeRequestPersist();
+    } catch (_) {}
+  }
+
+  // ── Install nudge state ──
+
+  /** @returns {InstallNudgeState} */
+  function _loadNudgeState() {
+    try {
+      const raw = localStorage.getItem(INSTALL_NUDGE_KEY);
+      if (raw) return JSON.parse(raw);
+    } catch (_) {}
+    return { visits: 0, nextShow: 1, neverShow: false };
+  }
+
+  /** @param {InstallNudgeState} state */
+  function _saveNudgeState(state) {
+    try { localStorage.setItem(INSTALL_NUDGE_KEY, JSON.stringify(state)); } catch (_) {}
+  }
+
+  // ── Persisted-storage one-shot request ──
+  // Called on the first value moment (audio play, bookmark save). Result is
+  // best-effort: navigator.storage.persist() may show a browser prompt on
+  // Safari/Firefox; on Chrome it grants silently when the site has high
+  // engagement. Even if denied, the LRU loop in audio-cache.js still
+  // functions, just without iOS 7-day evict immunity.
+  let _persistAttempted = false;
+  function _maybeRequestPersist() {
+    if (_persistAttempted) return;
+    _persistAttempted = true;
+    if (!navigator.storage?.persist) return;
+    navigator.storage.persist()
+      .then((granted) => {
+        window.syncDebugLog?.log({ kind: "ACTION", event: "storage-persist", granted });
+      })
+      .catch(() => {});
+  }
+
+  return {
+    FONT_SIZES, DEFAULT_FONT_SIZE, COLOR_SCHEMES, SEARCH_HISTORY_MAX,
+    saveReadingPosition, loadReadingPosition, clearReadingPosition,
+    saveAudioTime, loadAudioTime, clearAudioTime,
+    normalizeSearchQuery, loadSearchHistory, saveSearchHistory,
+    pushSearchHistory, removeSearchHistory, clearSearchHistory,
+    loadStartupBehavior, saveStartupBehavior,
+    loadFontSize, saveFontSize,
+    loadColorScheme, saveColorScheme,
+    loadTheme, saveTheme,
+    loadBookOrder, saveBookOrder,
+    generateId, loadBookmarks, saveBookmarks,
+    _loadNudgeState, _saveNudgeState,
+    _maybeRequestPersist,
+  };
+})();
+
+// Marker so TypeScript treats this file as an ES module (function/typedef
+// scope = module scope). No actual exports needed — `window.appStorage` is
+// the runtime contract.
+export {};

--- a/js/sync/store-v2.js
+++ b/js/sync/store-v2.js
@@ -395,3 +395,11 @@ window.syncStoreV2 = {
   buildSyncPayload, validateRemote,
   bookmarkTreeFromFlat, applyToLegacyKeys,
 };
+
+// Marker so TypeScript treats this file as an ES module (function/typedef
+// scope = module scope). Required because js/app/storage.js (ADR-018 Phase 2)
+// also defines top-level `saveBookmarks`/`loadBookmarks`, which would
+// otherwise collide at the global script scope. Other sync files reach
+// these functions only through the `window.syncStoreV2` facade above, so
+// no caller change is needed. See ADR-018 §"채택 방식 — module-vs-script 예외".
+export {};

--- a/js/types.d.ts
+++ b/js/types.d.ts
@@ -487,6 +487,75 @@ export interface AppHelpers {
   trapFocus: (container: HTMLElement) => () => void;
 }
 
+// ── App storage facade (js/app/storage.js) ──────────────────────────────────
+// Phase 2 of the app.js modularization (ADR-018). All localStorage-backed
+// load/save helpers. Each save also notifies the sync layer (window.syncStoreV2
+// + window.driveSync) when applicable.
+
+// `INSTALL_NUDGE_KEY` shape — install.js `maybeShowInstallNudge` controls when
+// the Add-to-Home prompt re-appears. Stored as JSON in localStorage.
+export interface InstallNudgeState {
+  visits: number;
+  nextShow: number;
+  neverShow: boolean;
+}
+
+export interface AppStorage {
+  // UI-shared constants (also used by settings popover in Phase 3 and search
+  // history panel controller in Phase 5).
+  readonly FONT_SIZES: ReadonlyArray<number>;
+  readonly DEFAULT_FONT_SIZE: number;
+  readonly COLOR_SCHEMES: ReadonlyArray<ColorSchemeEntry>;
+  readonly SEARCH_HISTORY_MAX: number;
+
+  // Reading position
+  saveReadingPosition: (
+    bookId: string,
+    chapter: number | "prologue",
+    verse?: number | null,
+  ) => void;
+  loadReadingPosition: () => ReadingPosition | null;
+  clearReadingPosition: () => void;
+
+  // Audio time
+  saveAudioTime: (bookId: string, chapter: number, time: number) => void;
+  loadAudioTime: (bookId: string, chapter: number) => number | null;
+  clearAudioTime: () => void;
+
+  // Search history
+  normalizeSearchQuery: (q: unknown) => string;
+  loadSearchHistory: () => SearchHistoryList;
+  saveSearchHistory: (list: SearchHistoryList) => void;
+  pushSearchHistory: (q: string) => SearchHistoryList;
+  removeSearchHistory: (q: string) => SearchHistoryList;
+  clearSearchHistory: () => SearchHistoryList;
+
+  // Settings
+  loadStartupBehavior: () => string;
+  saveStartupBehavior: (val: string) => void;
+  loadFontSize: () => number;
+  saveFontSize: (size: number) => void;
+  loadColorScheme: () => ColorSchemeId;
+  saveColorScheme: (scheme: ColorSchemeId) => void;
+  loadTheme: () => ThemeMode;
+  saveTheme: (theme: string) => void;
+  loadBookOrder: () => BookOrderKind;
+  saveBookOrder: (order: string) => void;
+
+  // Bookmarks
+  generateId: () => string;
+  loadBookmarks: () => BookmarkTreeNode[];
+  saveBookmarks: (store: BookmarkTreeNode[]) => void;
+
+  // Install nudge state
+  _loadNudgeState: () => InstallNudgeState;
+  _saveNudgeState: (state: InstallNudgeState) => void;
+
+  // Persisted-storage one-shot request — also called from audio play (Phase 7
+  // owner). State `_persistAttempted` is encapsulated in the module.
+  _maybeRequestPersist: () => void;
+}
+
 // ── Window augmentation ──────────────────────────────────────────────────────
 
 declare global {
@@ -517,6 +586,7 @@ declare global {
 
     // App-layer module facades (ADR-018, see docs/design/app-modularization.md).
     appHelpers: AppHelpers;
+    appStorage: AppStorage;
 
     // UI side-effects defined in app.js. Optional because state-machine.js
     // guards each call with `typeof ... === "function"`.

--- a/sw.js
+++ b/sw.js
@@ -3,7 +3,7 @@
 // caches are preserved across shell-only releases. Bump DATA_CACHE only when
 // bible JSON or search index format changes; bump AUDIO_CACHE only when mp3
 // sources are re-encoded.
-const SHELL_CACHE = "shell-52";
+const SHELL_CACHE = "shell-53";
 const DATA_CACHE = "data-2";
 const AUDIO_CACHE = "audio-1"; // must equal js/audio-cache.js AUDIO_CACHE_NAME
 
@@ -26,6 +26,7 @@ const SHELL_FILES = [
   "/privacy.html",
   "/js/app.js",
   "/js/app/helpers.js",
+  "/js/app/storage.js",
   "/js/drive-sync.js",
   "/js/audio-cache.js",
   "/js/sync/debug-log.js",

--- a/tests/unit/search-history.test.js
+++ b/tests/unit/search-history.test.js
@@ -15,7 +15,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const APP_PATH = path.resolve(__dirname, "../../js/app.js");
+const APP_PATH = path.resolve(__dirname, "../../js/app/storage.js");
 const APP_SOURCE = fs.readFileSync(APP_PATH, "utf8");
 
 const BEGIN = "// ── BEGIN SEARCH HISTORY HELPERS ──";


### PR DESCRIPTION
## Summary

ADR-012 2차 적용 2라운드의 **두 번째 단계**. localStorage 기반 load/save 헬퍼와 UI 공유 상수를 단일 모듈로 분리. app.js 6,053 → **5,835줄** (-218).

## 신설 모듈

\`js/app/storage.js\` — 28개 함수 + 4개 export 상수, IIFE + \`window.appStorage\`, \`// @ts-check\` 영구 활성화.

| 영역 | 함수 |
|---|---|
| Reading position | \`save\`/\`load\`/\`clearReadingPosition\` |
| Audio time | \`save\`/\`load\`/\`clearAudioTime\` |
| Search history | \`normalize\`/\`load\`/\`save\`/\`push\`/\`remove\`/\`clearSearchHistory\` (BEGIN/END 마커도 함께 이동) |
| Settings | \`load\`/\`save\` × {\`StartupBehavior\`, \`FontSize\`, \`ColorScheme\`, \`Theme\`, \`BookOrder\`} |
| Bookmarks | \`generateId\`, \`loadBookmarks\`, \`saveBookmarks\` |
| Install nudge | \`_loadNudgeState\`, \`_saveNudgeState\` |
| Storage 헬퍼 | \`_maybeRequestPersist\` (\`saveBookmarks\` 내부 호출 + 오디오 play에서도 사용 예정) |

상수 export: \`FONT_SIZES\`, \`DEFAULT_FONT_SIZE\`, \`COLOR_SCHEMES\`, \`SEARCH_HISTORY_MAX\`.

## ESM 옵트인 (ADR-018 §모듈-vs-스크립트 예외 신설)

\`storage.js\`가 정의하는 \`saveBookmarks\`/\`loadBookmarks\`가 \`js/sync/store-v2.js\`의 동일 이름 글로벌 함수와 충돌. 두 파일 모두 ES module로 옵트인 (\`export {};\` + \`<script type="module">\`)하여 함수/typedef를 module scope로 격리.

- 다른 sync 파일은 store-v2 함수를 \`window.syncStoreV2.X\` facade로만 호출 → **caller 변경 0**
- ADR-001 SPA 단순성 유지 (빌드 단계 0, import/export 의무 없음, \`window.X\` 글로벌 노출 그대로)
- ADR-018에 옵트인 절차·사유·범위 명시

부수 효과: \`store-v2.js\`가 ESM이라 글로벌 \`BookmarkTreeNode\` typedef 끊김 → \`app.js\` 모듈 헤드에 자체 typedef 추가 (1라운드 PR-3에서 충돌 회피로 deferred했던 부분이 자연 해소).

## 다른 변경

- \`js/types.d.ts\`: \`AppStorage\` 인터페이스 + \`InstallNudgeState\` + \`Window\` augmentation
- \`js/app.js\`: 정의 모두 제거, 모듈 헤드에 destructure 추가
- \`index.html\`: \`<script type="module">\` 두 개 (storage.js + store-v2.js)
- \`sw.js\`: SHELL_CACHE \`shell-52\` → \`shell-53\`, \`/js/app/storage.js\` 추가
- \`tests/unit/search-history.test.js\`: \`APP_PATH\` 갱신

## Test plan

- [x] \`npx tsc -p tsconfig.app.json --noEmit\` — 잔여 3 (gtag-init.js 외부)
- [x] \`npx tsc -p tsconfig.json --noEmit\` — 0 error
- [x] \`npx tsc -p tsconfig.worker.json --noEmit\` — 0 error
- [x] \`node --test tests/unit/*.test.js\` — 111/111 pass
- [ ] 브라우저 동작 확인 — 머지 전 사용자 수동 (\`scripts/serve.py 8080\` → \`/\` 접속, 콘솔 0 오류; 특히 북마크 저장/불러오기 + 설정 변경 + 검색 history)

## 다음 단계

Phase 3: \`settings-ui.js\` (~600줄) — Settings popover + 외관(Color/Theme/Book order/Icon recoloring/Launch screen). storage 의존, helpers 의존.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly a refactor, but it changes script loading to mix `defer` and `type="module"` for `storage.js` and `sync/store-v2.js`, plus bumps the SW shell cache; any load-order/CSP/module-scope mismatch could break app initialization or sync/bookmark persistence.
> 
> **Overview**
> Implements ADR-018 Phase 2 by extracting all localStorage-backed persistence logic (reading position, audio time, search history, settings, bookmarks, install nudge, and persisted-storage request) into a new `js/app/storage.js` facade exposed as `window.appStorage`, and wiring `app.js` to consume these helpers/constants via destructuring.
> 
> To avoid TypeScript global name collisions (`saveBookmarks`/`loadBookmarks`) the PR opts `js/app/storage.js` and `js/sync/store-v2.js` into ES module scope via `export {}` and loads both with `<script type="module">` in `index.html`.
> 
> Updates typings (`AppStorage`, `InstallNudgeState`, `window.appStorage`), moves the search-history unit-test extraction target to `storage.js`, documents the new module-vs-script exception in ADR/design docs, and bumps the service worker shell cache to include the new module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46a2d3ffdee1cc28e8b5d8a47d2d6bc59406494a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->