### PR TITLE
fix: PR #101 Bugbot 2건 — 데드 변수 + stale 주석 제거

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -93,7 +93,6 @@ window.clearAllCaches = clearAllCaches;
 
 const $app = _$("app");
 const $title = _$("page-title");
-const $breadcrumb = _$("breadcrumb");
 const $announce = _$("a11y-announce");
 const $audioBar = _$("audio-bar");
 const $resumeBannerSlot = _$("resume-banner-slot");

--- a/js/app/views-routing.js
+++ b/js/app/views-routing.js
@@ -215,13 +215,6 @@ let appVersion = null;
   }, { passive: true });
 })();
 
-// Search history helpers were extracted to js/app/storage.js
-// (ADR-018 Phase 2). The BEGIN/END markers + tests/unit/storage.test.js
-// follow the new location.
-
-// `loadStartupBehavior`, `saveStartupBehavior`, `loadFontSize`, `saveFontSize`
-// were extracted to js/app/storage.js (ADR-018 Phase 2).
-
 // ── Data fetching ──
 // ── BEGIN DATA_FETCHING ──
 // Exercised by tests/unit/views-routing.test.js. The 4 functions are


### PR DESCRIPTION
## Summary
PR #101의 Cursor Bugbot 리포트 2건(Low Severity)을 정리.

- **`js/app.js:96`** — `$breadcrumb`은 `setBreadcrumb`이 views-routing.js로 이전된 후 데드 변수가 됨. 같은 모듈에서 재선언되어 사용되므로 app.js 쪽 선언만 제거.
- **`js/app/views-routing.js:217-223`** — sed 기반 추출 시 함께 따라온 storage.js 관련 stale 주석 블록 2개(검색 이력 / 시작 동작·폰트 크기) 제거. views-routing.js와 무관한 내용.

## Test plan
- [x] `node --test tests/unit/*.test.js` → 245/245 통과 (회귀 0)
- [x] `js/app.js`의 `$title`은 4곳에서 계속 사용 중 (299/386/387/432/433) — 영향 없음 확인
- [ ] 브라우저: SW 캐시 무효화 후 페이지 제목·breadcrumb 정상 표시

## Notes
- base는 `feat/app-modular-phase7a` (PR #101 브랜치). PR #101 머지 시 자동으로 main 기준으로 합쳐짐.
- `npx tsc --noEmit`은 TS 6.0의 `moduleResolution=node10` deprecation 경고가 PR #101 시점부터 이미 발생 중인 환경 이슈로, 본 변경과 무관.

https://claude.ai/code/session_01LhbSLcD49RMDfEzFVBLfx5

---
_Generated by [Claude Code](https://claude.ai/code/session_01LhbSLcD49RMDfEzFVBLfx5)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk cleanup that only removes an unused variable and outdated comments, with no behavior changes.
> 
> **Overview**
> Removes the now-dead `$breadcrumb` DOM anchor declaration from `js/app.js` after breadcrumb rendering moved to `views-routing.js`.
> 
> Cleans up `js/app/views-routing.js` by deleting outdated comment blocks about storage/search-history helpers that no longer live in this module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56d515d3d5861823632ceec9ecfd9be8f2d75113. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->