### PR TITLE
docs: docs/design/ 4개 살아있는 설계 문서 status 현행화

### DIFF
--- a/docs/design/app-modularization.md
+++ b/docs/design/app-modularization.md
@@ -4,8 +4,9 @@
 > 시점 고정 결정 기록은 ADR-018 + 본 문서의 진행 일지 참조.
 
 - 작성: 2026-05-09
-- 상태: **결정 확정** — Phase 1 진행 예정
-- 관련 ADR: ADR-001(SPA), ADR-012(TS 점진 도입, 2차 1라운드 완료), ADR-013(유닛 테스트), ADR-016(오디오 캐시), ADR-018(본 의제)
+- 종료: 2026-05-10 (Phase 1~8 머지 완료)
+- 상태: **완료** — `js/app.js` 6,082 → 283줄 (95% 감소), 9개 도메인 모듈 분할 + ESM 일괄 전환(ADR-019) + ADR-012 2차 라운드 종료
+- 관련 ADR: ADR-001(SPA), ADR-012(TS 점진 도입, 1·2차 완료), ADR-013(유닛 테스트), ADR-016(오디오 캐시), ADR-018(본 의제), ADR-019(ESM)
 - 1라운드 문서: `docs/design/app-typescript-migration.md`
 
 ---
@@ -405,3 +406,4 @@ CLAUDE.md `tests/e2e/` 절차를 따라 사용자 수동 실행:
 | 2026-05-10 | Phase 7b 작성 완료 | Views + Routing + Audio Player 전체를 views-routing.js에 합류(540 → 1,783줄, +1,243). Phase 7a 시점에 임시 노출했던 4개 const facade는 같은 모듈 안 caller로 흡수돼 자연 해소(잔존 노출). 추가 이전: Audio Player 상태 3개(`currentAudio`/`_audioController`/`_audioSaveTimer`), Routing 상태 2개(`_scrollTrackCleanup`/`_isInitialLoad`), `startScrollTracking`(Reading position section에 잔류했던 routing-internal 함수). popstate listener도 동행. **DOMContentLoaded 부트스트랩은 app.js 잔류**(app-main 책임): `route`/`loadVersion`/`initCompactHeader`/`maybeShowInstallNudge`는 window facade로 호출, `initSheetDrag`(search.js)·`initBookmarkSheetDrag`/`initBookmarkDrawerResize`(app.js Phase 8 잔류)·`registerServiceWorker`(app.js)는 module-local. `currentAudio` 접근을 위한 `window.getCurrentAudio` 게터 신설(app.js 접근성 spacebar handler용). gtag-init.js의 `function gtag()` module-scoped 잔재 회귀 정리: `window.gtag = gtag` 노출 + dataLayer ?? 가드. types.d.ts에 `Window.getCurrentAudio`/`gtag`/`dataLayer`/`appVersion` + 글로벌 `function gtag` + `const dataLayer` 추가. CLAUDE.md 트리에 app.js 역할 갱신(부트스트랩 + 접근성 + Audio cache LRU + SW 등록 잔류 ~460줄). SHELL_CACHE shell-61 → shell-62. app.js 1,650 → 464줄 (−1,186). 누적 6,082 → 464줄 (−5,618, **92% 감소**). main + worker tsc 0 error, **app.config 0 error**(gtag/dataLayer 잔재 동시 해소!), 유닛 245 통과 |
 | 2026-05-10 | Phase 7b 머지 (#103) | Bugbot 3차(stale facade 5건 + 중복 appVersion + 미사용 import + stale anchor + 4개 const stale facade) 모두 fix 적용 후 main 통합. app.js 464줄 |
 | 2026-05-10 | Phase 8 작성 완료 — **모듈 분할 종료** | 잔류 정리: app.js의 `initBookmarkSheetDrag`/`initBookmarkDrawerResize` → bookmark.js (drawer geometry init은 bookmark 모듈 책임) + bookmark.js facade에 `appBookmark.initBookmarkSheetDrag`/`initBookmarkDrawerResize` 추가, types.d.ts AppBookmark + 글로벌 declare 갱신. app.js 헤드 슬림화: 미사용 typedef 14개 + 미사용 destructure(storage 25개 중 22개, helpers 6개 중 4개) 제거, 마이그레이션 경위 코멘트 정리, dead 섹션 마커(`Reading position` / `Font size` / `Book order` / `Helpers`) 정리. **`// @ts-check` 영구 활성화** + `tsconfig.app.json` 삭제. ADR-012 2차 라운드 종료 마킹 + ADR-018 본 의제 종료. CLAUDE.md "현재 상태" 섹션의 모듈 분할 항목 갱신, `project_inflight_work.md` 메모리 종료. SHELL_CACHE shell-62 → shell-63. app.js 464 → 283줄 (−181). 누적 6,082 → 283줄 (**95% 감소**). main + worker tsc 0 error, 유닛 245 통과 |
+| 2026-05-10 | Phase 8 머지 — **의제 종료** | Phase 1~8 8 PR이 모두 main 통합. 최종 결과: `js/app.js` 283줄(부트스트랩 + 접근성 keydown + Audio cache LRU 소프트캡 + SW 등록만 잔류), `js/app/` 9개 도메인 모듈(helpers·storage·settings-ui·install·search·reading-context·bookmark·views-routing 8개 + 잔류 app.js), ESM 일괄 채택, ADR-012 2차 라운드 종료, 유닛 테스트 baseline 111 → 245 케이스. 후속 의제는 `project_inflight_work.md` / `project_unit_test_expansion.md` 메모리 참조 |

--- a/docs/design/app-typescript-migration.md
+++ b/docs/design/app-typescript-migration.md
@@ -4,8 +4,10 @@
 > 시점 고정 결정 기록은 ADR-012 본문 + 머지 시 추가될 `> **개정 (날짜):**` 블록 참조.
 
 - 작성: 2026-05-09
-- 상태: **1라운드 종료** (PR-1~7 머지 완료). `// @ts-check` 영구 활성화 + `tsconfig.app.json` 삭제는 **app.js 파일 분할 리팩터링과 결합한 별도 의제**로 보류
-- 관련 ADR: ADR-001(SPA), ADR-012(TS 점진 도입), ADR-013(유닛 테스트)
+- 종료: 2026-05-10 (2라운드 = ADR-018 모듈 분할과 동행 종료)
+- 상태: **완료** — 1라운드(PR-1~7, 점진 JSDoc 도입) + 2라운드(`// @ts-check` 영구 활성화 + `tsconfig.app.json` 삭제, ADR-018 Phase 8 동행). 모든 클라이언트 JS가 영구 타입 체크 대상
+- 관련 ADR: ADR-001(SPA), ADR-012(TS 점진 도입, 본 의제), ADR-013(유닛 테스트), ADR-018(모듈 분할 — 2라운드 동행)
+- 후속 설계 문서: `docs/design/app-modularization.md`
 
 ---
 
@@ -249,3 +251,4 @@ PR-7 시작 시 main `tsconfig.json` 검사 환경에서 `// @ts-check`를 `js/a
 | 2026-05-09 | PR-6 머지 (#86) | CI Unit tests + Cursor Bugbot 모두 green, main 통합 (rebase) |
 | 2026-05-09 | PR-7 시작 | `feat/app-jsdoc-pr7` 브랜치 분기. 영역: 내보내기/가져오기 + 절 선택 + 드로어 + SW 등록 (L5670-L6082, ~412줄) — 마지막 PR |
 | 2026-05-09 | PR-7 마무리 | **마이그레이션 1라운드 종료**. PR-7 영역 잔여 11 fix(button/input narrow, FileReader result narrow, `_$` 통일) + 모듈 상태 변수 ~30개 일괄 narrow(`booksCache: BooksData \| null`, `_audioSaveTimer: ReturnType<typeof setTimeout> \| null` 등) + narrow 부작용 정리(`loadBooks`/`loadVersion` 반환 흐름, `_audioSaveTimer` null guard, `getAttribute(...) ?? ""` 패턴 ~10곳, `_bookmarkDrawerLastFocus` `HTMLElement` narrow). `// @ts-check` 영구 활성화 + `tsconfig.app.json` 삭제는 **app.js 파일 분할 리팩터링과 결합한 별도 의제로 보류** ([§9](#9-pr-7-마무리-방식-변경)). 검증: tsconfig.app.json 잔여 3 (gtag-init.js 외부), main tsc 0, worker tsc 0, 유닛 111건 통과 |
+| 2026-05-10 | **2라운드 종료 — 본 의제 마무리** | ADR-018 모듈 분할(Phase 1~8)과 동행으로 진행. 각 도메인 모듈(`js/app/helpers.js` / `storage.js` / `settings-ui.js` / `install.js` / `search.js` / `reading-context.js` / `bookmark.js` / `views-routing.js`)을 추출하면서 모듈마다 `// @ts-check`를 영구 활성화. Phase 8(2026-05-10)에 잔류 `js/app.js`(283줄)에도 `// @ts-check` 영구 활성화 + **`tsconfig.app.json` 삭제 → 메인 `tsconfig.json` 단일 검증으로 통합**. 후속 ESM 일괄 전환(ADR-019, 2026-05-09)으로 모듈 scope 정착해 cross-file 글로벌 alias 충돌도 자연 해소. ADR-012에 2026-05-10 개정 블록 추가, status를 '1차 + 2차 적용 완료'로 갱신. 자세한 phase별 변천은 `docs/design/app-modularization.md` 참조 |

--- a/docs/design/pkce-migration.md
+++ b/docs/design/pkce-migration.md
@@ -4,9 +4,10 @@
 > 시점 고정 결정 기록은 ADR-011 §Phase 2h 참조.
 
 - 작성: 2026-05-07
-- 상태: 단계 5 PR open — 단계 1·2·3·4 모두 머지 완료, 5는 정리 단계
-- 관련 ADR: ADR-001(SPA), ADR-011(북마크 동기화), ADR-012(TS), ADR-013(유닛 테스트)
-- 보안 감사: `docs/audit/2026-05-07-pkce-refresh-token.md`
+- 종료: 2026-05-08 (Phase 2h 단계 1~6 머지 완료)
+- 상태: **완료** — PKCE + refresh token 단일 경로 운영 중. 데스크톱·Android·iOS 모두 같은 흐름. 단계 6에서 dev/prod 환경 분리 + nginx BFF(ADR-017) + 탭 활성화 자동 sync까지 동행. 후속 Phase 2i(sync 사이클 캐시, 2026-05-08)도 종료
+- 관련 ADR: ADR-001(SPA), ADR-011(북마크 동기화, Phase 2h·2i 완료), ADR-012(TS), ADR-013(유닛 테스트), ADR-017(nginx BFF)
+- 보안 감사: `docs/audit/2026-05-07-pkce-refresh-token.md` — Critical/High/Medium 0건. `docs/audit/2026-05-08-second-comprehensive.md`(2차) — Critical 0, High 4 즉시 fix(PR #67)
 
 ---
 

--- a/docs/design/search-history.md
+++ b/docs/design/search-history.md
@@ -4,8 +4,9 @@
 > 시점 고정 결정 기록은 ADR-014.
 
 - 작성: 2026-05-07
-- 상태: 설계 단계 (구현 전)
-- 관련 ADR: ADR-001(SPA), ADR-005(검색 인덱싱), ADR-014(검색 히스토리 + 터치 타깃)
+- 상태: **완료** — `js/app/search.js`의 `createSearchHistoryController` 운영 중. 저장 한도 30개·기본 표시 10개·"더 보기" 점진 펼침·키보드 자동 펼침 모두 적용
+- 유닛 테스트: 검색 이력 33 케이스(PR #106, `tests/unit/storage.test.js`의 search-history 영역) + HISTORY_CONTROLLER 33 케이스(PR #113, `tests/unit/search.test.js`)
+- 관련 ADR: ADR-001(SPA), ADR-005(검색 인덱싱), ADR-014(검색 히스토리 + 터치 타깃 — '제안됨' → '승인·적용 완료'로 갱신됨)
 
 ---
 
@@ -623,3 +624,5 @@ $searchInput.addEventListener("keydown", (e) => {
 
 - 2026-05-07 — 초안 작성, ADR-014 제안과 동기화
 - 2026-05-07 — 저장 30 / 표시 10 + "더 보기" 점진 펼침 도입 (키보드 자동 펼침 포함)
+- 2026-05-09 — ADR-018 Phase 5(`js/app/search.js` 추출) 동행으로 `createSearchHistoryController` 팩토리화. `topSearchHistory` + `sheetSearchHistory` 두 인스턴스가 같은 컨트롤러 공유
+- 2026-05-11 — 유닛 테스트 추가: 검색 이력 영역 33 케이스(`tests/unit/storage.test.js`, PR #106) + HISTORY_CONTROLLER 33 케이스(`tests/unit/search.test.js`, PR #113). ADR-014 status를 '제안됨' → '승인·적용 완료'로 갱신(PR #117)


### PR DESCRIPTION
## Summary

\`docs/design/\`의 4개 살아있는 설계 문서가 옛 진행 상태로 멈춰 있어 stale. ADR-117에서 ADR status 8건 정정한 것과 같은 정신으로 헤더 + 마무리 일지만 surgical 정정. 본문 변천 기록은 보존(역사적 가치).

## 정정 4건

| 문서 | 이전 status | 정정 |
| --- | --- | --- |
| **app-modularization.md** | 결정 확정 — Phase 1 진행 예정 | **완료** (Phase 1~8 머지, 2026-05-10): \`js/app.js\` 6,082 → 283줄, 9개 도메인 모듈, ESM 일괄 |
| **app-typescript-migration.md** | 1라운드 종료 + 결합 별도 의제로 보류 | **완료** — 1라운드(PR-1~7) + 2라운드(ADR-018 동행, 2026-05-10). 모든 클라이언트 JS 영구 \`// @ts-check\`, \`tsconfig.app.json\` 삭제 |
| **pkce-migration.md** | 단계 5 PR open | **완료** (단계 1~6 머지, 2026-05-08). 후속 Phase 2i까지 종료. 보안 감사 2건 참조 |
| **search-history.md** | 설계 단계 (구현 전) | **완료** — \`createSearchHistoryController\` 운영. 유닛 테스트 66 케이스 |

## 패턴

- 헤더 status 라인 + "종료:" 라인 추가
- 진행 일지(있는 경우) 마지막에 종료 행 한 줄
- 변경 이력(있는 경우) 두세 줄 추가
- 본문 변천 기록은 무수정

## Test plan

- [x] 코드 변경 0, 문서 단독
- [x] 본문 변천 기록 무수정 (역사 보존)

🤖 Generated with [Claude Code](https://claude.com/claude-code)