### PR TITLE
test: e2e 깨진 테스트 17건 수선 + 검색 combobox role 정정

### DIFF
--- a/docs/qa/2026-05-12-e2e-regression.md
+++ b/docs/qa/2026-05-12-e2e-regression.md
@@ -1,0 +1,160 @@
+# E2E 테스트 보고서: 2026-05-12 회귀 점검
+
+**날짜:** 2026-05-12
+**범위:** 전체 e2e 173건 재실행 + 모듈 분할·기능 추가 이후 누적된 깨진 테스트 수선
+**작성자:** Joshua Huh
+
+## 1. 한눈 요약
+
+- **결과:** 173건 전수 통과 (실패 0, 스킵 0), 약 6분 33초 소요
+- **수선 대상:** 시작 시점 18건 실패 (a11y 3, 모달 a11y/키보드 3, 북마크 1, 내보내기 5, PKCE 4, 오디오 1, 검색 1) + 재실행 중 드러난 오디오 플레이어 회귀 5건
+- **원인 분포:**
+  - **테스트가 옛 전역 함수 이름을 호출 (8건)** — `app.js` 9개 모듈 분할(ADR-018) 이후 `openSaveModal` / `exportBookmarks` / `_currentBookId` 같은 이름이 모듈 내부로 들어갔다. 새 진입점(버튼 클릭, `window.readingContext`) 으로 갈아끼움
+  - **테스트가 비동기 전이 완료 전에 상태를 읽음 (4건)** — PKCE 콜백 실패 → 상태머신 `NEEDS_CONSENT` 정착은 마이크로태스크 한 단계 뒤. URL 정리 시점이 아니라 상태 자체를 폴링하도록 변경
+  - **테스트가 오디오 에러 리스너에 휘말림 (6건)** — 빈 바디 응답이 chromium 에서 `error` 이벤트를 즉시 발화 → `_teardownAudio()` 가 컨트롤을 통째로 떼어 버려 후속 단언이 timeout. `HTMLAudioElement.addEventListener('error', …)` 등록을 init script 에서 차단해 바를 살린다
+  - **테스트가 비동기 렌더링 끝 전에 단언 (1건)** — `runSheetSearch` 가 onPartial 콜백으로 결과를 증분 렌더링. 첫 항목이 보이자마자 단언하면 뒤따라 오는 최종 렌더가 cleanup 을 덮어쓴다. 로딩 사라짐 + a11y announce 발화까지 대기 추가
+  - **실제 a11y 회귀 1건 (앱 코드 수정)** — `#search-input` / `#search-sheet-input` 에 `aria-autocomplete` / `aria-controls` / `aria-expanded` 만 있고 `role="combobox"` 가 없어 axe-core critical 발화. 검색 히스토리 기능(ADR-014) 도입 시 빠진 속성을 보충
+
+## 2. 실행 환경
+
+| 항목 | 값 |
+|------|----|
+| Python | 3.12.12 |
+| pytest | 9.0.2 |
+| pytest-playwright | 0.7.2 |
+| Chromium | 145.0.7632.6 |
+| axe-playwright-python | 0.1.7 |
+| 개발 서버 | `python3 scripts/serve.py 8080` |
+
+## 3. 실행 결과
+
+| 단계 | 통과 | 실패 | 비고 |
+|------|------|------|------|
+| 시작 시점 | 155 | 18 | 모듈 분할 + 기능 추가 누적 |
+| 수선 1차 후 | 168 | 5 | 오디오 컨트롤 race 드러남 |
+| 수선 2차 후 | **173** | **0** | 전수 통과 |
+
+총 소요 시간: 약 393초.
+
+## 4. 카테고리별 수선 내역
+
+### 4.1 모듈 분할로 사라진 전역 (테스트 8건)
+
+ADR-018 분할 이후 `app.js` 내부 함수들은 `js/app/*.js` 모듈 안에 갇혔다. 테스트가 `window.openSaveModal()` 처럼 직접 호출하는 패턴은 모두 깨진다.
+
+| 테스트 | 옛 호출 | 새 트리거 |
+|--------|---------|----------|
+| `test_a11y_axe.py::test_a11y_bm_save_modal` | `page.evaluate("openSaveModal('chapter')")` | `#bm-save-chapter-btn` 클릭 |
+| `test_a11y_keyboard.py::test_escape_closes_bm_save_modal` | 동일 | 동일 |
+| `test_a11y_keyboard.py::test_focus_trap_in_bm_save_modal` | 동일 | 동일 |
+| `test_bookmark.py::test_select_verses_button_preserves_chapter_after_drawer_close` | `_currentBookId` / `_currentChapter` / `_verseSelectMode` | `window.readingContext.{bookId,chapter,verseSelectMode}` |
+| `test_bookmark_export_import.py` 내보내기 5건 | `exportBookmarks()` | `#bm-overflow-btn` 열고 `#bm-export-btn` 클릭 (오버플로 메뉴로 이전됨) |
+
+내보내기 인터셉트 헬퍼는 Blob 생성자 후킹은 그대로 두되, 호출 트리거만 버튼 클릭으로 바꿔 행위(=다운로드 동작) 그대로 검증한다.
+
+### 4.2 비동기 PKCE 전이 race (테스트 4건)
+
+`test_pkce_callback_state_mismatch_rejected` / `_error_param_rejected` (desktop + iOS 변종, 합 4건).
+
+옛 코드:
+```python
+page.wait_for_function("() => location.search === ''")
+assert page.evaluate("window.driveSync.getStatus()") == "NEEDS_CONSENT"
+```
+
+콜백 IIFE 가 URL 을 정리하는 시점과 상태머신이 `DISABLED → NEEDS_CONSENT` 로 전이하는 시점이 다르다. 후자는 `_machine.enable() → _attemptSilentRefresh() → (no refresh token) → _transition(NEEDS_CONSENT)` 의 async 체인으로 약 100ms 뒤에 정착한다. URL 정리만 기다리면 9 / 10 회 race 패배.
+
+새 코드:
+```python
+page.wait_for_function("() => location.search === ''")
+page.wait_for_function(
+    "() => window.driveSync.getStatus() === 'NEEDS_CONSENT'",
+    timeout=5_000,
+)
+```
+
+### 4.3 오디오 에러 리스너로 인한 컨트롤 소실 (테스트 6건)
+
+`test_audio_controls.py` 6 중 5 건. `_open(browser)` 가 `**/data/audio/**` 를 200 + 빈 바디로 응답시킨다. chromium 은 디코드 실패로 `error` 이벤트를 발화하고, `views-routing.js` 의 핸들러가 `_teardownAudio() → showAudioUnavailable()` 로 컨트롤을 모두 떼어 낸다. 테스트가 `.audio-speed-btn`, `.audio-play-btn`, `.audio-progress` 를 찾으려 하면 30초 timeout.
+
+수선: init script 에서 `HTMLAudioElement.prototype.addEventListener` 를 후킹해 `'error'` 등록을 차단한다. `error` → unavailable 전이 자체를 검증하는 테스트는 `test_audio.py` 로 분리돼 있으므로 이쪽만 적용해도 커버리지 손실 없음.
+
+```js
+const origAdd = HTMLAudioElement.prototype.addEventListener;
+HTMLAudioElement.prototype.addEventListener = function(type, listener, opts) {
+    if (type === 'error') return;
+    return origAdd.call(this, type, listener, opts);
+};
+```
+
+(이전에는 1차 실행에서 race 가 잠재해 5건이 우연히 통과하던 상태였다. 수선 1차 후 재실행에서 한꺼번에 드러나 일관성 있게 잡혔다.)
+
+### 4.4 검색 증분 렌더링 race (테스트 1건)
+
+`test_search.py::test_mobile_focus_in_expanded_reverts_to_compact`.
+
+`runSheetSearch` 는 비동기로 `onPartial` 콜백을 여러 번 호출해 결과를 증분 렌더링한 뒤 마지막에 `renderSearchResultList` 로 최종 결과를 채운다. 첫 항목이 등장하자마자 input.focus() 를 호출하면, 포커스 핸들러의 `clearNode($searchSheetResults)` 는 잘 동작하지만 그 직후 await 가 풀린 본체가 결과를 다시 채워 단언이 5건을 발견한다.
+
+수선: 로딩 placeholder 가 detach 되고 `a11y-announce` 에 "검색 결과 N건" 문구가 뜨는 시점까지 대기 후 포커스.
+
+### 4.5 실제 a11y 회귀 (앱 코드 1건)
+
+`test_a11y_axe.py::test_a11y_home_books_list` / `_chapter_text` / `_search_results` 3건이 `axe-core critical: aria-allowed-attr` 로 실패.
+
+원인: ADR-014 검색 히스토리 기능을 도입할 때 `<input type="search">` 에 `aria-autocomplete="list"`, `aria-controls="search-history"`, `aria-expanded="false"` 를 추가했지만, 이 속성들은 `combobox` role 에서만 허용된다. 입력 요소의 native role 인 `searchbox` 에서는 위반.
+
+수선 (`index.html` 117, 154행, 헤더 + 모바일 시트 양쪽):
+
+```html
+<input id="search-input" type="search"
+       role="combobox" aria-autocomplete="list"
+       aria-controls="search-history" aria-expanded="false" ...>
+```
+
+ARIA 1.2 combobox 패턴에 맞게 정정. axe-core 4.11 critical 위반 0건으로 복귀.
+
+## 5. 카테고리별 결과 매트릭스
+
+| 카테고리 | 시작 실패 | 수선 후 | 비고 |
+|----------|----------|--------|------|
+| a11y axe-core | 3 | 0 | combobox role 보충 |
+| a11y axe-core (modal) | 1 | 0 | 버튼 클릭으로 전환 |
+| a11y keyboard (modal) | 2 | 0 | 버튼 클릭으로 전환 |
+| 북마크 verse-select | 1 | 0 | readingContext 전환 |
+| 북마크 export | 5 | 0 | 버튼 클릭으로 전환 |
+| PKCE state mismatch / error | 4 | 0 | 상태 폴링 추가 |
+| 오디오 컨트롤 race | 1+5 | 0 | error 리스너 차단 |
+| 검색 모바일 포커스 race | 1 | 0 | 검색 완료 대기 |
+
+## 6. 수정된 앱 코드
+
+| # | 파일 | 변경 | 사유 |
+|---|------|------|------|
+| 1 | `index.html` (117행) | `<input id="search-input">` 에 `role="combobox"` 추가 | ARIA 1.2 — `aria-autocomplete`/`aria-controls`/`aria-expanded` 는 combobox 한정 |
+| 2 | `index.html` (154행) | `<input id="search-sheet-input">` 동일 | 동일 (모바일 시트) |
+
+## 7. 수정된 테스트 코드
+
+| 파일 | 변경 골자 |
+|------|-----------|
+| `tests/e2e/test_a11y_axe.py` | save modal 트리거를 `#bm-save-chapter-btn` 클릭으로 |
+| `tests/e2e/test_a11y_keyboard.py` | 동일 (escape·focus trap 2건) |
+| `tests/e2e/test_bookmark.py` | `_currentBookId` 등 → `window.readingContext.*` |
+| `tests/e2e/test_bookmark_export_import.py` | `exportBookmarks()` 호출 → 오버플로 메뉴 → 내보내기 버튼 클릭 |
+| `tests/e2e/test_drive_sync.py` | PKCE 실패 → `NEEDS_CONSENT` 폴링 (2건) |
+| `tests/e2e/test_drive_sync_ios.py` | 동일 (2건) |
+| `tests/e2e/test_audio_controls.py` | `_open` 에 `_SUPPRESS_AUDIO_ERROR` init script 추가 |
+| `tests/e2e/test_search.py` | 검색 완료 대기 후 포커스로 변경 |
+
+## 8. 운영 관찰
+
+- **데이터 서브모듈 부재 환경:** worktree clone 직후 `data/` 가 비어 있을 때 모든 테스트가 즉시 fail 하므로, e2e 실행 전 `git submodule update --init --recursive` 가 필수다. SSH 키가 없으면 메인 체크아웃의 데이터로 보조하는 우회가 필요하다 (이번에는 worktree 안에 메인 데이터 파일을 개별 심볼릭 링크해 dev 서버를 worktree 디렉터리로 띄웠다).
+- **오디오 race 의 잠재성:** 이번 1차 실행과 2차 실행에서 5건의 audio_controls 테스트가 들쭉날쭉했다. error 리스너 차단을 `_open` 공통화한 이후 일관되게 통과. 다음 회귀 점검 때 빠진 케이스가 다시 떠오르면 같은 패턴으로 처리.
+- **PKCE race 의 가능성:** 상태머신이 더 많은 비동기 단계로 확장될 경우, 이번처럼 "URL 정리"가 아닌 "최종 상태 폴링"이 디폴트 단언 패턴이 돼야 한다.
+
+## 9. 비고
+
+- 데스크톱 Chromium 단일 브라우저 (iOS/Android 는 UA + viewport 시뮬레이션)
+- 모바일 핀치 / 실제 IME 동작은 자동화 한계 — 수동 QA 영역
+- e2e 는 로컬 전용 (CI 미포함, CLAUDE.md 정책 유지)
+- 데이터 서브모듈 포인터는 `378f05bb…` 시점 (변경 없음)

--- a/index.html
+++ b/index.html
@@ -114,7 +114,7 @@
         <nav id="breadcrumb" aria-label="탐색 경로"></nav>
         <div id="header-actions">
           <div id="search-bar">
-            <input id="search-input" type="search" placeholder="검색 (예: 사랑, 사랑 in:요한, 창세 1:3)" aria-label="성경 검색" autocomplete="off" aria-autocomplete="list" aria-controls="search-history" aria-expanded="false">
+            <input id="search-input" type="search" placeholder="검색 (예: 사랑, 사랑 in:요한, 창세 1:3)" aria-label="성경 검색" autocomplete="off" role="combobox" aria-autocomplete="list" aria-controls="search-history" aria-expanded="false">
             <button id="search-history-toggle" type="button" aria-label="최근 검색어 열기" aria-haspopup="listbox" aria-expanded="false" aria-controls="search-history" hidden>
               <svg width="14" height="14" viewBox="0 0 12 12" fill="currentColor" aria-hidden="true"><path d="M2 4l4 4 4-4z"/></svg>
             </button>
@@ -151,7 +151,7 @@
     <div id="search-sheet-handle" aria-hidden="true"><span></span></div>
     <div id="search-sheet-bar">
       <div id="search-sheet-input-wrap">
-        <input id="search-sheet-input" type="search" inputmode="search" enterkeyhint="search" autocorrect="off" autocapitalize="off" spellcheck="false" placeholder="검색 (예: 사랑, 사랑 in:요한, 창세 1:3)" aria-label="성경 검색" autocomplete="off" aria-autocomplete="list" aria-controls="search-sheet-history" aria-expanded="false">
+        <input id="search-sheet-input" type="search" inputmode="search" enterkeyhint="search" autocorrect="off" autocapitalize="off" spellcheck="false" placeholder="검색 (예: 사랑, 사랑 in:요한, 창세 1:3)" aria-label="성경 검색" autocomplete="off" role="combobox" aria-autocomplete="list" aria-controls="search-sheet-history" aria-expanded="false">
         <button id="search-sheet-history-toggle" type="button" aria-label="최근 검색어 열기" aria-haspopup="listbox" aria-expanded="false" aria-controls="search-sheet-history" hidden>
           <svg width="16" height="16" viewBox="0 0 12 12" fill="currentColor" aria-hidden="true"><path d="M2 4l4 4 4-4z"/></svg>
         </button>

--- a/tests/e2e/test_a11y_axe.py
+++ b/tests/e2e/test_a11y_axe.py
@@ -120,9 +120,7 @@ def test_a11y_bm_save_modal(browser):
         page.wait_for_selector("article.chapter-text .verse")
         page.locator(".title-bookmark-btn").click()
         page.wait_for_selector("#bookmark-drawer:not([hidden])")
-        page.locator("#bm-add-folder-btn").click()
-        # Open save modal via long-press path
-        page.evaluate("""() => openSaveModal('chapter')""")
+        page.locator("#bm-save-chapter-btn").click()
         page.wait_for_selector("#bm-save-modal:not([hidden])")
         v = _violations(page, context="#bm-save-modal")
         assert not v, f"Save modal: {len(v)} violation(s):\n{_fmt(v)}"

--- a/tests/e2e/test_a11y_keyboard.py
+++ b/tests/e2e/test_a11y_keyboard.py
@@ -60,7 +60,7 @@ def test_escape_closes_bm_save_modal(browser):
         page.wait_for_selector("article.chapter-text .verse")
         page.locator(".title-bookmark-btn").click()
         page.wait_for_selector("#bookmark-drawer:not([hidden])")
-        page.evaluate("() => openSaveModal('chapter')")
+        page.locator("#bm-save-chapter-btn").click()
         page.wait_for_selector("#bm-save-modal:not([hidden])")
 
         page.keyboard.press("Escape")
@@ -91,7 +91,7 @@ def test_focus_trap_in_bm_save_modal(browser):
         page.wait_for_selector("article.chapter-text .verse")
         page.locator(".title-bookmark-btn").click()
         page.wait_for_selector("#bookmark-drawer:not([hidden])")
-        page.evaluate("() => openSaveModal('chapter')")
+        page.locator("#bm-save-chapter-btn").click()
         page.wait_for_selector("#bm-save-modal:not([hidden])")
 
         # Tab through all focusable elements inside modal

--- a/tests/e2e/test_audio_controls.py
+++ b/tests/e2e/test_audio_controls.py
@@ -49,10 +49,27 @@ _AUDIO_MOCK = """
 """
 
 
+_SUPPRESS_AUDIO_ERROR = """
+(() => {
+    // Block the 'error' listener that views-routing.js binds in showAudioPlayer:
+    //   audio.addEventListener('error', () => { _teardownAudio(); showAudioUnavailable(); });
+    // Without this, the empty / 404 audio body fires 'error' during page setup,
+    // tears down the audio bar UI, and interaction tests (speed/play/seek/...)
+    // hit timeouts waiting for the now-gone .audio-* controls.
+    const origAdd = HTMLAudioElement.prototype.addEventListener;
+    HTMLAudioElement.prototype.addEventListener = function(type, listener, opts) {
+        if (type === 'error') return;
+        return origAdd.call(this, type, listener, opts);
+    };
+})();
+"""
+
+
 def _open(browser):
     ctx = browser.new_context()
     ctx.add_init_script(CLEAR_APP_STORAGE)
     ctx.add_init_script(_AUDIO_MOCK)
+    ctx.add_init_script(_SUPPRESS_AUDIO_ERROR)
     page = ctx.new_page()
     # Block audio file requests so the player initialises without network
     page.route("**/data/audio/**", lambda r: r.fulfill(status=200, body=b"", content_type="audio/mpeg"))
@@ -121,20 +138,20 @@ def test_pause_btn_click_triggers_pause(browser):
 
 # ── seek ──────────────────────────────────────────────────────────────────────
 
+
 def test_seek_via_progress_input(browser):
     """progress input 값 변경 → 'input' 이벤트 → audio.currentTime 업데이트."""
     ctx, page = _open(browser)
     try:
-        # Expose audio element; set max so seek has valid range
         page.evaluate("""() => {
             const audio = window.__testAudio;
             if (!audio) return;
             Object.defineProperty(audio, 'duration', { get: () => 300, configurable: true });
         }""")
 
+        page.wait_for_selector(".audio-progress")
         page.evaluate("""() => {
             const progress = document.querySelector('.audio-progress');
-            if (!progress) return;
             progress.max = '300';
             progress.value = '60';
             progress.dispatchEvent(new Event('input', { bubbles: true }));

--- a/tests/e2e/test_bookmark.py
+++ b/tests/e2e/test_bookmark.py
@@ -160,12 +160,14 @@ def test_select_verses_button_preserves_chapter_after_drawer_close(browser):
     page.locator("#bm-select-verses-btn").click()
 
     # Drawer closes, verse-select bar appears, and the bar must reflect gen/1
-    # — i.e. _currentBookId/_currentChapter are not clobbered to null.
+    # — i.e. readingContext.{bookId,chapter} are not clobbered to null.
     page.wait_for_selector("#bookmark-drawer", state="hidden")
     page.wait_for_selector("#verse-select-bar:not([hidden])")
 
     state = page.evaluate(
-        "() => ({ book: _currentBookId, chapter: _currentChapter, mode: _verseSelectMode })"
+        "() => ({ book: window.readingContext.bookId,"
+        "         chapter: window.readingContext.chapter,"
+        "         mode: window.readingContext.verseSelectMode })"
     )
     assert state["mode"] is True, "verse-select mode should be active"
     assert state["book"] == "gen" and state["chapter"] == 1, \

--- a/tests/e2e/test_bookmark_export_import.py
+++ b/tests/e2e/test_bookmark_export_import.py
@@ -13,50 +13,44 @@ BASE = "http://localhost:8080"
 # 다운로드를 트리거한다.  headless Chromium에서는 blob URL 다운로드 이벤트가
 # 신뢰할 수 없으므로, Blob 생성자와 anchor 클릭을 동기로 가로채
 # JSON 문자열을 직접 캡처한다.
-_INTERCEPT_EXPORT_JS = """() => {
+#
+# ADR-018 모듈 분할 이후 exportBookmarks 는 전역 함수가 아니라
+# #bm-export-btn 클릭 핸들러로만 노출된다. 인터셉트 훅은 그대로 두고
+# 트리거만 버튼 클릭으로 바꿔 동일한 효과를 얻는다.
+_INSTALL_EXPORT_INTERCEPT_JS = """() => {
+    window.__bmExportCaptured = { filename: null, data: null };
     const OrigBlob = window.Blob;
     const origAppend = document.body.appendChild.bind(document.body);
     const origRevoke = URL.revokeObjectURL.bind(URL);
 
-    let capturedJson = null;
-    let capturedFilename = null;
-
-    // Blob 생성자 가로채기 — application/json 페이로드만 캡처
     window.Blob = function(parts, options) {
         if (options && options.type === 'application/json' && parts.length === 1) {
-            capturedJson = parts[0];
+            window.__bmExportCaptured.data = JSON.parse(parts[0]);
         }
         return new OrigBlob(parts, options);
     };
 
-    // <a download> 클릭 억제 및 파일명 캡처
     document.body.appendChild = (node) => {
         if (node && node.tagName === 'A' && node.download) {
-            capturedFilename = node.download;
+            window.__bmExportCaptured.filename = node.download;
             node.click = () => {};
         }
         return origAppend(node);
     };
 
-    // blob URL 조기 해제 방지
     URL.revokeObjectURL = () => {};
-
-    exportBookmarks();
-
-    window.Blob = OrigBlob;
-    document.body.appendChild = origAppend;
-    URL.revokeObjectURL = origRevoke;
-
-    return {
-        filename: capturedFilename,
-        data: capturedJson ? JSON.parse(capturedJson) : null
-    };
 }"""
 
 
 def _intercept_export(page) -> dict:
-    """exportBookmarks() 를 호출하고 파일명·JSON 페이로드를 가로채 반환한다."""
-    return page.evaluate(_INTERCEPT_EXPORT_JS)
+    """#bm-export-btn 을 클릭해 exportBookmarks 핸들러를 트리거하고,
+    Blob 생성자와 anchor.appendChild 를 가로채 JSON 페이로드/파일명을 반환한다.
+    내보내기 버튼은 오버플로 패널 안에 숨겨져 있으므로 먼저 ⋯ 버튼을 연다."""
+    page.evaluate(_INSTALL_EXPORT_INTERCEPT_JS)
+    page.locator("#bm-overflow-btn").click()
+    page.wait_for_selector("#bm-overflow-panel:not([hidden])")
+    page.locator("#bm-export-btn").click()
+    return page.evaluate("() => window.__bmExportCaptured")
 
 
 # ── 테스트용 픽스처 데이터 ──────────────────────────────────────────────────

--- a/tests/e2e/test_drive_sync.py
+++ b/tests/e2e/test_drive_sync.py
@@ -526,11 +526,15 @@ def test_pkce_callback_state_mismatch_rejected(browser, fake_drive, fake_oauth):
             "() => location.search === '' || location.search === undefined",
             timeout=15_000,
         )
+        # initDriveSync → _machine.enable() fires _attemptSilentRefresh
+        # asynchronously; it returns false (no refresh token) and the machine
+        # parks in NEEDS_CONSENT. Poll for that terminal state rather than
+        # sampling immediately, which races with the async transition.
+        page.wait_for_function(
+            "() => window.driveSync.getStatus() === 'NEEDS_CONSENT'",
+            timeout=5_000,
+        )
         assert page.evaluate("window.driveSync.isAuthenticated()") is False
-        # __pendingRedirectError captured the reason before initDriveSync ran.
-        # By the time we check, initDriveSync has already consumed it; assert
-        # via the machine state instead.
-        assert page.evaluate("window.driveSync.getStatus()") == "NEEDS_CONSENT"
     finally:
         page.context.close()
 
@@ -547,8 +551,11 @@ def test_pkce_callback_error_param_rejected(browser, fake_drive, fake_oauth):
             "() => location.search === '' || location.search === undefined",
             timeout=15_000,
         )
+        page.wait_for_function(
+            "() => window.driveSync.getStatus() === 'NEEDS_CONSENT'",
+            timeout=5_000,
+        )
         assert page.evaluate("window.driveSync.isAuthenticated()") is False
-        assert page.evaluate("window.driveSync.getStatus()") == "NEEDS_CONSENT"
     finally:
         page.context.close()
 

--- a/tests/e2e/test_drive_sync_ios.py
+++ b/tests/e2e/test_drive_sync_ios.py
@@ -248,8 +248,12 @@ def test_ios_callback_state_mismatch_rejected(browser, fake_drive, fake_oauth):
         page.wait_for_function(
             "() => location.search === ''", timeout=15_000,
         )
+        # ENABLE → _attemptSilentRefresh is async; poll for NEEDS_CONSENT.
+        page.wait_for_function(
+            "() => window.driveSync.getStatus() === 'NEEDS_CONSENT'",
+            timeout=5_000,
+        )
         assert page.evaluate("window.driveSync.isAuthenticated()") is False
-        assert page.evaluate("window.driveSync.getStatus()") == "NEEDS_CONSENT"
     finally:
         page.context.close()
 
@@ -266,8 +270,11 @@ def test_ios_callback_error_param_rejected(browser, fake_drive, fake_oauth):
         page.wait_for_function(
             "() => location.search === ''", timeout=15_000,
         )
+        page.wait_for_function(
+            "() => window.driveSync.getStatus() === 'NEEDS_CONSENT'",
+            timeout=5_000,
+        )
         assert page.evaluate("window.driveSync.isAuthenticated()") is False
-        assert page.evaluate("window.driveSync.getStatus()") == "NEEDS_CONSENT"
     finally:
         page.context.close()
 

--- a/tests/e2e/test_search.py
+++ b/tests/e2e/test_search.py
@@ -284,6 +284,16 @@ def test_mobile_focus_in_expanded_reverts_to_compact(browser):
             "#search-sheet-results .search-result-item:not(.ref-match-item)",
             timeout=8_000,
         )
+        # runSheetSearch is async — onPartial then the post-await clearNode +
+        # renderSearchResultList run after the first .search-result-item match.
+        # Wait for the loading placeholder to disappear AND the a11y announce
+        # to fire so the focus handler's clearNode isn't immediately
+        # overwritten by a trailing render.
+        page.wait_for_selector("#search-sheet-results .loading", state="detached", timeout=3_000)
+        page.wait_for_function(
+            "() => /검색 결과/.test(document.getElementById('a11y-announce')?.textContent || '')",
+            timeout=3_000,
+        )
 
         # Programmatically focus to bypass iOS pointer quirks; the JS focus
         # handler is what we're testing.


### PR DESCRIPTION
## Summary

- 모듈 분할(ADR-018)·기능 추가 누적으로 깨진 e2e 17건 일괄 수선 — 173건 전수 통과
- 검색 입력 `role="combobox"` 누락(ADR-014 도입 시 빠짐) 보완 — axe-core critical 회귀 정정
- 비기술 독자용 회귀 보고서 1편 ([docs/qa/2026-05-12-e2e-regression.md](https://github.com/anglican-kr/common-bible/blob/claude/infallible-noyce-78557a/docs/qa/2026-05-12-e2e-regression.md))

## 카테고리별 수선

| 분류 | 건수 | 골자 |
|------|-----|------|
| 모듈 분할로 사라진 전역 | 8 | `openSaveModal` / `exportBookmarks` / `_currentBookId` → 버튼 클릭 + `window.readingContext` |
| PKCE 콜백 race | 4 | URL 정리가 아니라 상태머신 `NEEDS_CONSENT` 정착을 폴링 |
| 오디오 컨트롤 race | 6 | 빈 바디 응답이 fire 한 `error` 이벤트가 컨트롤을 떼어 냈음 — init script 로 리스너 차단 |
| 검색 증분 렌더링 race | 1 | 로딩 종료 + a11y announce 발화까지 대기 |
| 실제 a11y 회귀 (앱 코드) | 3 | `<input type="search">` 에 `role="combobox"` 추가 |

## Test plan
- [x] `pytest tests/e2e/` 173/173 통과 (약 6분 33초)
- [x] axe-core critical 위반 0건 복귀 (홈/본문/검색 결과)
- [x] 카테고리별 격리 재실행 시 모두 안정 — 오디오 race 도 `_open` 공통화 후 일관 통과
- [ ] 모바일(iOS 17 Safari)에서 검색 입력 combobox role 추가 후 VoiceOver 발화 수동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly updates E2E tests to use user-facing triggers and add more robust waits; only production change is adding `role="combobox"` to search inputs for ARIA validity, so runtime risk is minimal.
> 
> **Overview**
> Restores the E2E suite to green after recent module/UI changes by replacing calls to removed globals (e.g. `openSaveModal`, `exportBookmarks`, `_currentBookId`) with real UI interactions (`#bm-save-chapter-btn`, bookmark overflow export) and `window.readingContext`.
> 
> Hardens flaky flows by polling for terminal states (`driveSync` PKCE failures waiting for `NEEDS_CONSENT`), suppressing early audio `error` handlers during audio-control interaction tests, and waiting for mobile search rendering/announcements before asserting focus/cleanup.
> 
> Fixes an axe-core *critical* accessibility regression by adding `role="combobox"` to `#search-input` and `#search-sheet-input` to match the existing `aria-autocomplete`/`aria-controls` attributes, and adds a Korean E2E regression report under `docs/qa/2026-05-12-e2e-regression.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69fdfd51896861b925ff9194f5a2aca12f246aed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->