### PR TITLE
feat: 절 복사 후 스낵바 알림 + 스낵바 색상 톤 다운

### DIFF
--- a/js/app/bookmark.js
+++ b/js/app/bookmark.js
@@ -1899,9 +1899,11 @@ async function copySelectedVerses() {
   try {
     await navigator.clipboard.writeText(fullText);
     announce("복사했습니다.");
+    window._showSyncSnackbar?.("복사했습니다.");
     exitVerseSelectMode();
   } catch {
-    announce("복사에 실패했습니다.");
+    announce("복사하지 못했습니다.");
+    window._showSyncSnackbar?.("복사하지 못했습니다.");
   }
 }
 

--- a/js/drive-sync.js
+++ b/js/drive-sync.js
@@ -89,13 +89,13 @@ window.addEventListener("online", () => {
   if (_machine.isEnabled()) _machine.dispatch({ type: "NET_RECOVERED" });
 });
 
-// ── Snackbar (UI notification, called by state machine) ────────────────────────
-// Inverts page colors (bg=--text, fg=--bg) so contrast stays AA-grade across
-// every theme/color-scheme combination.
+// ── Snackbar (UI notification, called by state machine and other modules) ─────
+// Uses --bg-card surface so the toast harmonizes with the page background
+// across themes; --border and a soft shadow keep it readable on cream/white.
 window._showSyncSnackbar = function (msg) {
   const el = document.createElement("div");
   el.textContent = msg;
-  el.style.cssText = "position:fixed;bottom:80px;left:50%;transform:translateX(-50%);max-width:calc(100vw - 32px);background:var(--text);color:var(--bg);padding:12px 20px;border-radius:8px;font-family:-apple-system,BlinkMacSystemFont,'Apple SD Gothic Neo','Noto Sans KR',sans-serif;font-size:14px;line-height:1.4;z-index:9999;box-shadow:0 4px 16px rgba(0,0,0,.3);text-align:center;";
+  el.style.cssText = "position:fixed;bottom:calc(env(safe-area-inset-bottom, 0px) + 80px);left:50%;transform:translateX(-50%);max-width:calc(100vw - 32px);background:var(--bg-card);color:var(--text);border:1px solid var(--border);padding:12px 20px;border-radius:8px;font-family:-apple-system,BlinkMacSystemFont,'Apple SD Gothic Neo','Noto Sans KR',sans-serif;font-size:14px;line-height:1.4;z-index:9999;box-shadow:0 4px 12px rgba(0,0,0,.15);text-align:center;";
   document.body.appendChild(el);
   setTimeout(() => el.remove(), 3500);
 };


### PR DESCRIPTION
## Summary
- 절 복사 성공/실패 시 "복사했습니다." 스낵바를 띄워 시각 피드백 추가. 그동안은 액션 바만 닫혀서 동작 여부를 알기 어려웠음
- 스낵바 배경을 페이지 색 완전 반전(`--text`)에서 `--bg-card` + `--border` + 부드러운 그림자로 변경 → 배경과 어울리는 톤
- 동기화 알림에도 동일하게 적용 (`_showSyncSnackbar` 공용)

## Test plan
- [ ] 절 선택 → 복사 버튼 → "복사했습니다." 스낵바가 잠시 떴다 사라지는지 확인
- [ ] 스낵바 색이 페이지 배경과 어울리는지 (라이트/다크 모드 둘 다)
- [ ] 클립보드에 절 본문 + 인용 표기가 정상 들어갔는지
- [ ] 동기화 오류 스낵바도 새 톤으로 자연스럽게 보이는지

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only changes: adds optional toast notifications and tweaks styling/positioning without affecting sync logic or data handling.
> 
> **Overview**
> Shows a visual snackbar toast when copying selected verses succeeds or fails by calling the shared `window._showSyncSnackbar` from `copySelectedVerses`.
> 
> Rethemes `_showSyncSnackbar` to use `--bg-card`/`--border`, a softer shadow, and safe-area-aware bottom positioning, making sync (and now copy) toasts less visually jarring across themes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d025e63bc9eee1b9be9db234a1fad38ba51d60b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->