### PR TITLE
style: 절 선택 모드 진입 시 가로 마진 변화로 인한 줄바꿈 방지

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2570,9 +2570,13 @@ body.verse-select-active #search-fab {
 }
 
 
+/* Negative horizontal margin offsets the padding so adjacent inline text
+   keeps the same position — the highlight extends visually, but the line
+   does not reflow when entering verse-select mode. */
 body.verse-select-active .verse[data-vref] {
   cursor: pointer;
   padding: 0.1em 0.15em;
+  margin: 0 -0.15em;
   transition: background 0.1s;
 }
 
@@ -2583,9 +2587,11 @@ body.verse-select-active .verse[data-vref]:not(.verse-selected):hover {
 
 /* Poetry verses use a 2rem left gutter for the verse-num (margin-left: -2rem).
    The shorthand padding above would shrink that gutter and push the number
-   off-screen, so restore it here. */
+   off-screen, so restore it here. Cancel the left negative margin so the
+   gutter math is unaffected. */
 body.verse-select-active .verse.verse-poetry[data-vref] {
   padding-left: 2rem;
+  margin-left: 0;
 }
 
 .verse.verse-selected {


### PR DESCRIPTION
## 증상

절 선택 모드(long-press)로 진입하는 순간 본문 텍스트의 줄바꿈 위치가 미세하게 달라져, 같은 절의 텍스트가 한 줄 더 내려가거나 위치가 바뀌어 보이는 문제.

## 원인

`css/style.css:2573` 의 `body.verse-select-active .verse[data-vref]` 가 모든 절에 `padding: 0.1em 0.15em` 을 추가한다. `.verse` 는 `display: inline` (line 1857) 이라 좌우 0.15em padding 이 인접 텍스트를 옆으로 밀어내며, 그 누적이 줄바꿈 위치를 흔든다.

## 변경

- `body.verse-select-active .verse[data-vref]` 에 `margin: 0 -0.15em` 추가. 좌우 padding 을 음수 마진으로 상쇄해 선택 하이라이트의 시각적 여유(둥근 배경의 좌우 확장)는 유지하면서 인접 텍스트는 흔들리지 않도록 한다.
- `body.verse-select-active .verse.verse-poetry[data-vref]` 는 `padding-left: 2rem` 으로 verse-num 의 2rem 좌측 gutter 를 복원하고 있어, 음수 마진까지 적용되면 gutter 계산이 어긋난다. `margin-left: 0` 으로 음수 마진만 다시 취소한다(시 형식은 block 이라 가로 reflow 가 원래 없다).

## 테스트 계획

- [ ] 창세기 1장에서 long-press 로 절 선택 모드 진입 시 본문 줄바꿈 위치가 그대로 유지되는지 확인 (스크린샷 비교)
- [ ] 시편 등 `verse-poetry` 장에서 verse-num 의 좌측 정렬이 어긋나지 않는지 확인
- [ ] 연속된 절을 다중 선택했을 때 둥근 배경이 자연스럽게 이어지는지(`verse-selected-join-prev/next`) 확인
- [ ] 호버 상태(데스크탑)에서도 마진 변화 없음 확인

🤖 https://claude.ai/code/session_01NGHqmkJhSFTHfNon17i97w

---
_Generated by [Claude Code](https://claude.ai/code/session_01NGHqmkJhSFTHfNon17i97w)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CSS-only change that tweaks inline verse spacing in `verse-select` mode; main risk is minor visual regressions around verse gutters/highlights in poetry layouts.
> 
> **Overview**
> Prevents subtle line-wrapping shifts when entering *verse selection mode* by offsetting the added horizontal `padding` on inline `.verse[data-vref]` elements with an equivalent negative horizontal `margin`.
> 
> Adjusts the poetry verse variant to cancel the left negative margin (`margin-left: 0`) so the existing 2rem verse-number gutter remains aligned while keeping the new non-reflowing highlight behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7f94b5cf82c14d8c6d1cc53a2b3fd382044e12a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->