### PR TITLE
fix: 절 선택·북마크 하이라이트가 인접 줄과 겹치는 문제 해결

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1589,7 +1589,10 @@ mark.search-highlight {
 .verse-highlight {
   background: rgba(107, 58, 42, 0.08) !important;
   border-radius: 5px;
-  padding: 0.1em 0.15em;
+  /* Inline padding only — vertical padding on inline elements extends the
+     painted background past the line-box and overlaps neighboring lines on
+     iOS Safari (Korean fonts fill the full line-height). */
+  padding: 0 0.15em;
 }
 
 /* In a run of consecutive highlighted verses, flatten the corners that abut
@@ -2572,10 +2575,13 @@ body.verse-select-active #search-fab {
 
 /* Negative horizontal margin offsets the padding so adjacent inline text
    keeps the same position — the highlight extends visually, but the line
-   does not reflow when entering verse-select mode. */
+   does not reflow when entering verse-select mode. Vertical padding is 0
+   because on inline elements it extends the painted background past the
+   line-box and overlaps neighboring lines on iOS Safari with Korean fonts
+   (ascent + descent already fill the full line-height). */
 body.verse-select-active .verse[data-vref] {
   cursor: pointer;
-  padding: 0.1em 0.15em;
+  padding: 0 0.15em;
   margin: 0 -0.15em;
   transition: background 0.1s;
 }


### PR DESCRIPTION
## Summary

- 절 선택 모드(`verse-select-active`)·북마크 하이라이트(`.verse-highlight`)에서 같은 절이 여러 줄로 줄바꿈될 때 위·아래 줄의 하이라이트 배경이 시각적으로 겹쳐 보이는 문제 수정
- `padding: 0.1em 0.15em` → `padding: 0 0.15em` (세로 padding 제거)
- iOS Safari + 한국어 시스템 폰트(Apple SD Gothic Neo)는 ascent + descent가 line-height 전체를 차지하므로 half-leading이 거의 0이라, inline 요소의 세로 padding 만으로도 이웃 줄 배경을 침범했음

## 영향 범위

- inline 절(평문): 세로 padding이 사라져 배경이 line-box 안에 정확히 머무름 → 겹침 해소
- 시 형식(`.verse-poetry`, block): 인접 절 배경이 맞닿는 형태로 표시되어 기존 `join-prev/next` 모서리 평탄화 로직과 자연스럽게 호환
- 가로 padding 0.15em·음수 마진(`margin: 0 -0.15em`)은 그대로 유지 → 모서리 둥글기·reflow 방지 영향 없음

## Test plan

- [ ] iPhone Safari에서 창세기 1:3-5 선택 → 줄 사이 배경 겹침 사라졌는지 육안 확인
- [ ] 북마크된 절이 여러 줄에 걸칠 때 배경 겹침 사라졌는지 확인
- [ ] 시 형식 본문(예: 시편)에서 절 선택 모드 시 인접 절이 자연스럽게 이어지는지 확인
- [x] `node --test tests/unit/*.test.js` (491/491 통과)

https://claude.ai/code/session_012iriMpLh82aisL1sjQ8uYi

---
_Generated by [Claude Code](https://claude.ai/code/session_012iriMpLh82aisL1sjQ8uYi)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CSS-only tweak that removes vertical padding from inline verse highlight/selection styles to avoid iOS Safari line-box overlap; main risk is minor visual regression in highlight spacing on other browsers.
> 
> **Overview**
> Fixes a visual overlap bug where **wrapped inline verse highlights** (bookmarks via `.verse-highlight` and verse-select mode via `body.verse-select-active .verse[data-vref]`) could paint into adjacent lines.
> 
> The change removes **vertical padding** (`0.1em` → `0`) while keeping the existing horizontal padding/margins, and adds comments documenting the iOS Safari/Korean font line-box behavior that motivated it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b0e9c13a5b8ec8e64fcf373a2cec95600200aac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->