### PR TITLE
fix: 절 선택 모드 inline padding/margin 잔존 어긋남 제거

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2573,16 +2573,14 @@ body.verse-select-active #search-fab {
 }
 
 
-/* Negative horizontal margin offsets the padding so adjacent inline text
-   keeps the same position — the highlight extends visually, but the line
-   does not reflow when entering verse-select mode. Vertical padding is 0
-   because on inline elements it extends the painted background past the
-   line-box and overlaps neighboring lines on iOS Safari with Korean fonts
-   (ascent + descent already fill the full line-height). */
+/* No inline padding/margin in select mode. Even a 0.15em horizontal padding
+   offset by an equal negative margin still produced ~1px shifts on iOS
+   Safari due to subpixel rounding of em-based metrics on inline boxes that
+   contain a `vertical-align: super` <sup>. The visual "breathing room"
+   around the highlight is drawn via box-shadow on .verse-selected below —
+   shadows paint outside the line-box without affecting reflow. */
 body.verse-select-active .verse[data-vref] {
   cursor: pointer;
-  padding: 0 0.15em;
-  margin: 0 -0.15em;
   transition: background 0.1s;
 }
 
@@ -2591,18 +2589,32 @@ body.verse-select-active .verse[data-vref]:not(.verse-selected):hover {
   border-radius: 5px;
 }
 
-/* Poetry verses use a 2rem left gutter for the verse-num (margin-left: -2rem).
-   The shorthand padding above would shrink that gutter and push the number
-   off-screen, so restore it here. Cancel the left negative margin so the
-   gutter math is unaffected. */
-body.verse-select-active .verse.verse-poetry[data-vref] {
-  padding-left: 2rem;
-  margin-left: 0;
+.verse.verse-selected {
+  --selected-bg: color-mix(in srgb, var(--accent) 20%, transparent);
+  background: var(--selected-bg) !important;
+  border-radius: 5px;
 }
 
-.verse.verse-selected {
-  background: color-mix(in srgb, var(--accent) 20%, transparent) !important;
-  border-radius: 5px;
+/* Extend the highlight 0.15em on each side without changing inline layout.
+   Block (poetry) verses span the full content width already, so they don't
+   need horizontal extension. */
+.verse.verse-selected:not(.verse-poetry) {
+  box-shadow:
+    0.15em 0 0 var(--selected-bg),
+    -0.15em 0 0 var(--selected-bg);
+}
+
+/* In a run of consecutive selected inline verses, suppress the box-shadow
+   on the inner edges so the semi-transparent shadows don't overlap and
+   double the color at the boundary. */
+.verse.verse-selected.verse-selected-join-prev:not(.verse-poetry) {
+  box-shadow: 0.15em 0 0 var(--selected-bg);
+}
+.verse.verse-selected.verse-selected-join-next:not(.verse-poetry) {
+  box-shadow: -0.15em 0 0 var(--selected-bg);
+}
+.verse.verse-selected.verse-selected-join-prev.verse-selected-join-next:not(.verse-poetry) {
+  box-shadow: none;
 }
 
 /* In a run of consecutive selected verses, flatten the corners that abut


### PR DESCRIPTION
## 배경

오늘 두 차례 시도가 있었습니다.

- `2652af1` style: 절 선택 모드 진입 시 가로 마진 변화로 인한 줄바꿈 방지
  - `padding: 0.1em 0.15em` + `margin: 0 -0.15em` 로 padding 을 음수 margin 으로 상쇄
- `4089b30` fix: 절 선택·북마크 하이라이트가 인접 줄과 겹치는 문제 해결
  - 세로 padding 0 으로 → `padding: 0 0.15em; margin: 0 -0.15em`

이론상 padding + 동일 폭 음수 margin = 0 으로 상쇄되어야 하지만, iOS Safari 에서 절 선택 모드 진입 시 본문이 살짝 어긋나는 현상이 남아 있었습니다.

## 원인

`verse-num` 이 `<sup vertical-align: super; font-size: 0.7rem;>` 인 inline 자식을 품고 있어, 부모 inline box 의 em 단위 metric 계산이 미묘해집니다. 이 상태에서 0.15em 의 padding 과 동일 폭 음수 margin 을 함께 적용하면 Safari 의 서브픽셀 라운딩이 두 값을 완전히 같은 픽셀로 변환하지 못해 1px 미만의 잔존 어긋남이 나타납니다.

## 해법

inline 흐름에 영향을 주지 않는 방식으로 시각적 가로 여유를 그립니다.

1. `body.verse-select-active .verse[data-vref]` 에서 padding/margin 제거 → inline 흐름 영향 0
2. `.verse.verse-selected` 에 `box-shadow` 로 좌우 0.15em 색 확장 (line-box 바깥에 페인트만 추가, reflow 없음)
3. 연속 선택 구간(`verse-selected-join-prev/next`)에서는 안쪽 그림자를 제거 → 반투명 색이 겹쳐 진해지는 현상 방지
4. 시 형식(`.verse-poetry`, block)은 이미 콘텐츠 전체 폭을 차지하므로 가로 그림자 미적용
5. 더 이상 필요 없는 시 형식 전용 padding-left/margin-left 복원 규칙 정리

## Test plan

- [x] 유닛 테스트 491개 통과 (`node --test tests/unit/*.test.js`)
- [ ] iOS Safari 에서 절 선택 모드 토글 시 본문 위치 변동 없음 확인
- [ ] 인접한 여러 절을 연속 선택해도 경계 부분 색 중첩 없음 확인
- [ ] 시 형식 절(시편 등) 에서도 선택 시각이 정상 표시되는지 확인

https://claude.ai/code/session_012iriMpLh82aisL1sjQ8uYi

---
_Generated by [Claude Code](https://claude.ai/code/session_01TK24VFJWjSHLwW8GWYzMyH)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CSS-only changes to verse selection highlighting; main risk is subtle visual regressions in highlight appearance across browsers and for consecutive selections/poetry verses.
> 
> **Overview**
> Prevents tiny text/layout shifts on iOS Safari when entering *verse selection mode* by removing inline `padding`/negative `margin` from selectable `.verse[data-vref]` spans.
> 
> Reimplements the horizontal “breathing room” for selected verses using `box-shadow` on `.verse.verse-selected` (with join-aware rules to avoid double-darkening between adjacent selections) and drops the now-unneeded poetry-specific padding/margin override.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 534a60e8a19850a8f93b02d6f7becc3d4d5878b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->