### PR TITLE
fix: 절 선택 하이라이트 인접 절 경계 색 중첩 제거

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2573,10 +2573,10 @@ body.verse-select-active #search-fab {
 }
 
 
-/* No inline padding/margin in select mode. Even a 0.15em horizontal padding
-   offset by an equal negative margin still produced ~1px shifts on iOS
-   Safari due to subpixel rounding of em-based metrics on inline boxes that
-   contain a `vertical-align: super` <sup>. The visual "breathing room"
+/* No inline padding/margin in select mode. A 0.15em horizontal padding
+   offset by an equal negative margin produced ~1px shifts on iOS Safari
+   because of subpixel rounding of em-based metrics on inline boxes that
+   contain a `vertical-align: super` <sup>. The visible "breathing room"
    around the highlight is drawn via box-shadow on .verse-selected below —
    shadows paint outside the line-box without affecting reflow. */
 body.verse-select-active .verse[data-vref] {
@@ -2589,13 +2589,20 @@ body.verse-select-active .verse[data-vref]:not(.verse-selected):hover {
   border-radius: 5px;
 }
 
+/* Use an opaque color (the 20% accent pre-mixed with --bg) rather than a
+   semi-transparent overlay. A box-shadow offset of the same shape paints a
+   copy of the box behind itself; with a semi-transparent base, the area
+   where shadow and box overlap composites to ~36% accent instead of 20%,
+   leaving a visible darker column between adjacent selected verses. Pre-
+   mixing with --bg makes "shadow alone", "box alone", and "shadow + box"
+   all render the same color. */
 .verse.verse-selected {
-  --selected-bg: color-mix(in srgb, var(--accent) 20%, transparent);
+  --selected-bg: color-mix(in srgb, var(--accent) 20%, var(--bg));
   background: var(--selected-bg) !important;
   border-radius: 5px;
 }
 
-/* Extend the highlight 0.15em on each side without changing inline layout.
+/* Extend the highlight 0.15em on each side without affecting inline layout.
    Block (poetry) verses span the full content width already, so they don't
    need horizontal extension. */
 .verse.verse-selected:not(.verse-poetry) {
@@ -2605,8 +2612,9 @@ body.verse-select-active .verse[data-vref]:not(.verse-selected):hover {
 }
 
 /* In a run of consecutive selected inline verses, suppress the box-shadow
-   on the inner edges so the semi-transparent shadows don't overlap and
-   double the color at the boundary. */
+   on the inner edges. The shadow color is opaque, so this is not strictly
+   needed to avoid darker bands, but it stops the shadow from poking past
+   the run's interior boundary into the following / preceding verse. */
 .verse.verse-selected.verse-selected-join-prev:not(.verse-poetry) {
   box-shadow: 0.15em 0 0 var(--selected-bg);
 }


### PR DESCRIPTION
## 배경

직전 PR #128 이 머지된 뒤에도 사용자가 보고하길 — 인접한 절을 여러 개 선택했을 때 절 경계에 색이 한 단계 진해진 세로 띠가 보였습니다 (예: 6-8 절 동시 선택 시 6/7, 7/8 경계).

## 원인

`box-shadow: 0.15em 0 0 color` 은 박스를 "옆으로 늘리는" 게 아니라 **박스 모양 그대로의 복사본을 0.15em 만큼 옮겨 박스 뒤에 깔아두는** 효과입니다.

그림자 색이 `.verse-selected` 의 반투명 배경 (`color-mix(... var(--accent) 20%, transparent)`) 과 같으면, 박스와 그림자가 겹친 영역은 두 겹이 합성되어 ~36% accent 가 되고, 박스의 한쪽 끝 0.15em (그림자가 닿지 않는 쪽) 만 ~20% accent 한 겹이 됩니다.

`verse-selected-join-prev/next` 로 안쪽 그림자를 제거해도, 한 절 내부에서 좌·우측 농도가 다른 상태가 남아, 인접 선택 절 경계에서 (한쪽은 진하게, 한쪽은 연하게) 만나면서 진한 띠가 시각적으로 두드러집니다.

## 해법

`--selected-bg` 의 세 번째 색을 `transparent` 에서 `var(--bg)` 로 바꿔, 페이지 배경과 미리 합성한 **불투명 솔리드 색**으로 만듭니다.

- "그림자만 있는 영역", "박스만 있는 영역", "그림자 + 박스 겹친 영역" 모두 동일한 색을 그리게 됩니다 (불투명 색 위에 같은 불투명 색 = 동일 색)
- 다크 테마 (`--bg: #1a1a2e`) 에서도 자동으로 톤에 맞춰집니다
- 시각적 톤은 거의 동일 — 반투명 20% 가 흰 배경 위에 보이던 것과 같은 결과 색을 미리 계산해 두는 것일 뿐

`box-shadow` 의 join-prev/next 안쪽 그림자 제거 규칙은 그대로 둡니다. 솔리드라 색 농도 차는 사라지지만, 그림자가 인접 절을 0.15em 침범하는 것은 border-radius 평탄화 로직과 모순될 수 있어 유지합니다.

## Test plan

- [x] 유닛 테스트 491개 통과 (`node --test tests/unit/*.test.js`)
- [ ] iOS Safari 에서 인접 절 여러 개 선택 시 경계 색 중첩 없음 확인
- [ ] 단일 절만 선택해도 가로 0.15em 시각적 여유 유지됨 확인
- [ ] 다크 테마 토글 시 톤이 자연스러운지 확인
- [ ] 시 형식 절(시편 등) 의 선택 시각이 정상 표시되는지 확인

https://claude.ai/code/session_012iriMpLh82aisL1sjQ8uYi

---
_Generated by [Claude Code](https://claude.ai/code/session_01TK24VFJWjSHLwW8GWYzMyH)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CSS-only change that alters the selected-verse background color composition; potential impact is limited to verse selection highlight appearance across themes/browsers.
> 
> **Overview**
> Fixes a visual artifact in verse selection where adjacent selected verses formed darker boundary bands.
> 
> Changes `.verse-selected` to use an *opaque* pre-mixed `--selected-bg` (`color-mix(..., var(--bg))`) instead of a semi-transparent overlay so the `box-shadow` extension doesn’t double-composite at overlaps, and updates related comments while keeping the join-prev/join-next shadow suppression behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1ea1aba7659a0072f274df7707c7534ad0e6920. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->