### PR TITLE
style: 헤더 그라데이션 제거하고 frosted glass 적용

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -136,26 +136,17 @@ body {
 /* ── Header ── */
 #sticky-group {
   position: sticky;
-  top: env(safe-area-inset-top);
+  top: 0;
   z-index: 20;
-}
-
-#sticky-group::after {
-  content: "";
-  position: absolute;
-  left: 0;
-  right: 0;
-  top: 100%;
-  height: 2rem;
-  background: linear-gradient(to bottom, var(--bg), transparent);
-  pointer-events: none;
 }
 
 #app-header {
   font-family: -apple-system, BlinkMacSystemFont, "Apple SD Gothic Neo", "Noto Sans KR", sans-serif;
-  background: var(--bg);
+  background: color-mix(in srgb, var(--bg) 72%, transparent);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
   border-bottom: none;
-  padding: 0.6rem 1rem;
+  padding: calc(0.6rem + env(safe-area-inset-top)) 1rem 0.6rem;
   max-width: var(--max-width);
   margin: 0 auto;
 }
@@ -1667,7 +1658,7 @@ mark.search-highlight {
 /* ── Resume Banner ── */
 #resume-banner-slot {
   position: relative;
-  z-index: 10; /* above #app-header::before gradient (z-index: 9) */
+  z-index: 10;
   max-width: var(--max-width);
   margin: 0 auto;
   padding: 0 1rem;


### PR DESCRIPTION
## Summary

- 본문 위 페이드 그라데이션(`#sticky-group::after`) 삭제
- 헤더 배경을 `color-mix(in srgb, var(--bg) 72%, transparent)` + `backdrop-filter: blur(12px)` 로 변경 — 하단 오디오 플레이어와 일관된 frosted glass 패턴
- sticky `top` 을 `0` 으로 끌어올리고 헤더 `padding-top` 에 `env(safe-area-inset-top)` 합산해서 Android Chrome 135+ edge-to-edge 환경에서 상태바 영역까지 자연스럽게 blur 가 깔리도록 함
- `#resume-banner-slot` 의 stale 한 z-index 주석 정리

## 플랫폼별 동작 (조사 후 확정)

| 플랫폼 | env(safe-area-inset-top) | 결과 |
|---|---|---|
| iOS PWA (status-bar-style 메타 없음 = `default`) | 0 | 상태바는 iOS 시스템 레이어로 별도 렌더, theme-color 로 채색됨. 그 아래 frosted glass 헤더 — 시각적 간극 없음 |
| Android Chrome <135 | 0 | 시스템 상태바 아래 frosted glass 헤더 |
| Android Chrome 135+ (edge-to-edge 기본) | non-zero | 뷰포트가 상태바까지 확장되어 frosted glass 가 상태바 영역까지 자연스럽게 깔림 |

iOS 에서 `apple-mobile-web-app-status-bar-style: black-translucent` 를 쓰면 노치 ear 영역까지 frosted glass 를 깔 수 있지만, 라이트 모드(`#faf8f5` 크림 배경) 에서 흰색 강제 상태바 텍스트가 안 보이게 되는 트레이드오프가 있어 채택하지 않음.

## Test plan

- [ ] iOS Safari 데스크탑/모바일(라이트·다크 모드)에서 헤더가 frosted glass 로 보이는지
- [ ] 본문 스크롤 시 헤더 뒤로 텍스트가 흐릿하게 비치는지
- [ ] iOS PWA(홈 화면 추가) 모드에서 상태바와 헤더 사이 시각적 간극이 없는지
- [ ] Android Chrome 최신(135+) PWA 에서 상태바 영역까지 blur 가 자연스럽게 이어지는지
- [ ] 다크 모드에서 blur 강도 & 투명도 가독성
- [ ] 데스크탑(폭 > 720px) 에서 헤더가 가운데 정렬된 frosted glass 컬럼으로 보이는지

https://claude.ai/code/session_01DBRDQzcY7U3abwNeXLaS87

---
_Generated by [Claude Code](https://claude.ai/code/session_01DBRDQzcY7U3abwNeXLaS87)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure CSS visual/layout tweaks to the sticky header (background blur, safe-area padding, and positioning) with minimal functional impact; main risk is cross-browser rendering differences for `backdrop-filter`/`color-mix` and safe-area insets.
> 
> **Overview**
> Updates the sticky header styling to a frosted-glass treatment: removes the `#sticky-group::after` fade gradient, switches `#app-header` to a semi-transparent `color-mix(...)` background with `backdrop-filter` blur, and adjusts sticky positioning (`top: 0`) with `env(safe-area-inset-top)` folded into header padding for edge-to-edge mobile layouts.
> 
> Also cleans up a stale `z-index` comment on `#resume-banner-slot` without changing behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f580c32d72e7ba1cc0a275f3b7bd3b9e2b28097. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->