### PR TITLE
fix: 오디오 없는 책에서 FAB 위치 보정

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -939,9 +939,8 @@ body {
   bottom: max(calc(1.5rem + env(safe-area-inset-bottom)), var(--fab-lift-nav, 0px));
 }
 
-/* Lift FAB when the sticky audio player is visible. The unavailable-state bar
-   sits inline at the end of content (position: static) and must not lift the FAB. */
-#audio-bar:not([hidden]):not(.unavailable) ~ #search-fab {
+/* Lift FAB when audio bar is visible */
+#audio-bar:not([hidden]) ~ #search-fab {
   bottom: max(calc(5rem + env(safe-area-inset-bottom)), var(--fab-lift-nav, 0px));
 }
 
@@ -2127,12 +2126,6 @@ mark.search-highlight {
   display: none;
 }
 
-/* "Audio file is being prepared" placeholder sits inline at the end of
-   content rather than sticking to the viewport bottom. */
-#audio-bar.unavailable {
-  position: static;
-}
-
 .audio-player {
   display: flex;
   align-items: center;
@@ -2292,15 +2285,17 @@ mark.search-highlight {
   border-color: var(--text-secondary);
 }
 
-/* Unavailable message */
+/* Unavailable message — sized to match .audio-player so the sticky bar
+   keeps the same footprint whether audio is available or not. */
 .audio-unavailable {
   display: flex;
   align-items: center;
   justify-content: center;
   gap: 0.4em;
+  min-height: 2.4rem;
+  margin: 0;
   font-size: 0.75rem;
   color: var(--text-secondary);
-  padding: 0.15rem 0;
 }
 
 .audio-unavailable-icon {

--- a/css/style.css
+++ b/css/style.css
@@ -939,8 +939,9 @@ body {
   bottom: max(calc(1.5rem + env(safe-area-inset-bottom)), var(--fab-lift-nav, 0px));
 }
 
-/* Lift FAB when audio bar is visible */
-#audio-bar:not([hidden]) ~ #search-fab {
+/* Lift FAB when the sticky audio player is visible. The unavailable-state bar
+   sits inline at the end of content (position: static) and must not lift the FAB. */
+#audio-bar:not([hidden]):not(.unavailable) ~ #search-fab {
   bottom: max(calc(5rem + env(safe-area-inset-bottom)), var(--fab-lift-nav, 0px));
 }
 
@@ -2124,6 +2125,12 @@ mark.search-highlight {
 
 #audio-bar[hidden] {
   display: none;
+}
+
+/* "Audio file is being prepared" placeholder sits inline at the end of
+   content rather than sticking to the viewport bottom. */
+#audio-bar.unavailable {
+  position: static;
 }
 
 .audio-player {

--- a/js/app/views-routing.js
+++ b/js/app/views-routing.js
@@ -1613,6 +1613,7 @@ function _teardownAudio() {
 function hideAudioBar() {
   _teardownAudio();
   $audioBar.hidden = true;
+  $audioBar.classList.remove("unavailable");
   clearNode($audioBar);
 }
 
@@ -1763,8 +1764,8 @@ function showAudioPlayer(bookId, chapter) {
   }, { signal });
 
   $audioBar.appendChild(container);
+  $audioBar.classList.remove("unavailable");
   $audioBar.hidden = false;
-  $audioBar.style.position = "sticky";
 }
 
 function showAudioUnavailable() {
@@ -1773,8 +1774,8 @@ function showAudioUnavailable() {
   msg.appendChild(el("span", { className: "audio-unavailable-icon", "aria-hidden": "true" }));
   msg.appendChild(document.createTextNode(" 오디오 파일을 준비 중입니다."));
   $audioBar.appendChild(msg);
+  $audioBar.classList.add("unavailable");
   $audioBar.hidden = false;
-  $audioBar.style.position = "static";
 }
 // ── Window facade ──
 // Both an `appViewsRouting` aggregate and per-name globals so app.js's

--- a/js/app/views-routing.js
+++ b/js/app/views-routing.js
@@ -1613,7 +1613,6 @@ function _teardownAudio() {
 function hideAudioBar() {
   _teardownAudio();
   $audioBar.hidden = true;
-  $audioBar.classList.remove("unavailable");
   clearNode($audioBar);
 }
 
@@ -1764,7 +1763,6 @@ function showAudioPlayer(bookId, chapter) {
   }, { signal });
 
   $audioBar.appendChild(container);
-  $audioBar.classList.remove("unavailable");
   $audioBar.hidden = false;
 }
 
@@ -1774,7 +1772,6 @@ function showAudioUnavailable() {
   msg.appendChild(el("span", { className: "audio-unavailable-icon", "aria-hidden": "true" }));
   msg.appendChild(document.createTextNode(" 오디오 파일을 준비 중입니다."));
   $audioBar.appendChild(msg);
-  $audioBar.classList.add("unavailable");
   $audioBar.hidden = false;
 }
 // ── Window facade ──


### PR DESCRIPTION
## 문제

오디오 미제공 책(예: 토비트)에서 검색 FAB 가 sticky 오디오 플레이어가 있을 때처럼 5rem 위로 떠 있어, 하단에 빈 공간이 생기는 문제.

## 원인

`showAudioUnavailable()` 이 `#audio-bar.hidden = false` 로 두고 `position` 만 `static` 으로 바꿔 "오디오 파일을 준비 중입니다" 메시지를 본문 흐름 끝에 노출했다. 그러나 FAB lift 셀렉터 `#audio-bar:not([hidden]) ~ #search-fab` 는 hidden 만 확인하므로, sticky 영역이 비어 있는데도 FAB 는 5rem 위로 떠 빈 공간이 보였다.

## 수정

`#audio-bar` 를 항상 sticky 로 두고, 두 상태(`.audio-player` / `.audio-unavailable`) 가 같은 footprint 를 갖도록 안내 메시지에 `min-height` 를 부여한다. 이렇게 하면 FAB lift 셀렉터를 건드리지 않아도 두 상태에서 동일한 위치/크기로 정렬되고, 안내 메시지도 본문 끝이 아닌 sticky 영역에서 바로 보인다.

- `css/style.css` — `.audio-unavailable` 에 `min-height: 2.4rem` + `margin: 0` 적용 (재생 버튼 높이에 맞춤)
- `js/app/views-routing.js` — `showAudioPlayer()` / `showAudioUnavailable()` 에 있던 인라인 `$audioBar.style.position = ...` 제거 (`#audio-bar` 의 CSS `position: sticky` 만으로 충분)

> 검토 메모: 초기 시도(`.unavailable` 클래스로 `position: static` 분기)는 안내 메시지가 본문 끝까지 스크롤해야 보이는 UX 문제가 있어 폐기했다.

## 테스트

- `node --test tests/unit/views-routing.test.js` — 60/60 통과
- `npx tsc -p tsconfig.json --noEmit` — 0 error (deprecation 경고 제외)
- 브라우저 수동 확인 필요: 토비트 1장 (no audio) / 요한복음 5장 (audio 있음) FAB 위치 비교

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vey71L9AAk993wXZYxWnpg)_