### PR TITLE
style: 헤더 하단 라인 정렬을 위해 #app-header 하단 패딩 제거

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -146,7 +146,7 @@ body {
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
   border-bottom: none;
-  padding: calc(0.6rem + env(safe-area-inset-top)) 1rem 0.6rem;
+  padding: calc(0.6rem + env(safe-area-inset-top)) 1rem 0;
   max-width: var(--max-width);
   margin: 0 auto;
 }


### PR DESCRIPTION
## Summary

`#app-header`의 `::after` 디바이더 라인 아래에 0.6rem padding-bottom이 남아 있어 라인이 헤더 하단 가장자리와 맞붙지 않았습니다. 하단 패딩을 0으로 변경해 라인이 헤더 바닥에 정렬되도록 했습니다.

## Changes

- `css/style.css` — `#app-header` 패딩: `... 1rem 0.6rem` → `... 1rem 0`

## Test plan

- [ ] 챕터 화면에서 헤더 하단의 디바이더 라인이 헤더의 바닥 모서리에 정확히 붙는지 확인
- [ ] 본문 컨텐츠가 헤더 라인 바로 아래에서 시작되는지 확인
- [ ] iOS safe area inset이 적용된 환경에서 헤더 상단 여백이 그대로 유지되는지 확인
- [ ] 다크 모드에서도 라인이 동일하게 보이는지 확인

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eap2Bfcb8kANpGp45ZdBsL)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk visual-only CSS tweak; may slightly change header/content vertical spacing across breakpoints and safe-area devices.
> 
> **Overview**
> Removes `#app-header` bottom padding (sets it to `0`) so the `#app-header::after` divider line sits flush with the header’s bottom edge, tightening the vertical spacing below the header.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3363fa707919590d776ceb0054beb02c6310253. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->