### PR TITLE
style: 헤더 아래 그라데이션 높이 축소 (2rem → 0.5rem)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -146,7 +146,7 @@ body {
   left: 0;
   right: 0;
   top: 100%;
-  height: 2rem;
+  height: 0.667rem;
   background: linear-gradient(to bottom, var(--bg), transparent);
   pointer-events: none;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -146,7 +146,7 @@ body {
   left: 0;
   right: 0;
   top: 100%;
-  height: 0.667rem;
+  height: 0.5rem;
   background: linear-gradient(to bottom, var(--bg), transparent);
   pointer-events: none;
 }


### PR DESCRIPTION
## Summary
- `#sticky-group::after`의 페이드 그라데이션 높이를 `2rem` → `0.5rem`로 축소

## Test plan
- [ ] 헤더 아래 페이드 영역이 기존 대비 얇아진 것 시각 확인
- [ ] 스크롤 시 본문이 헤더 경계에서 자연스럽게 페이드되는지 확인
