### PR TITLE
style: 책 목록 화면에서 FAB가 박스 버튼 가리지 않도록 하단 여백 추가

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2635,6 +2635,11 @@ html.cite-sheet-open {
   .chapter-nav {
     margin-top: 4.5rem;
   }
+
+  /* Reserve space below the last book list so the FAB doesn't overlap buttons */
+  .division:last-child {
+    padding-bottom: calc(3.2rem + 2.5rem + env(safe-area-inset-bottom));
+  }
 }
 
 /* Desktop: hide FAB and bottom sheet */


### PR DESCRIPTION
## 변경 사항

홈·구약·신약·외경 책 목록 화면에서 끝까지 스크롤했을 때 우측 하단의 검색 FAB가 마지막 행의 책 버튼을 가리던 문제를 수정.

`.division:last-child`에 FAB 높이(3.2rem) + FAB의 하단 여백(1.5rem) + 추가 간격(1rem) + `env(safe-area-inset-bottom)` 만큼 `padding-bottom`을 추가. FAB이 노출되는 모바일(`max-width: 768px`)에만 적용.

## 영향 범위

- 홈 화면(`renderBookList`) — 마지막 division(보통 신약 또는 외경)
- 구약/신약/외경 화면(`renderDivisionList`) — 단일 division
- 데스크탑(>768px), 챕터/구절 뷰 영향 없음 (`.division` 미사용)

## 테스트 계획

- [ ] 모바일 뷰포트에서 홈 화면 끝까지 스크롤 → 마지막 책 버튼이 FAB에 가려지지 않음
- [ ] 신약 화면(스크린샷 기준)에서 끝까지 스크롤 → 요한의 둘째/셋째 편지가 FAB에 가려지지 않음
- [ ] 외경 분리/포함 설정 모두에서 검증
- [ ] 데스크탑(>768px)에서 시각적 변화 없음 (FAB이 숨겨지므로)


---
_Generated by [Claude Code](https://claude.ai/code/session_01SopAeLvC1h54c74Us8aJ9A)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk visual-only CSS tweak scoped to mobile book list layouts; main risk is unintended extra whitespace at the end of lists on small screens.
> 
> **Overview**
> Prevents the mobile search FAB from covering the last row of book buttons by adding extra bottom padding to `.division:last-child` under the `@media (max-width: 768px)` rules (including safe-area inset). Desktop behavior is unchanged since the FAB remains hidden there.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dce15ee5c3edd2966b2d2378f85994445300a54a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->