### PR TITLE
style: cite·search 바텀시트 UX 개선 (클리핑·헤더·확장 뷰·드래그·너비 통일)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2119,11 +2119,16 @@ body.cites-shown .note-anchor--variant:focus-visible {
   display: none;
 }
 
+/* Larger vertical padding gives a comfortable touch target (~24px tall)
+   around the visible 4px bar; touch-action:none keeps the gesture from
+   scrolling the page during a drag-resize. */
 #cite-sheet-handle {
   display: flex;
   justify-content: center;
-  padding: 0.5rem 0 0;
-  pointer-events: none;
+  align-items: center;
+  padding: 0.6rem 0;
+  cursor: ns-resize;
+  touch-action: none;
 }
 
 #cite-sheet-handle span {
@@ -2131,6 +2136,7 @@ body.cites-shown .note-anchor--variant:focus-visible {
   height: 4px;
   border-radius: 2px;
   background: var(--border);
+  pointer-events: none;
 }
 
 #cite-sheet-header {

--- a/css/style.css
+++ b/css/style.css
@@ -2092,15 +2092,22 @@ body.cites-shown .note-anchor--variant:focus-visible {
    main reading view (ADR-022 §6 — "본 앱 본문 렌더와 동일 양식 재사용"). */
 #cite-sheet {
   position: fixed;
-  bottom: 0.75rem;
-  left: 0.75rem;
-  right: 0.75rem;
+  /* Flush to the viewport bottom edge so devices with rounded display corners
+     (iPhone X+ ~39–62pt, recent Pixels ~26dp) mask the sheet's bottom corners
+     naturally — instead of a small bottom margin that lets the display curve
+     clip a visible rounded corner. Content stays above the home indicator via
+     padding-bottom: env(safe-area-inset-bottom). iOS native sheet pattern. */
+  bottom: 0;
+  left: 0;
+  right: 0;
   margin-inline: auto;
   max-width: var(--max-width);
   z-index: 60;
   background: var(--bg);
-  border-radius: 16px;
-  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.22);
+  /* Only the top corners are rounded; the bottom is hidden by the display
+     curve on mobile or by the viewport edge on desktop. */
+  border-radius: 16px 16px 0 0;
+  box-shadow: 0 -4px 24px rgba(0, 0, 0, 0.18);
   display: flex;
   flex-direction: column;
   height: 65vh;

--- a/css/style.css
+++ b/css/style.css
@@ -2188,13 +2188,6 @@ body.cites-shown .note-anchor--variant:focus-visible {
   color: var(--accent);
 }
 
-.cite-sheet-chapter-label {
-  margin: 0.6rem 0 0.3rem;
-  font-family: -apple-system, BlinkMacSystemFont, "Apple SD Gothic Neo", "Noto Sans KR", sans-serif;
-  font-size: 0.78rem;
-  color: var(--text-secondary);
-}
-
 /* Sheet body article: inherits body serif font + .chapter-text styles
    (line-height, poetry indent, verse-num) so cited passages match main view.
    Slight margin trim because the sheet is more compact than the main page. */

--- a/css/style.css
+++ b/css/style.css
@@ -2154,7 +2154,8 @@ body.cites-shown .note-anchor--variant:focus-visible {
   white-space: nowrap;
 }
 
-#cite-sheet-close {
+#cite-sheet-close,
+#cite-sheet-back {
   font-size: 1.4rem;
   line-height: 1;
   width: 2rem;
@@ -2166,8 +2167,14 @@ body.cites-shown .note-anchor--variant:focus-visible {
   border-radius: 6px;
 }
 
+#cite-sheet-back {
+  font-size: 1.8rem;
+}
+
 #cite-sheet-close:hover,
-#cite-sheet-close:focus-visible {
+#cite-sheet-close:focus-visible,
+#cite-sheet-back:hover,
+#cite-sheet-back:focus-visible {
   background: var(--border);
   color: var(--text);
   outline: none;
@@ -2180,12 +2187,45 @@ body.cites-shown .note-anchor--variant:focus-visible {
   color: var(--text);
 }
 
-.cite-sheet-ref-title {
+/* Ref header: flex row with title (truncating) + "더 보기" text button.
+   min-width:0 on the title lets text-overflow:ellipsis kick in instead of
+   overflowing and pushing the button out of view. */
+.cite-sheet-ref-header {
+  display: flex;
+  align-items: baseline;
+  gap: 0.6rem;
   margin: 0 0 0.5rem;
+}
+
+.cite-sheet-ref-title {
+  margin: 0;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   font-family: -apple-system, BlinkMacSystemFont, "Apple SD Gothic Neo", "Noto Sans KR", sans-serif;
   font-size: 0.85rem;
   font-weight: 600;
   color: var(--accent);
+}
+
+.cite-sheet-ref-expand {
+  flex-shrink: 0;
+  padding: 0.15rem 0.3rem;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font-family: -apple-system, BlinkMacSystemFont, "Apple SD Gothic Neo", "Noto Sans KR", sans-serif;
+  font-size: 0.82rem;
+  color: var(--accent);
+  border-radius: 4px;
+}
+
+.cite-sheet-ref-expand:hover,
+.cite-sheet-ref-expand:focus-visible {
+  background: var(--border);
+  outline: none;
 }
 
 /* Sheet body article: inherits body serif font + .chapter-text styles
@@ -2213,27 +2253,6 @@ body.cites-shown .note-anchor--variant:focus-visible {
   font-family: -apple-system, BlinkMacSystemFont, "Apple SD Gothic Neo", "Noto Sans KR", sans-serif;
   color: var(--text-secondary);
   font-size: 0.85rem;
-}
-
-.cite-sheet-expand-btn {
-  display: block;
-  width: 100%;
-  margin: 1.2rem 0 0.4rem;
-  padding: 0.7rem 1rem;
-  background: transparent;
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  cursor: pointer;
-  font-family: -apple-system, BlinkMacSystemFont, "Apple SD Gothic Neo", "Noto Sans KR", sans-serif;
-  font-size: 0.88rem;
-  color: var(--accent);
-  text-align: center;
-}
-
-.cite-sheet-expand-btn:hover,
-.cite-sheet-expand-btn:focus-visible {
-  background: var(--border);
-  outline: none;
 }
 
 /* ── First-use coachmark for cite chips ─────────────────────────────────── */

--- a/css/style.css
+++ b/css/style.css
@@ -1263,18 +1263,26 @@ body {
   font-family: -apple-system, BlinkMacSystemFont, "Apple SD Gothic Neo", "Noto Sans KR", sans-serif;
   display: none;
   position: fixed;
-  /* Float on all four sides — the same 12px breathing room compact already
-     uses, so expanded reads as a card, not a flush bottom sheet. */
-  bottom: 0.75rem;
-  left: 0.75rem;
-  right: 0.75rem;
+  /* Default (expanded, keyboard dismissed) = flush to viewport bottom edge,
+     same iOS-native pattern as #cite-sheet. The display's rounded corners
+     mask the sheet's bottom corners naturally; the compact-state rule below
+     restores floating margins for the keyboard-up state where a floating
+     card pairs better with the keyboard. */
+  bottom: 0;
+  left: 0;
+  right: 0;
+  /* Match #cite-sheet's desktop cap so the two bottom sheets render at the
+     same width on wide screens — otherwise expanded results stretch the
+     full viewport while cite content caps at 720px, an awkward mismatch. */
+  margin-inline: auto;
+  max-width: var(--max-width);
   z-index: 50;
   background: var(--bg);
   background-clip: padding-box;
-  /* All four corners rounded — both states float as cards with margins. */
-  border-radius: 16px;
-  /* Omnidirectional shadow suits the floating card on all four sides. */
-  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.18);
+  /* Only top corners rounded in expanded — display curve masks the bottom. */
+  border-radius: 16px 16px 0 0;
+  /* Upward-cast shadow for the bottom-attached expanded state. */
+  box-shadow: 0 -4px 24px rgba(0, 0, 0, 0.18);
   flex-direction: column;
   height: 55vh;
   max-height: 80vh;
@@ -1284,23 +1292,29 @@ body {
     bottom 220ms cubic-bezier(0.4, 0, 0.2, 1),
     left 220ms cubic-bezier(0.4, 0, 0.2, 1),
     right 220ms cubic-bezier(0.4, 0, 0.2, 1),
+    border-radius 220ms cubic-bezier(0.4, 0, 0.2, 1),
     box-shadow 220ms cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 /* Compact state: only input bar + chips visible, sized to sit above keyboard.
-   Fixed px so compact↔expanded `height` transition can interpolate.
-   left/right margins are inherited from the base rule (already 0.75rem); the
-   bottom is applied via JS in adjustSheetForKeyboard (keyboardOffset + 12). */
+   Restores the floating-card geometry — 12px breathing room on all sides,
+   fully rounded corners, omnidirectional shadow — because a card hovering
+   above the keyboard reads more naturally than an edge-to-edge sheet pinned
+   to its top. The bottom is overridden via JS in adjustSheetForKeyboard
+   (keyboardOffset + 12) when the keyboard is up. */
 #search-sheet[data-state="compact"] {
+  bottom: 0.75rem;
+  left: 0.75rem;
+  right: 0.75rem;
+  border-radius: 16px;
+  /* Omnidirectional shadow so the modal reads as a floating card. */
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.22);
   /* Add the safe-area inset so it doesn't eat the chip row. With
      box-sizing:border-box the base `padding-bottom: env(safe-area-inset-bottom)`
      subtracts from the fixed height, and on devices with a home indicator the
      value stays >0 even while the keyboard is up (it tracks the layout viewport,
      not the visual one). */
   height: calc(6.4rem + env(safe-area-inset-bottom));
-  /* Omnidirectional shadow so the modal reads as a floating card. The base
-     rule's negative-Y shadow only suits the bottom-attached expanded state. */
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.22);
 }
 
 /* The handle normally provides top breathing room above the input bar; add

--- a/index.html
+++ b/index.html
@@ -298,6 +298,7 @@
   <aside id="cite-sheet" role="dialog" aria-modal="true" aria-labelledby="cite-sheet-title" hidden>
     <div id="cite-sheet-handle" aria-hidden="true"><span></span></div>
     <header id="cite-sheet-header">
+      <button id="cite-sheet-back" type="button" aria-label="뒤로" hidden>&lsaquo;</button>
       <h2 id="cite-sheet-title"></h2>
       <button id="cite-sheet-close" type="button" aria-label="닫기">&times;</button>
     </header>

--- a/js/app/citations.js
+++ b/js/app/citations.js
@@ -786,6 +786,11 @@ window.appCitations = (() => {
     _sheetReturnFocus = returnFocusEl;
     _sheetState = { src, parallels: parallels || null, tradition: tradition || null, expandedRefIndex: null };
     titleEl.textContent = "인용된 구절";
+    // Reset any drag-resize from a previous open. The body stays interactive
+    // while the sheet is open (only a focus trap, no scrim) so cite chips
+    // visible in the unobscured portion can re-trigger openCiteSheet without
+    // a closeCiteSheet in between — the previous inline height would leak in.
+    sheet.style.height = "";
     sheet.hidden = false;
     document.documentElement.classList.add("cite-sheet-open");
     _updateSheetHeader();

--- a/js/app/citations.js
+++ b/js/app/citations.js
@@ -704,6 +704,45 @@ window.appCitations = (() => {
   }
 
   /**
+   * Drag-resize the sheet by its top handle. Mirrors the search-sheet /
+   * bookmark-drawer pattern (pointerdown → setPointerCapture → pointermove
+   * adjusts inline height → pointerup releases). Clamped to 30vh~90vh;
+   * dragging below 20vh snaps the sheet closed.
+   */
+  function _initSheetDrag() {
+    const handle = document.getElementById("cite-sheet-handle");
+    const sheet = /** @type {HTMLElement | null} */ (document.getElementById("cite-sheet"));
+    if (!handle || !sheet) return;
+    let startY = 0;
+    let startH = 0;
+    /** @param {number} clientY */
+    function onMove(clientY) {
+      const delta = startY - clientY;
+      const newH = Math.min(
+        Math.max(startH + delta, window.innerHeight * 0.30),
+        window.innerHeight * 0.90,
+      );
+      sheet.style.height = `${newH}px`;
+    }
+    /** @param {PointerEvent} e */
+    function onPointerMove(e) { onMove(e.clientY); }
+    function onPointerUp() {
+      handle.removeEventListener("pointermove", onPointerMove);
+      if (sheet.offsetHeight < window.innerHeight * 0.20) {
+        closeCiteSheet();
+      }
+    }
+    handle.addEventListener("pointerdown", (e) => {
+      e.preventDefault();
+      startY = e.clientY;
+      startH = sheet.offsetHeight;
+      handle.setPointerCapture(e.pointerId);
+      handle.addEventListener("pointermove", onPointerMove);
+      handle.addEventListener("pointerup", onPointerUp, { once: true });
+    });
+  }
+
+  /**
    * Open the cite sheet showing the cited passage(s). Primary src first, then
    * each parallel divided by a horizontal rule (ADR-022 §6).
    *
@@ -736,6 +775,9 @@ window.appCitations = (() => {
     const sheet = /** @type {HTMLElement | null} */ (document.getElementById("cite-sheet"));
     if (!sheet) return;
     sheet.hidden = true;
+    // Reset any drag-resize so the next open starts from the CSS default
+    // (65vh) rather than the user's previous resize.
+    sheet.style.height = "";
     document.documentElement.classList.remove("cite-sheet-open");
     if (_sheetTrapCleanup) { _sheetTrapCleanup(); _sheetTrapCleanup = null; }
     if (_sheetReturnFocus && typeof _sheetReturnFocus.focus === "function") {
@@ -745,7 +787,7 @@ window.appCitations = (() => {
     _sheetState = null;
   }
 
-  /** Wire up close button, back button, ESC key, and `.cite-chip` click delegation. */
+  /** Wire up close button, back button, drag handle, ESC key, and `.cite-chip` click delegation. */
   function initCiteSheet() {
     document.getElementById("cite-sheet-close")?.addEventListener("click", closeCiteSheet);
     document.getElementById("cite-sheet-back")?.addEventListener("click", () => {
@@ -754,6 +796,7 @@ window.appCitations = (() => {
       _updateSheetHeader();
       void _renderSheetBody();
     });
+    _initSheetDrag();
 
     document.addEventListener("keydown", (e) => {
       if (e.key === "Escape") {

--- a/js/app/citations.js
+++ b/js/app/citations.js
@@ -704,10 +704,33 @@ window.appCitations = (() => {
   }
 
   /**
+   * Decide what happens on drag-release given the current sheet height and
+   * the viewport innerHeight. Pure function so the threshold relationships
+   * stay testable — Cursor Bugbot caught a real regression where the close
+   * threshold (20vh) was unreachable because the move clamp held at 30vh;
+   * keeping this as a pure helper guards that invariant.
+   *
+   * Threshold semantics:
+   *   - h < 20vh  → close
+   *   - 20vh <= h < 30vh → snap back to the 30vh rest min
+   *   - h >= 30vh → stay where released
+   *
+   * @param {number} h    final sheet height in px (post-drag)
+   * @param {number} vh   viewport innerHeight in px
+   * @returns {"close" | "snap-min" | "stay"}
+   */
+  function _dragReleaseAction(h, vh) {
+    if (h < vh * 0.20) return "close";
+    if (h < vh * 0.30) return "snap-min";
+    return "stay";
+  }
+
+  /**
    * Drag-resize the sheet by its top handle. Mirrors the search-sheet /
    * bookmark-drawer pattern (pointerdown → setPointerCapture → pointermove
-   * adjusts inline height → pointerup releases). Clamped to 30vh~90vh;
-   * dragging below 20vh snaps the sheet closed.
+   * adjusts inline height → pointerup releases). Move clamp is loose (0 to
+   * 90vh) so the user can drag visually below the rest min; release decides
+   * close vs snap-back vs stay via `_dragReleaseAction`.
    */
   function _initSheetDrag() {
     const handle = document.getElementById("cite-sheet-handle");
@@ -718,11 +741,6 @@ window.appCitations = (() => {
     /** @param {number} clientY */
     function onMove(clientY) {
       const delta = startY - clientY;
-      // Lower bound is 0 (not 30vh) so the user can drag the sheet visually
-      // below its resting min — that drag is the affordance for the snap-
-      // close gesture. onPointerUp then decides: <20vh → close, 20vh~30vh →
-      // snap back to the resting min, ≥30vh → stay where released. With a
-      // hard 30vh clamp here the 20vh close threshold would be unreachable.
       const newH = Math.min(
         Math.max(startH + delta, 0),
         window.innerHeight * 0.90,
@@ -733,10 +751,10 @@ window.appCitations = (() => {
     function onPointerMove(e) { onMove(e.clientY); }
     function onPointerUp() {
       handle.removeEventListener("pointermove", onPointerMove);
-      const h = sheet.offsetHeight;
-      if (h < window.innerHeight * 0.20) {
+      const action = _dragReleaseAction(sheet.offsetHeight, window.innerHeight);
+      if (action === "close") {
         closeCiteSheet();
-      } else if (h < window.innerHeight * 0.30) {
+      } else if (action === "snap-min") {
         sheet.style.height = `${window.innerHeight * 0.30}px`;
       }
     }
@@ -926,6 +944,7 @@ window.appCitations = (() => {
 
   return {
     _computeCiteShowPositions,
+    _dragReleaseAction,
     chipText,
     buildCiteChip,
     wrapNoteAnchorsInArticle,

--- a/js/app/citations.js
+++ b/js/app/citations.js
@@ -359,7 +359,7 @@ window.appCitations = (() => {
   let _sheetReturnFocus = null;
   /** @type {(() => void) | null} */
   let _sheetTrapCleanup = null;
-  /** @type {{ src: string, parallels: ReadonlyArray<string> | null, tradition: string | null, expanded: boolean } | null} */
+  /** @type {{ src: string, parallels: ReadonlyArray<string> | null, tradition: string | null, expandedRefIndex: number | null } | null} */
   let _sheetState = null;
 
   const COACHMARK_KEY = "bible-cite-coachmark-seen";
@@ -575,8 +575,10 @@ window.appCitations = (() => {
    * @param {string} src
    * @param {string | null} tradition  null when not the primary reference
    * @param {boolean} expanded  true → render full chapters, mark cited verses
+   * @param {(() => void) | null} onExpand  click handler for the per-ref
+   *   "더 보기" button. Pass null in expanded mode (button is hidden).
    */
-  async function _renderRef(container, src, tradition, expanded) {
+  async function _renderRef(container, src, tradition, expanded, onExpand) {
     const parsed = _parseCiteSrc(src);
     if (!parsed) {
       container.appendChild(el("p", { className: "cite-sheet-error" },
@@ -591,7 +593,17 @@ window.appCitations = (() => {
       return;
     }
     const refTitle = (tradition ? `${tradition} ` : "") + src;
-    container.appendChild(el("h3", { className: "cite-sheet-ref-title" }, refTitle));
+    const headerEl = el("div", { className: "cite-sheet-ref-header" });
+    headerEl.appendChild(el("h3", { className: "cite-sheet-ref-title" }, refTitle));
+    if (onExpand) {
+      const expandBtn = el("button", {
+        type: "button",
+        className: "cite-sheet-ref-expand",
+      }, "› 더 보기");
+      expandBtn.addEventListener("click", onExpand);
+      headerEl.appendChild(expandBtn);
+    }
+    container.appendChild(headerEl);
 
     const chapters = new Set();
     for (const p of parsed.parts) {
@@ -625,8 +637,13 @@ window.appCitations = (() => {
   }
 
   /**
-   * Re-render the sheet body using the current `_sheetState`. Used after
-   * the user toggles expanded mode.
+   * Re-render the sheet body using the current `_sheetState`.
+   *
+   * When `expandedRefIndex === null` (default), all refs are rendered in
+   * compact slice mode with a "› 더 보기" button beside each header.
+   * When set to an index, only that ref is rendered with full chapters and
+   * the first cited verse is scrolled into the middle of the body so the
+   * user lands on the passage with its surrounding context already visible.
    */
   async function _renderSheetBody() {
     const bodyEl = /** @type {HTMLElement | null} */ (document.getElementById("cite-sheet-body"));
@@ -635,30 +652,55 @@ window.appCitations = (() => {
     bodyEl.appendChild(el("p", { className: "cite-sheet-loading" }, "불러오는 중…"));
     try {
       clearNode(bodyEl);
-      const { src, parallels, tradition, expanded } = _sheetState;
+      const { src, parallels, tradition, expandedRefIndex } = _sheetState;
       const refs = [src, ...(parallels || [])];
-      for (let i = 0; i < refs.length; i++) {
-        if (i > 0) bodyEl.appendChild(el("hr", { className: "cite-sheet-divider" }));
-        await _renderRef(bodyEl, refs[i], i === 0 ? tradition : null, expanded);
+      if (expandedRefIndex !== null) {
+        const idx = expandedRefIndex;
+        const refSrc = refs[idx];
+        const refTradition = idx === 0 ? tradition : null;
+        await _renderRef(bodyEl, refSrc, refTradition, true, null);
+        _scrollFirstHighlightIntoView(bodyEl);
+      } else {
+        for (let i = 0; i < refs.length; i++) {
+          if (i > 0) bodyEl.appendChild(el("hr", { className: "cite-sheet-divider" }));
+          const idx = i;
+          await _renderRef(bodyEl, refs[i], i === 0 ? tradition : null, false, () => {
+            if (!_sheetState) return;
+            _sheetState.expandedRefIndex = idx;
+            _updateSheetHeader();
+            void _renderSheetBody();
+          });
+        }
       }
-      if (!expanded) bodyEl.appendChild(_buildExpandButton());
     } catch (_) {
       clearNode(bodyEl);
       bodyEl.appendChild(el("p", { className: "cite-sheet-error" }, "불러오는 데 실패했습니다."));
     }
   }
 
-  function _buildExpandButton() {
-    const btn = el("button", {
-      type: "button",
-      className: "cite-sheet-expand-btn",
-    }, "이 장 전체 보기");
-    btn.addEventListener("click", async () => {
-      if (!_sheetState) return;
-      _sheetState.expanded = true;
-      await _renderSheetBody();
-    });
-    return btn;
+  /**
+   * Center the first cited verse in the sheet body so at least one verse
+   * before and after is visible as context (request: "인용된 절을 중심으로
+   * 1절, +1절에 포커스"). The body itself is the scroll container; the
+   * sheet shell does not scroll.
+   *
+   * @param {HTMLElement} bodyEl
+   */
+  function _scrollFirstHighlightIntoView(bodyEl) {
+    const first = bodyEl.querySelector(".verse-highlight");
+    if (first && typeof first.scrollIntoView === "function") {
+      first.scrollIntoView({ block: "center", behavior: "auto" });
+    }
+  }
+
+  /**
+   * Toggle the header back-button visibility based on whether the sheet is
+   * currently showing an expanded ref view.
+   */
+  function _updateSheetHeader() {
+    const backBtn = /** @type {HTMLElement | null} */ (document.getElementById("cite-sheet-back"));
+    if (!backBtn) return;
+    backBtn.hidden = !(_sheetState && _sheetState.expandedRefIndex !== null);
   }
 
   /**
@@ -677,10 +719,11 @@ window.appCitations = (() => {
     if (!sheet || !titleEl || !bodyEl) return;
 
     _sheetReturnFocus = returnFocusEl;
-    _sheetState = { src, parallels: parallels || null, tradition: tradition || null, expanded: false };
+    _sheetState = { src, parallels: parallels || null, tradition: tradition || null, expandedRefIndex: null };
     titleEl.textContent = "인용된 구절";
     sheet.hidden = false;
     document.documentElement.classList.add("cite-sheet-open");
+    _updateSheetHeader();
 
     const closeBtn = /** @type {HTMLElement | null} */ (document.getElementById("cite-sheet-close"));
     if (closeBtn) closeBtn.focus();
@@ -702,15 +745,30 @@ window.appCitations = (() => {
     _sheetState = null;
   }
 
-  /** Wire up close button, ESC key, and `.cite-chip` click delegation. */
+  /** Wire up close button, back button, ESC key, and `.cite-chip` click delegation. */
   function initCiteSheet() {
     document.getElementById("cite-sheet-close")?.addEventListener("click", closeCiteSheet);
+    document.getElementById("cite-sheet-back")?.addEventListener("click", () => {
+      if (!_sheetState || _sheetState.expandedRefIndex === null) return;
+      _sheetState.expandedRefIndex = null;
+      _updateSheetHeader();
+      void _renderSheetBody();
+    });
 
     document.addEventListener("keydown", (e) => {
       if (e.key === "Escape") {
         const sheet = document.getElementById("cite-sheet");
         if (sheet && !sheet.hidden) {
           e.stopPropagation();
+          // In expanded ref view, Esc steps back to the compact list first
+          // before closing — mirrors the visual nav stack the back button
+          // exposes.
+          if (_sheetState && _sheetState.expandedRefIndex !== null) {
+            _sheetState.expandedRefIndex = null;
+            _updateSheetHeader();
+            void _renderSheetBody();
+            return;
+          }
           closeCiteSheet();
           return;
         }

--- a/js/app/citations.js
+++ b/js/app/citations.js
@@ -80,8 +80,8 @@ window.appCitations = (() => {
    * @returns {string}
    */
   function chipText(src, parallels, tradition) {
-    const parts = [src];
-    if (tradition) parts.push(tradition);
+    const primary = (tradition ? `${tradition} ` : "") + src;
+    const parts = [primary];
     if (parallels && parallels.length) parts.push(...parallels);
     return `(${parts.join(" · ")})`;
   }

--- a/js/app/citations.js
+++ b/js/app/citations.js
@@ -464,15 +464,11 @@ window.appCitations = (() => {
    * mirror of views-routing.js's render loop minus those features.
    *
    * @param {HTMLElement} container
-   * @param {string} bookNameKo
-   * @param {number} chapter
    * @param {ReadonlyArray<BibleVerse>} verses
    * @param {Set<number> | null} [highlightedNumbers] verse numbers to mark as
    *   the originally-cited slice (full-chapter expanded view).
    */
-  function _renderVerses(container, bookNameKo, chapter, verses, highlightedNumbers) {
-    container.appendChild(el("div", { className: "cite-sheet-chapter-label" },
-      `${bookNameKo} ${chapter}장`));
+  function _renderVerses(container, verses, highlightedNumbers) {
     const article = el("article", { className: "chapter-text cite-sheet-article", lang: "ko" });
     let isFirst = true;
     let prevVerseEndType = null;
@@ -594,7 +590,7 @@ window.appCitations = (() => {
         `알 수 없는 책 약어: ${parsed.abbr}`));
       return;
     }
-    const refTitle = src + (tradition ? ` · ${tradition}` : "");
+    const refTitle = (tradition ? `${tradition} ` : "") + src;
     container.appendChild(el("h3", { className: "cite-sheet-ref-title" }, refTitle));
 
     const chapters = new Set();
@@ -616,10 +612,10 @@ window.appCitations = (() => {
         if (expanded) {
           // Show full chapter; highlight verses that were originally cited.
           const cited = new Set(_selectVerses(data.verses, parsed.parts, ch).map((v) => v.number));
-          _renderVerses(container, data.book_name_ko, ch, data.verses, cited);
+          _renderVerses(container, data.verses, cited);
         } else {
           const slice = _selectVerses(data.verses, parsed.parts, ch);
-          _renderVerses(container, data.book_name_ko, ch, slice, null);
+          _renderVerses(container, slice, null);
         }
       } catch (_) {
         container.appendChild(el("p", { className: "cite-sheet-error" },
@@ -682,7 +678,7 @@ window.appCitations = (() => {
 
     _sheetReturnFocus = returnFocusEl;
     _sheetState = { src, parallels: parallels || null, tradition: tradition || null, expanded: false };
-    titleEl.textContent = chipText(src, parallels, tradition).slice(1, -1);
+    titleEl.textContent = "인용된 구절";
     sheet.hidden = false;
     document.documentElement.classList.add("cite-sheet-open");
 

--- a/js/app/citations.js
+++ b/js/app/citations.js
@@ -718,8 +718,13 @@ window.appCitations = (() => {
     /** @param {number} clientY */
     function onMove(clientY) {
       const delta = startY - clientY;
+      // Lower bound is 0 (not 30vh) so the user can drag the sheet visually
+      // below its resting min — that drag is the affordance for the snap-
+      // close gesture. onPointerUp then decides: <20vh → close, 20vh~30vh →
+      // snap back to the resting min, ≥30vh → stay where released. With a
+      // hard 30vh clamp here the 20vh close threshold would be unreachable.
       const newH = Math.min(
-        Math.max(startH + delta, window.innerHeight * 0.30),
+        Math.max(startH + delta, 0),
         window.innerHeight * 0.90,
       );
       sheet.style.height = `${newH}px`;
@@ -728,8 +733,11 @@ window.appCitations = (() => {
     function onPointerMove(e) { onMove(e.clientY); }
     function onPointerUp() {
       handle.removeEventListener("pointermove", onPointerMove);
-      if (sheet.offsetHeight < window.innerHeight * 0.20) {
+      const h = sheet.offsetHeight;
+      if (h < window.innerHeight * 0.20) {
         closeCiteSheet();
+      } else if (h < window.innerHeight * 0.30) {
+        sheet.style.height = `${window.innerHeight * 0.30}px`;
       }
     }
     handle.addEventListener("pointerdown", (e) => {

--- a/js/types.d.ts
+++ b/js/types.d.ts
@@ -607,6 +607,7 @@ export interface AppStorage {
 
 export interface AppCitations {
   _computeCiteShowPositions: (verses: ReadonlyArray<BibleVerse>) => Set<string>;
+  _dragReleaseAction: (h: number, vh: number) => "close" | "snap-min" | "stay";
   chipText: (
     src: string,
     parallels: ReadonlyArray<string> | null | undefined,

--- a/tests/unit/citations.test.js
+++ b/tests/unit/citations.test.js
@@ -165,9 +165,9 @@ test("chipText: src only", () => {
   assert.equal(c.chipText("이사 53:5", null, null), "(이사 53:5)");
 });
 
-test("chipText: src + tradition", () => {
+test("chipText: src + tradition — tradition prefixed without separator", () => {
   const c = loadCitations();
-  assert.equal(c.chipText("이사 40:3", null, "칠십인역"), "(이사 40:3 · 칠십인역)");
+  assert.equal(c.chipText("이사 40:3", null, "칠십인역"), "(칠십인역 이사 40:3)");
 });
 
 test("chipText: src + parallels", () => {
@@ -178,11 +178,11 @@ test("chipText: src + parallels", () => {
   );
 });
 
-test("chipText: src + tradition + parallels — tradition before parallels", () => {
+test("chipText: src + tradition + parallels — tradition fused to primary, separator only between refs", () => {
   const c = loadCitations();
   assert.equal(
     c.chipText("이사 40:3", ["마르 1:3"], "칠십인역"),
-    "(이사 40:3 · 칠십인역 · 마르 1:3)",
+    "(칠십인역 이사 40:3 · 마르 1:3)",
   );
 });
 
@@ -218,7 +218,7 @@ test("buildCiteChip: poetry → cite-chip--poetry block class", () => {
   const node = c.buildCiteChip("이사 7:14", null, "칠십인역", "poetry");
   assert.equal(node.attrs.className, "cite-chip cite-chip--poetry");
   assert.equal(node.attrs["data-cite-tradition"], "칠십인역");
-  assert.equal(node.textContent, "(이사 7:14 · 칠십인역)");
+  assert.equal(node.textContent, "(칠십인역 이사 7:14)");
 });
 
 test("buildCiteChip: parallels stored as semicolon-joined data attr", () => {

--- a/tests/unit/citations.test.js
+++ b/tests/unit/citations.test.js
@@ -9,6 +9,7 @@
 // Sections (one per `// ── <area> ──`):
 //   - _computeCiteShowPositions (dedup)
 //   - chipText
+//   - _dragReleaseAction (drag-resize release thresholds)
 //   - buildCiteChip
 //   - buildNoteElement
 
@@ -197,6 +198,57 @@ test("chipText: multi-parallel", () => {
 test("chipText: empty parallels array treated as no parallels", () => {
   const c = loadCitations();
   assert.equal(c.chipText("이사 53:5", [], null), "(이사 53:5)");
+});
+
+// ── _dragReleaseAction (drag-resize release thresholds) ──────────────────────
+// Regression guard: Cursor Bugbot caught that an earlier draft clamped the
+// move handler to 30vh while checking close at <20vh, making snap-close
+// unreachable. These tests pin the three-tier semantics (close/snap-min/stay)
+// independently of the DOM/pointer plumbing.
+
+test("_dragReleaseAction: well below 20vh → close", () => {
+  const c = loadCitations();
+  assert.equal(c._dragReleaseAction(50, 1000), "close"); // 5vh
+});
+
+test("_dragReleaseAction: just below 20vh → close", () => {
+  const c = loadCitations();
+  assert.equal(c._dragReleaseAction(199, 1000), "close");
+});
+
+test("_dragReleaseAction: exactly at 20vh → snap-min (close is strict <)", () => {
+  const c = loadCitations();
+  assert.equal(c._dragReleaseAction(200, 1000), "snap-min");
+});
+
+test("_dragReleaseAction: between 20vh and 30vh → snap-min", () => {
+  const c = loadCitations();
+  assert.equal(c._dragReleaseAction(250, 1000), "snap-min");
+});
+
+test("_dragReleaseAction: just below 30vh → snap-min", () => {
+  const c = loadCitations();
+  assert.equal(c._dragReleaseAction(299, 1000), "snap-min");
+});
+
+test("_dragReleaseAction: exactly at 30vh → stay (snap-min is strict <)", () => {
+  const c = loadCitations();
+  assert.equal(c._dragReleaseAction(300, 1000), "stay");
+});
+
+test("_dragReleaseAction: well above 30vh → stay", () => {
+  const c = loadCitations();
+  assert.equal(c._dragReleaseAction(700, 1000), "stay");
+});
+
+test("_dragReleaseAction: thresholds scale with viewport height", () => {
+  const c = loadCitations();
+  // 100px height in an 800px viewport is 12.5vh → close
+  assert.equal(c._dragReleaseAction(100, 800), "close");
+  // 200px in 800px is 25vh → snap-min
+  assert.equal(c._dragReleaseAction(200, 800), "snap-min");
+  // 400px in 800px is 50vh → stay
+  assert.equal(c._dragReleaseAction(400, 800), "stay");
 });
 
 // ── buildCiteChip ────────────────────────────────────────────────────────────


### PR DESCRIPTION
cite (인용) + search (검색) 바텀시트의 시각·정보 구조를 정리하고, ref 별 확장 뷰 / 드래그 리사이즈 / 두 시트 간 너비 통일을 추가하는 6건의 커밋.

## 1. cite-sheet 디스플레이 곡률 클리핑 해결 (commit 1)

iPhone 17 (디스플레이 모서리 반지름 약 55~62pt) 에서 floating 시트 (`bottom/left/right: 0.75rem` + 사방 `border-radius: 16px`) 의 **하단 둥근 모서리** 가 디스플레이 곡선에 잘려 보이는 문제. 12px 바깥 마진은 iPhone 의 큰 곡률을 비껴갈 수 없음.

iOS 네이티브 시트 패턴 (Apple Maps, Safari Tab Group) 처럼 **edge-to-edge** 로 변경:

- `bottom/left/right: 0` — 시트가 뷰포트 하단 모서리에 밀착
- `border-radius: 16px 16px 0 0` — 상단 두 모서리만 둥글게
- `box-shadow: 0 -4px 24px rgba(0,0,0,0.18)` — 상방향 그림자
- `padding-bottom: env(safe-area-inset-bottom)` 그대로 유지 — 홈 인디케이터 영역 비킴
- `max-width: var(--max-width)` + `margin-inline: auto` 유지 — 데스크톱에서는 720px 중앙 정렬

디스플레이의 둥근 모서리가 시트 하단을 자연스럽게 마스킹하므로 기기별 곡률 차이 (iPhone X+ 39~62pt, recent Pixels ~26dp 등) 를 코드에서 신경 쓸 필요 없음.

## 2. cite-sheet 헤더·ref-title·chapter-label 정리 (commit 2)

- **시트 헤더 (`#cite-sheet-title`)**: 동적 장/절 문자열 → **"인용된 구절"** 고정. 헤더는 시트 정체성, 구체적 출처는 본문 ref-title 이 담당하도록 책임 분리.
- **본문 ref-title (`.cite-sheet-ref-title`)**: `"이사 7:14 · 칠십인역"` → `"칠십인역 이사 7:14"`. 구분점 (`·`) 없이 공백으로 연결해 한국어 관용 어순 ("칠십인역 ○○서 ○장 ○절") 에 맞춤.
- **chapter-label (`이사야 7장`) 제거**: ref-title 만으로 출처가 충분히 식별 가능하므로 중복 표기 제거. `_renderVerses` 의 `bookNameKo`/`chapter` 인자와 사용처 없는 CSS 규칙도 정리.

## 3. chip 텍스트의 tradition 어순 통일 (commit 3)

본문 인라인 chip 도 시트 ref-title 과 같은 어순으로 맞춤:
- 이전: `(이사 40:3 · 칠십인역 · 마르 1:3)` — tradition 이 parallels 와 같은 ` · ` 구분자를 공유해 인용 절처럼 보이는 시각적 혼선
- 이후: `(칠십인역 이사 40:3 · 마르 1:3)` — tradition 을 primary src 에 공백으로 fuse, 구분자는 인용 절 사이에서만 사용

`chipText` 함수 갱신 + 관련 유닛 테스트 어서션 3건 (`chipText` 2건 + `buildCiteChip` poetry 케이스 1건) 갱신.

## 4. cite-sheet — ref 별 "더 보기" 버튼 · 확장 뷰 · 뒤로가기 (commit 4)

- 단일 "이 장 전체 보기" 버튼 (시트 하단) 을 **ref 별 "› 더 보기" 텍스트 버튼** (각 헤더 옆) 으로 대체. 이전에는 버튼 한 개가 src + 모든 parallels 를 동시에 확장했는데, 이제 각 ref 를 독립적으로 확장할 수 있음.
  - 헤더는 flex 컨테이너 (`.cite-sheet-ref-header`) — 제목은 ellipsis, 버튼은 `flex-shrink: 0` 으로 긴 ref-title 에 가려지지 않음
- 확장 뷰는 선택된 ref 하나만 full chapter 로 렌더하고, 첫 `.verse-highlight` 를 `scrollIntoView({ block: "center" })` 로 본문 중앙에 위치시켜 **인용 절 앞/뒤 절이 컨텍스트로 보이게** 함
- 확장 뷰에서는 시트 헤더 좌측에 **뒤로가기 버튼 (`‹`)** 표시. 클릭 시 compact 뷰로 복귀. ESC 키도 단계적 처리 (확장 뷰면 먼저 compact 로, 한 번 더 누르면 시트 닫힘)
- 상태 모델: `expanded: boolean` → `expandedRefIndex: number | null`

## 5. cite-sheet — 핸들 드래그-리사이즈 (commit 5)

시트 상단 핸들이 시각적 어포던스만 있고 동작이 없었음. `search-sheet` / `bookmark-drawer` 와 동일한 pointer-capture 패턴으로 드래그-리사이즈 추가:

- 높이 범위: **30vh ~ 90vh**
  - max 90vh — 상단에 ~10vh 여백을 남겨 본문이 살짝 비치므로 "모달 위에 있음" 시각 단서 유지
  - min 30vh — 헤더 + 첫 절 정도가 보이는 최소 의미 있는 크기
- 닫기 임계: **<20vh** 까지 끌어내리면 스냅-닫기
- `closeCiteSheet` 에서 inline `style.height` 리셋 → 다음 open 은 CSS 기본 65vh 로 시작 (사용자 리사이즈가 다른 ref 시트로 누설되지 않게)
- 핸들 영역: `cursor: ns-resize` + `touch-action: none` + 패딩 0.6rem 으로 ~24px 터치 타깃 확보

## 6. search-sheet expanded 상태 edge-to-edge + cite-sheet 와 너비 통일 (commit 6)

검색 결과 시트 (`data-state="expanded"`, 키보드 dismissed) 도 동일한 iOS-native 패턴으로 전환. 결정 근거:
- 키보드가 사라진 결과 뷰는 "키보드 위 떠 있는 작은 카드" 가 아니라 "본문 위에 펼쳐진 콘텐츠 패널" 이라 edge-to-edge 가 더 자연스러움
- 결과 텍스트 가용 폭도 12px 만큼 확보됨

변경 사항:
- **base `#search-sheet`** = edge-to-edge (bottom/left/right 0, border-radius `16px 16px 0 0`, 상방향 그림자, `max-width: var(--max-width)` + `margin-inline: auto`)
- **`[data-state="compact"]`** = 기존 floating 카드 (0.75rem 마진 + 사방 border-radius + 옴니 그림자) — 키보드 up 상태는 그대로 보존
- compact ↔ expanded **부드러운 220ms morphing** — transition 목록에 `border-radius` 추가, `height/bottom/left/right/box-shadow` 는 기존부터 보간되어 있음. 결과적으로 키보드 dismiss 시 floating 카드가 edge-to-edge 시트로 자연스럽게 펼쳐짐
- cite-sheet 와 동일하게 데스크톱 720px 중앙 정렬되어 두 시트의 너비가 일치함

## 검토 대상 (별도 PR)

기존에 미적용된 search-sheet 의 keyboard-up 상태 (`compact`) 는 의도된 floating 디자인을 유지함 — 키보드 레이아웃과의 시각적 조화 때문.

## Test plan

### 자동
- [x] 유닛 테스트 529 케이스 통과 (`node --test tests/unit/*.test.js`)
- [x] TypeScript 타입 체크 통과 (`npx tsc -p tsconfig.json --noEmit`)

### 수동
#### cite-sheet
- [ ] iPhone 17 에서 cite chip 탭 → 시트 하단 모서리가 디스플레이 곡률에 잘리지 않는지 확인
- [ ] iPhone 13/14 (~39pt 곡률) 등 다른 iPhone 모델에서도 정상 표시 확인
- [ ] 홈 인디케이터 영역과 시트 하단 컨텐츠가 겹치지 않는지 확인
- [ ] 데스크톱 (>720px) 에서 시트가 720px 폭으로 중앙 정렬되어 표시되는지 확인
- [ ] 시트 헤더가 항상 "인용된 구절" 로 표시되는지 확인
- [ ] 본문 인라인 chip 이 `(칠십인역 이사 40:3 · 마르 1:3)` 형태로 표시되는지 확인
- [ ] 시트 본문 ref-title 이 `칠십인역 이사 7:14` 표시되는지 확인
- [ ] 각 ref 헤더 옆 "› 더 보기" 버튼이 보이는지 확인
- [ ] 긴 ref-title 에서 ellipsis 처리되고 "더 보기" 버튼이 가려지지 않는지 확인
- [ ] "더 보기" 클릭 시 그 ref 만 full chapter 로 표시되고, 인용 절이 시트 중앙에 위치하는지 확인
- [ ] 확장 뷰 헤더 좌측의 "‹" 뒤로가기 버튼 → compact 뷰로 복귀 확인
- [ ] ESC 키 동작 확인 (확장 뷰 → compact → 닫기 순서)
- [ ] parallels 가 있는 인용에서 각 parallel 도 독립적으로 "더 보기" 확장 가능한지 확인
- [ ] 핸들 드래그로 높이가 부드럽게 조절되는지 확인 (30vh~90vh)
- [ ] 핸들을 화면 아래로 충분히 끌어내리면 시트가 닫히는지 확인 (<20vh)
- [ ] 시트를 닫고 다시 열면 기본 65vh 로 초기화되는지 확인
- [ ] 데스크톱에서 핸들 위 마우스 커서가 ns-resize 모양으로 바뀌는지 확인

#### search-sheet
- [ ] FAB 탭 → compact 시트가 floating 카드로 표시되고 키보드 위에 떠 있는지 확인
- [ ] 검색 후 키보드 dismiss → compact → expanded 전환이 부드럽게 morphing 되는지 확인 (좌우 마진이 동시에 사라지면서 하단 모서리가 평탄해지는 220ms 애니메이션)
- [ ] iPhone 17 에서 expanded 시트의 하단 모서리가 디스플레이 곡률에 잘리지 않는지 확인
- [ ] 데스크톱 (>720px) 에서 expanded 시트가 720px 폭으로 중앙 정렬되어 cite-sheet 와 동일한 너비인지 확인
- [ ] expanded 상태에서 결과 텍스트가 좌우 12px 더 넓게 표시되는지 확인

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly presentation and cite-sheet client UX in `citations.js`/`style.css` with added unit tests; no auth, sync, or data-pipeline changes.
> 
> **Overview**
> **cite** and **search** mobile bottom sheets are reworked for iOS-style **edge-to-edge** layout when expanded (flush bottom, top-only `border-radius`, upward shadow, shared `max-width: var(--max-width)`), while **search** `data-state="compact"` keeps the floating card above the keyboard with **220ms** transitions between geometries.
> 
> The **cite sheet** gains clearer information hierarchy: fixed title **"인용된 구절"**, ref headers with per-reference **"› 더 보기"** (replacing one sheet-wide expand control), **back** + staged **Esc** navigation, expanded view that scrolls the first **`.verse-highlight`** to center, and **handle drag-resize** with close/snap/stay thresholds via **`_dragReleaseAction`** (unit-tested). Redundant **chapter labels** in the sheet body are removed.
> 
> **Inline cite chips** and sheet ref titles now prefix **tradition** onto the primary reference (e.g. `(칠십인역 이사 40:3 · …)`) instead of treating tradition as another `·`-separated ref.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 037c1480727890668dc84163a70ccd888a9d30b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->