### PR TITLE
fix: search-sheet/bookmark-drawer drag-close 도달 불가 + 공유 헬퍼화

### DIFF
--- a/js/app/bookmark.js
+++ b/js/app/bookmark.js
@@ -18,7 +18,7 @@
 /** @typedef {import("../types").DragState} DragState */
 /** @typedef {import("../types").BooksData} BooksData */
 
-const { _$, el, clearNode, chUnit, setInert, trapFocus } = window.appHelpers;
+const { _$, el, clearNode, chUnit, setInert, trapFocus, dragReleaseAction } = window.appHelpers;
 const { loadBookmarks, saveBookmarks, generateId } = window.appStorage;
 const { readingContext } = window;
 
@@ -2072,7 +2072,11 @@ function initBookmarkSheetDrag() {
 
   function onMove(clientY) {
     const delta = startY - clientY;
-    const newH = Math.min(Math.max(startH + delta, window.innerHeight * 0.3), window.innerHeight * 0.92);
+    // Lower bound is 0 (not 30vh) so the user can drag the drawer visually
+    // below its rest min — that's the affordance for the snap-close gesture.
+    // A hard 30vh clamp here would make dragReleaseAction's close branch
+    // unreachable (Cursor Bugbot caught this exact regression in cite-sheet).
+    const newH = Math.min(Math.max(startH + delta, 0), window.innerHeight * 0.92);
     drawer.style.height = `${newH}px`;
   }
 
@@ -2090,9 +2094,12 @@ function initBookmarkSheetDrag() {
   function onPointerMove(e) { onMove(e.clientY); }
   function onPointerUp() {
     handle.removeEventListener("pointermove", onPointerMove);
-    if (drawer.offsetHeight < window.innerHeight * 0.2) {
+    const action = dragReleaseAction(drawer.offsetHeight, window.innerHeight);
+    if (action === "close") {
       closeBookmarkDrawer();
       drawer.style.height = "";
+    } else if (action === "snap-min") {
+      drawer.style.height = `${window.innerHeight * 0.3}px`;
     }
   }
 }

--- a/js/app/citations.js
+++ b/js/app/citations.js
@@ -24,7 +24,7 @@ window.appCitations = (() => {
   /** @typedef {import("../types").BibleChapter} BibleChapter */
   /** @typedef {import("../types").BooksData} BooksData */
 
-  const { el, clearNode, trapFocus } = window.appHelpers;
+  const { el, clearNode, trapFocus, dragReleaseAction } = window.appHelpers;
 
   /**
    * For each `(verseIndex, segmentIndex)` whose segment has a `cite`, decide
@@ -704,33 +704,11 @@ window.appCitations = (() => {
   }
 
   /**
-   * Decide what happens on drag-release given the current sheet height and
-   * the viewport innerHeight. Pure function so the threshold relationships
-   * stay testable — Cursor Bugbot caught a real regression where the close
-   * threshold (20vh) was unreachable because the move clamp held at 30vh;
-   * keeping this as a pure helper guards that invariant.
-   *
-   * Threshold semantics:
-   *   - h < 20vh  → close
-   *   - 20vh <= h < 30vh → snap back to the 30vh rest min
-   *   - h >= 30vh → stay where released
-   *
-   * @param {number} h    final sheet height in px (post-drag)
-   * @param {number} vh   viewport innerHeight in px
-   * @returns {"close" | "snap-min" | "stay"}
-   */
-  function _dragReleaseAction(h, vh) {
-    if (h < vh * 0.20) return "close";
-    if (h < vh * 0.30) return "snap-min";
-    return "stay";
-  }
-
-  /**
    * Drag-resize the sheet by its top handle. Mirrors the search-sheet /
    * bookmark-drawer pattern (pointerdown → setPointerCapture → pointermove
    * adjusts inline height → pointerup releases). Move clamp is loose (0 to
    * 90vh) so the user can drag visually below the rest min; release decides
-   * close vs snap-back vs stay via `_dragReleaseAction`.
+   * close vs snap-back vs stay via `appHelpers.dragReleaseAction`.
    */
   function _initSheetDrag() {
     const handle = document.getElementById("cite-sheet-handle");
@@ -751,7 +729,7 @@ window.appCitations = (() => {
     function onPointerMove(e) { onMove(e.clientY); }
     function onPointerUp() {
       handle.removeEventListener("pointermove", onPointerMove);
-      const action = _dragReleaseAction(sheet.offsetHeight, window.innerHeight);
+      const action = dragReleaseAction(sheet.offsetHeight, window.innerHeight);
       if (action === "close") {
         closeCiteSheet();
       } else if (action === "snap-min") {
@@ -949,7 +927,6 @@ window.appCitations = (() => {
 
   return {
     _computeCiteShowPositions,
-    _dragReleaseAction,
     chipText,
     buildCiteChip,
     wrapNoteAnchorsInArticle,

--- a/js/app/helpers.js
+++ b/js/app/helpers.js
@@ -112,7 +112,35 @@ window.appHelpers = (() => {
     return () => container.removeEventListener("keydown", handler);
   }
 
-  return { _$, chUnit, el, clearNode, setInert, trapFocus };
+  /**
+   * Decide what should happen when a drag-resizable bottom sheet finishes
+   * a drag (pointerup). Pure function so the threshold semantics stay
+   * unit-testable independently of the DOM/pointer plumbing — Cursor Bugbot
+   * caught a regression where the move handler clamped at 30vh while
+   * onPointerUp checked close at 20vh, making snap-close unreachable. This
+   * helper pins the relationship between the three thresholds so the bug
+   * class can't reappear in any sheet.
+   *
+   * Threshold semantics (using viewport-height ratios):
+   *   - h < 20vh  → close
+   *   - 20vh ≤ h < 30vh → snap-min (animate back to the 30vh rest min)
+   *   - h ≥ 30vh → stay where released
+   *
+   * Callers' onMove handlers MUST allow the visual height to drop below the
+   * 30vh rest min (clamp at 0, not 30vh) — otherwise the close branch is
+   * structurally unreachable.
+   *
+   * @param {number} h    final sheet height in px (post-drag)
+   * @param {number} vh   viewport innerHeight in px
+   * @returns {"close" | "snap-min" | "stay"}
+   */
+  function dragReleaseAction(h, vh) {
+    if (h < vh * 0.20) return "close";
+    if (h < vh * 0.30) return "snap-min";
+    return "stay";
+  }
+
+  return { _$, chUnit, el, clearNode, setInert, trapFocus, dragReleaseAction };
 })();
 
 // ESM module marker (ADR-019). No runtime effect; signals TypeScript that

--- a/js/app/search.js
+++ b/js/app/search.js
@@ -12,7 +12,7 @@
 
 /** @typedef {import("../types").SearchHistoryList} SearchHistoryList */
 
-const { _$, el, clearNode, chUnit } = window.appHelpers;
+const { _$, el, clearNode, chUnit, dragReleaseAction } = window.appHelpers;
 const {
   SEARCH_HISTORY_MAX,
   loadSearchHistory, pushSearchHistory, removeSearchHistory, clearSearchHistory,
@@ -1027,7 +1027,11 @@ function initSheetDrag() {
   /** @param {number} clientY */
   function onMove(clientY) {
     const delta = startY - clientY;
-    const newH = Math.min(Math.max(startH + delta, window.innerHeight * 0.3), window.innerHeight * 0.9);
+    // Lower bound is 0 (not 30vh) so the user can drag the sheet visually
+    // below its rest min — that's the affordance for the snap-close gesture.
+    // A hard 30vh clamp here would make dragReleaseAction's close branch
+    // unreachable (Cursor Bugbot caught this exact regression in cite-sheet).
+    const newH = Math.min(Math.max(startH + delta, 0), window.innerHeight * 0.9);
     $searchSheet.style.height = `${newH}px`;
   }
 
@@ -1044,10 +1048,12 @@ function initSheetDrag() {
   function onPointerMove(e) { onMove(e.clientY); }
   function onPointerUp() {
     handle.removeEventListener("pointermove", onPointerMove);
-    // Snap close if dragged very low
-    if ($searchSheet.offsetHeight < window.innerHeight * 0.2) {
+    const action = dragReleaseAction($searchSheet.offsetHeight, window.innerHeight);
+    if (action === "close") {
       closeSearchSheet();
       $searchSheet.style.height = "";
+    } else if (action === "snap-min") {
+      $searchSheet.style.height = `${window.innerHeight * 0.3}px`;
     }
   }
 }

--- a/js/types.d.ts
+++ b/js/types.d.ts
@@ -531,6 +531,7 @@ export interface AppHelpers {
   clearNode: (node: Node) => void;
   setInert: (on: boolean, selectors: string) => void;
   trapFocus: (container: HTMLElement) => () => void;
+  dragReleaseAction: (h: number, vh: number) => "close" | "snap-min" | "stay";
 }
 
 // ── App storage facade (js/app/storage.js) ──────────────────────────────────
@@ -607,7 +608,6 @@ export interface AppStorage {
 
 export interface AppCitations {
   _computeCiteShowPositions: (verses: ReadonlyArray<BibleVerse>) => Set<string>;
-  _dragReleaseAction: (h: number, vh: number) => "close" | "snap-min" | "stay";
   chipText: (
     src: string,
     parallels: ReadonlyArray<string> | null | undefined,

--- a/tests/unit/citations.test.js
+++ b/tests/unit/citations.test.js
@@ -9,7 +9,6 @@
 // Sections (one per `// ── <area> ──`):
 //   - _computeCiteShowPositions (dedup)
 //   - chipText
-//   - _dragReleaseAction (drag-resize release thresholds)
 //   - buildCiteChip
 //   - buildNoteElement
 
@@ -198,57 +197,6 @@ test("chipText: multi-parallel", () => {
 test("chipText: empty parallels array treated as no parallels", () => {
   const c = loadCitations();
   assert.equal(c.chipText("이사 53:5", [], null), "(이사 53:5)");
-});
-
-// ── _dragReleaseAction (drag-resize release thresholds) ──────────────────────
-// Regression guard: Cursor Bugbot caught that an earlier draft clamped the
-// move handler to 30vh while checking close at <20vh, making snap-close
-// unreachable. These tests pin the three-tier semantics (close/snap-min/stay)
-// independently of the DOM/pointer plumbing.
-
-test("_dragReleaseAction: well below 20vh → close", () => {
-  const c = loadCitations();
-  assert.equal(c._dragReleaseAction(50, 1000), "close"); // 5vh
-});
-
-test("_dragReleaseAction: just below 20vh → close", () => {
-  const c = loadCitations();
-  assert.equal(c._dragReleaseAction(199, 1000), "close");
-});
-
-test("_dragReleaseAction: exactly at 20vh → snap-min (close is strict <)", () => {
-  const c = loadCitations();
-  assert.equal(c._dragReleaseAction(200, 1000), "snap-min");
-});
-
-test("_dragReleaseAction: between 20vh and 30vh → snap-min", () => {
-  const c = loadCitations();
-  assert.equal(c._dragReleaseAction(250, 1000), "snap-min");
-});
-
-test("_dragReleaseAction: just below 30vh → snap-min", () => {
-  const c = loadCitations();
-  assert.equal(c._dragReleaseAction(299, 1000), "snap-min");
-});
-
-test("_dragReleaseAction: exactly at 30vh → stay (snap-min is strict <)", () => {
-  const c = loadCitations();
-  assert.equal(c._dragReleaseAction(300, 1000), "stay");
-});
-
-test("_dragReleaseAction: well above 30vh → stay", () => {
-  const c = loadCitations();
-  assert.equal(c._dragReleaseAction(700, 1000), "stay");
-});
-
-test("_dragReleaseAction: thresholds scale with viewport height", () => {
-  const c = loadCitations();
-  // 100px height in an 800px viewport is 12.5vh → close
-  assert.equal(c._dragReleaseAction(100, 800), "close");
-  // 200px in 800px is 25vh → snap-min
-  assert.equal(c._dragReleaseAction(200, 800), "snap-min");
-  // 400px in 800px is 50vh → stay
-  assert.equal(c._dragReleaseAction(400, 800), "stay");
 });
 
 // ── buildCiteChip ────────────────────────────────────────────────────────────

--- a/tests/unit/helpers.test.js
+++ b/tests/unit/helpers.test.js
@@ -14,6 +14,7 @@
 //   - clearNode (firstChild loop)
 //   - setInert (inert + aria-hidden toggle on selector matches)
 //   - trapFocus (Tab / Shift-Tab cycling within a container)
+//   - dragReleaseAction (bottom-sheet drag-resize release thresholds)
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
@@ -563,4 +564,57 @@ test("trapFocus: includes elements with explicit tabindex (not -1)", () => {
   // div has tabindex=0 — first focusable; btn was last → wraps to div
   assert.equal(e._prevented, true);
   assert.equal(h.dom.getActive(), div);
+});
+
+// ── dragReleaseAction ───────────────────────────────────────────────────────
+// Three-tier release semantics for any drag-resizable bottom sheet.
+// Regression guard: Cursor Bugbot caught that an earlier cite-sheet draft
+// clamped the move handler at 30vh while checking close at <20vh, making
+// snap-close unreachable. Pinning this as a pure helper means the same
+// bug class can't reappear in search-sheet, bookmark-drawer, or any future
+// sheet that reuses this decision.
+
+test("dragReleaseAction: well below 20vh → close", () => {
+  const h = loadHelpers();
+  assert.equal(h.helpers.dragReleaseAction(50, 1000), "close"); // 5vh
+});
+
+test("dragReleaseAction: just below 20vh → close", () => {
+  const h = loadHelpers();
+  assert.equal(h.helpers.dragReleaseAction(199, 1000), "close");
+});
+
+test("dragReleaseAction: exactly at 20vh → snap-min (close is strict <)", () => {
+  const h = loadHelpers();
+  assert.equal(h.helpers.dragReleaseAction(200, 1000), "snap-min");
+});
+
+test("dragReleaseAction: between 20vh and 30vh → snap-min", () => {
+  const h = loadHelpers();
+  assert.equal(h.helpers.dragReleaseAction(250, 1000), "snap-min");
+});
+
+test("dragReleaseAction: just below 30vh → snap-min", () => {
+  const h = loadHelpers();
+  assert.equal(h.helpers.dragReleaseAction(299, 1000), "snap-min");
+});
+
+test("dragReleaseAction: exactly at 30vh → stay (snap-min is strict <)", () => {
+  const h = loadHelpers();
+  assert.equal(h.helpers.dragReleaseAction(300, 1000), "stay");
+});
+
+test("dragReleaseAction: well above 30vh → stay", () => {
+  const h = loadHelpers();
+  assert.equal(h.helpers.dragReleaseAction(700, 1000), "stay");
+});
+
+test("dragReleaseAction: thresholds scale with viewport height", () => {
+  const h = loadHelpers();
+  // 100px in an 800px viewport is 12.5vh → close
+  assert.equal(h.helpers.dragReleaseAction(100, 800), "close");
+  // 200px in 800px is 25vh → snap-min
+  assert.equal(h.helpers.dragReleaseAction(200, 800), "snap-min");
+  // 400px in 800px is 50vh → stay
+  assert.equal(h.helpers.dragReleaseAction(400, 800), "stay");
 });


### PR DESCRIPTION
PR #138 에서 cite-sheet 에 적용한 drag-close 수정과 동일한 버그가 `search-sheet` 와 `bookmark-drawer` 에도 사전 존재해 후속 정리.

## 문제

세 시트(`#cite-sheet`, `#search-sheet`, `#bookmark-drawer`)가 동일한 drag-resize 패턴을 공유하는데, `onMove` 가 height 를 **30vh 로 하한 clamp** 하면서 `onPointerUp` 은 height **< 20vh** 일 때만 close 를 호출. 30vh 미만으로 시각적으로 내려갈 수 없으니 20vh 임계가 영원히 도달 불가 → **drag-close 가 동작하지 않음**.

Cursor Bugbot 이 PR #138 에서 cite-sheet 한정으로 발견했고, 같은 클래스의 버그가 두 곳에 남아 있어서 본 PR 로 정리.

## 변경

### `appHelpers.dragReleaseAction(h, vh)` — 새 공유 헬퍼

세 모듈이 똑같은 3-단계 분기 로직을 공유하므로 `appHelpers` 에 추출:

```js
function dragReleaseAction(h, vh) {
  if (h < vh * 0.20) return "close";
  if (h < vh * 0.30) return "snap-min";
  return "stay";
}
```

회귀 가드를 한 곳에서 관리 — 같은 임계 버그가 미래 시트에서 재발하는 것을 구조적으로 방지.

### 세 모듈의 변경

| 모듈 | 변경 |
|---|---|
| `js/app/citations.js` | 내부 `_dragReleaseAction` 제거 → `appHelpers.dragReleaseAction` 위임 |
| `js/app/search.js` | onMove 하한 0 으로, onPointerUp 에서 헬퍼 사용 + snap-back 분기 추가 |
| `js/app/bookmark.js` | onMove 하한 0 으로, onPointerUp 에서 헬퍼 사용 + snap-back 분기 추가 |

세 모듈 모두 `onMove` 의 하한을 **0** 으로 (시각적 drag 가 rest min 미만으로 내려가야 close 분기에 도달). `onPointerUp` 은 헬퍼 반환값으로 분기:
- `"close"` → 시트 닫기 + 인라인 height 리셋
- `"snap-min"` → 30vh 로 스냅 복귀
- `"stay"` → 그대로 둠

### 테스트

`_dragReleaseAction` 테스트 8건을 `citations.test.js` → `helpers.test.js` 로 이전. 동일 임계 회귀를 한 곳에서 보호.

## Test plan

### 자동
- [x] 유닛 테스트 537 케이스 통과 (`node --test tests/unit/*.test.js`)
- [x] TypeScript 타입 체크 통과 (`npx tsc -p tsconfig.json --noEmit`)

### 수동
- [ ] FAB 로 검색 시트 열고 결과 표시 후 핸들로 화면 아래로 충분히 끌어내려 시트가 닫히는지 확인
- [ ] 검색 시트 핸들 드래그 → 20vh~30vh 사이에서 release 시 30vh 로 부드럽게 스냅 복귀하는지 확인
- [ ] 북마크 드로어 열고(모바일에서만 동작) 핸들 드래그 → 동일한 동작 확인
- [ ] 데스크톱(>=769px)에서 북마크 드로어 핸들이 드래그 영향 없는지 확인 (window.innerWidth 가드)
- [ ] cite 시트 핸들 드래그가 PR #138 머지 후와 동일하게 동작하는지 회귀 확인

---
_Generated by [Claude Code](https://claude.ai/code/session_01SThL2VdLYe3vRNZ7WLWjcC)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mobile UI gesture fixes and a pure helper refactor with unit test coverage; no auth, sync, or data-path changes.
> 
> **Overview**
> **Fixes drag-to-close on the search sheet and bookmark drawer** and **centralizes release logic** so cite, search, and bookmark sheets behave the same.
> 
> Previously, `onMove` clamped height at **30vh** while release only closed below **20vh**, so users could never drag low enough to dismiss. **Search** and **bookmark** now allow height down to **0** during drag and use shared `appHelpers.dragReleaseAction` on release: **close** (&lt;20vh), **snap back to 30vh** (20–30vh), or **stay**. **Citations** drops its local `_dragReleaseAction` and calls the same helper; threshold tests move to `helpers.test.js`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd1c101b991af7c5f88753765d1dfdc63af794bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->