### PR TITLE
fix: 검색어 X 버튼을 누르면 sheet 를 compact 모드로 전환

### DIFF
--- a/js/app/search.js
+++ b/js/app/search.js
@@ -973,13 +973,7 @@ $searchSheetInput.addEventListener("input", () => {
 // transitioned (not snapped) so any estimate mismatch glides into place.
 // adjustSheetForKeyboard is suspended throughout so its `transition: none`
 // snap doesn't interrupt the choreography; tracking resumes afterwards.
-// Set true around programmatic .focus() calls (e.g. after clear button) so
-// the focus-driven expanded→compact transition only fires for real user taps,
-// not for code that just refocuses the input as a courtesy.
-let _suppressFocusCompactTransition = false;
-
 $searchSheetInput.addEventListener("focus", () => {
-  if (_suppressFocusCompactTransition) return;
   if ($searchSheet.dataset.state !== "expanded") return;
   _suspendKeyboardAdjust = true;
   $searchSheet.style.transition = "";
@@ -1009,11 +1003,10 @@ $searchSheetClear.addEventListener("click", () => {
   $searchSheetInput.value = "";
   $searchSheetClear.hidden = true;
   $searchSheetInputWrap.dataset.clearHidden = "true";
-  // Refocus so the keyboard stays up, but do not collapse the sheet to compact
-  // — the user wants to keep seeing previous results while typing a refinement.
-  _suppressFocusCompactTransition = true;
+  // Refocus the input; the focus handler then collapses the sheet to compact
+  // so the user sees a clean input + keyboard instead of stale results sitting
+  // awkwardly under an empty field.
   $searchSheetInput.focus();
-  _suppressFocusCompactTransition = false;
 });
 
 // Drag-handle initializer — registered later in app.js's deferred startup


### PR DESCRIPTION
## 요약

검색 sheet 에서 키워드 X 버튼을 누르면 sheet 가 compact 모드(입력창 + 키보드)로 전환되도록 수정.

기존에는 X 를 눌러도 expanded 상태가 유지되어, 빈 입력창 아래 이전 검색 결과가 남는 어색한 상태가 발생했다 (스크린샷 참고). clear 핸들러에서 focus 전환을 억제하던 `_suppressFocusCompactTransition` 플래그를 제거하고, 기존 focus 핸들러가 자연스럽게 compact 전환(결과 비우기 + 키보드 띄우기)을 수행하도록 위임한다.

플래그는 clear 핸들러 외 사용처가 없어 선언과 focus 핸들러의 early-return 가드도 함께 삭제.

## 변경 사항

- `js/app/search.js:1002-1009` clear 핸들러에서 `_suppressFocusCompactTransition` 토글 제거
- `js/app/search.js:976-982` 사용되지 않는 플래그 선언 + 가드 코드 제거

## 테스트

- [x] `node --test tests/unit/*.test.js` — 537 케이스 통과
- [ ] 모바일에서 검색 sheet 를 expanded 상태로 열고 X 버튼 탭 → compact 모드로 전환되며 키보드가 올라오는지 확인

https://claude.ai/code/session_01SQbo8gJ3RV6zUzvydyUiqr

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQbo8gJ3RV6zUzvydyUiqr)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-file mobile search UI behavior change with no auth, data, or API impact.
> 
> **Overview**
> **Mobile search sheet clear (✕)** no longer blocks the expanded→compact transition. The `_suppressFocusCompactTransition` guard around programmatic `focus()` is removed entirely.
> 
> Tapping **✕** now clears the field, refocuses the input, and the existing **focus** handler collapses the sheet to **compact** (clears stale results, keyboard + input) instead of leaving **expanded** with an empty query and old results visible underneath.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ec941748dd979b75eaf3b35f865f2463a3b6bde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->