### PR TITLE
style: cite 시트 뒤로 버튼을 헤더 뒤로 버튼과 동일한 스타일로 통일

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2174,8 +2174,7 @@ body.cites-shown .note-anchor--variant:focus-visible {
   white-space: nowrap;
 }
 
-#cite-sheet-close,
-#cite-sheet-back {
+#cite-sheet-close {
   font-size: 1.4rem;
   line-height: 1;
   width: 2rem;
@@ -2187,16 +2186,33 @@ body.cites-shown .note-anchor--variant:focus-visible {
   border-radius: 6px;
 }
 
-#cite-sheet-back {
-  font-size: 1.8rem;
-}
-
 #cite-sheet-close:hover,
-#cite-sheet-close:focus-visible,
-#cite-sheet-back:hover,
-#cite-sheet-back:focus-visible {
+#cite-sheet-close:focus-visible {
   background: var(--border);
   color: var(--text);
+  outline: none;
+}
+
+/* Sheet back button mirrors `.title-back-btn` in the main app header. */
+#cite-sheet-back {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.2rem;
+  height: 2.2rem;
+  padding: 0;
+  color: var(--accent);
+  background: none;
+  border: none;
+  cursor: pointer;
+  transition: opacity 0.15s;
+}
+
+#cite-sheet-back:active {
+  opacity: 0.4;
+}
+
+#cite-sheet-back:focus-visible {
   outline: none;
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -2212,10 +2212,6 @@ body.cites-shown .note-anchor--variant:focus-visible {
   opacity: 0.4;
 }
 
-#cite-sheet-back:focus-visible {
-  outline: none;
-}
-
 #cite-sheet-body {
   flex: 1;
   overflow-y: auto;

--- a/index.html
+++ b/index.html
@@ -298,7 +298,7 @@
   <aside id="cite-sheet" role="dialog" aria-modal="true" aria-labelledby="cite-sheet-title" hidden>
     <div id="cite-sheet-handle" aria-hidden="true"><span></span></div>
     <header id="cite-sheet-header">
-      <button id="cite-sheet-back" type="button" aria-label="뒤로" hidden>&lsaquo;</button>
+      <button id="cite-sheet-back" type="button" aria-label="뒤로" hidden><svg class="title-back-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M15.5 5 8.5 12l7 7" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/></svg></button>
       <h2 id="cite-sheet-title"></h2>
       <button id="cite-sheet-close" type="button" aria-label="닫기">&times;</button>
     </header>


### PR DESCRIPTION
## 요약

cite 시트(`#cite-sheet`) 헤더의 뒤로 버튼이 시각적으로 메인 앱 헤더의 뒤로 버튼과 달라 보였던 문제를 해결.
헤더 버튼(`.title-back-btn`)을 기준으로 cite 시트의 `#cite-sheet-back` 을 동일한 스타일로 맞춤.

## 변경 사항

- `index.html` — `#cite-sheet-back` 내용을 `&lsaquo;` 문자에서 헤더와 동일한 SVG 셰브런(`M15.5 5 8.5 12l7 7`)으로 교체
- `css/style.css` — `#cite-sheet-close` 와 공유되던 규칙을 분리:
  - `#cite-sheet-back`: 2.2rem × 2.2rem, `color: var(--accent)`, `background: none`, `:active { opacity: 0.4 }` — 헤더 뒤로 버튼과 동일
  - `#cite-sheet-close`: 기존 스타일(2rem × 2rem, `--text-secondary`, hover 배경) 그대로 유지

## 테스트 계획

- [x] `node --test tests/unit/citations.test.js` (18/18 pass)
- [ ] 로컬에서 cite 시트를 열고 ref 펼친 상태에서 뒤로 버튼이 헤더 뒤로 버튼과 동일하게 보이는지 육안 확인
- [ ] iOS Safari 다크 모드에서 `--accent` 색상이 적절한지 확인

---
_Generated by [Claude Code](https://claude.ai/code/session_01EqJwEsbE1kqycxEu6DB8mR)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS and static markup only; no auth, data, or cite-sheet logic changes.
> 
> **Overview**
> The cite sheet header **back** control is aligned with the main app header back button so both look and behave the same.
> 
> In **`index.html`**, `#cite-sheet-back` no longer uses the `‹` character; it uses the same chevron **SVG** and `title-back-icon` class as the chapter title back control. In **`css/style.css`**, shared rules for close and back are split: **`#cite-sheet-close`** keeps its smaller secondary-style close button, while **`#cite-sheet-back`** gets dedicated rules (2.2rem hit target, `var(--accent)`, no hover fill, `:active` opacity) matching **`.title-back-btn`**.
> 
> No JavaScript or citation behavior changes—presentation only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c40ca10471e42052d6ef874a2a30dc6d0c646d45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->