### PR TITLE
설정 패널 외경/인용 표시 순서 재배치

### DIFF
--- a/js/app/settings-ui.js
+++ b/js/app/settings-ui.js
@@ -321,8 +321,8 @@ window.appSettings = (() => {
       citeRow.appendChild(citeGroup);
 
       section1.appendChild(startupRow);
-      section1.appendChild(citeRow);
       section1.appendChild(orderRow);
+      section1.appendChild(citeRow);
       popover.appendChild(section1);
 
       // ── Section 2: Typography & appearance ──


### PR DESCRIPTION
## Summary
- 설정 패널 Section 1 의 행 순서를 `시작 화면 → 외경 → 인용 본문·주석 표시` 로 변경
- 기존 `시작 화면 → 인용 본문·주석 표시 → 외경` 에서 외경을 시작 화면 바로 아래로 이동하고 인용 행과 자리를 교환

## Test plan
- [ ] 설정 톱니바퀴를 열어 Section 1 행 순서가 `시작 화면 / 외경 / 인용 본문·주석 표시` 인지 확인
- [ ] 각 행의 토글 동작(외경 분리/포함, 인용 표시/숨김, 시작 화면) 회귀 없는지 확인

https://claude.ai/code/session_01EoHmnq943KKvdiDCiGnuyV

---
_Generated by [Claude Code](https://claude.ai/code/session_01EoHmnq943KKvdiDCiGnuyV)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only reorder in the settings popover; no behavior or data changes.
> 
> **Overview**
> Section 1 of the settings popover now lists rows as **시작 화면 → 외경 → 인용 본문·주석 표시** instead of placing **인용** before **외경**.
> 
> The change is only the `appendChild` order in `settings-ui.js` when `rebuild()` builds Section 1; labels, handlers, and persistence are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da7328c0a2bc437510520cd0b9441b002c9f65d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->