### PR TITLE
fix: 인용 시트 뒤로 가기 버튼이 평소에 노출되던 문제 수정

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2212,6 +2212,13 @@ body.cites-shown .note-anchor--variant:focus-visible {
   opacity: 0.4;
 }
 
+/* Explicit [hidden] rule — the ID selector above sets `display: flex` which
+   beats the user-agent's `[hidden] { display: none }` on specificity, so
+   _updateSheetHeader()'s `backBtn.hidden = …` would otherwise have no effect. */
+#cite-sheet-back[hidden] {
+  display: none;
+}
+
 #cite-sheet-body {
   flex: 1;
   overflow-y: auto;


### PR DESCRIPTION
## 요약

인용된 구절 시트(`#cite-sheet`)의 헤더 뒤로 가기 버튼이 시트를 처음 열었을 때부터 항상 노출되던 문제를 수정.

## 원인

`js/app/citations.js` 의 `_updateSheetHeader()` 가 `_sheetState.expandedRefIndex` 에 따라 `backBtn.hidden` 을 토글하고 있었지만, CSS 의 `#cite-sheet-back { display: flex }` (ID 선택자, 명시성 0,1,0,0) 가 user-agent 의 `[hidden] { display: none }` (속성 선택자, 명시성 0,0,1,0) 을 이겨서 버튼이 항상 보였음.

## 변경

`css/style.css` 에 명시적 override 추가 — `#search-clear[hidden]` / `#search-sheet-clear[hidden]` 와 동일한 기존 패턴.

```css
#cite-sheet-back[hidden] {
  display: none;
}
```

## 동작

- 시트 첫 진입(인용 칩 목록 보기): 뒤로 가기 버튼 **숨김**
- "더 보기" 클릭으로 확장 보기 진입: 뒤로 가기 버튼 **노출**
- 뒤로 가기 / Esc 로 목록으로 복귀: 뒤로 가기 버튼 다시 **숨김**

## 테스트

- `node --test tests/unit/citations.test.js` — 18/18 통과


---
_Generated by [Claude Code](https://claude.ai/code/session_016CBoGf7PwAekX2xQzTXXAF)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CSS specificity fix for cite sheet chrome; no auth, data, or API changes.
> 
> **Overview**
> The citation bottom sheet (`#cite-sheet`) back button was always visible on first open because `#cite-sheet-back { display: flex }` outranked the browser’s `[hidden] { display: none }`, so JavaScript toggling `backBtn.hidden` in `_updateSheetHeader()` had no visual effect.
> 
> **`css/style.css`** adds `#cite-sheet-back[hidden] { display: none; }`, matching the existing pattern used for `#search-clear` and `#search-sheet-clear`. The back control now stays hidden on the cite-chip list view and only appears in expanded “더 보기” mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b77c0acc55c405f72dedab6793743ce23185605b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->