### PR TITLE
fix: 글자 크기 확대 시 설정 팝오버 레이아웃 깨짐 수정

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -224,8 +224,12 @@ body {
   border-radius: var(--radius);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
   padding: 0.5rem;
-  width: 280px;
-  white-space: nowrap;
+  /* rem-based so the popover scales with the user's font-size choice;
+     capped to the viewport so it never overflows on the right at large
+     fonts. White-space wrapping is opt-in per child (buttons set nowrap
+     individually) so labels and rows can wrap when content doesn't fit. */
+  width: 17.5rem;
+  max-width: calc(100vw - 1rem);
 }
 
 /* Container is programmatically focused on pointer-driven open so the first
@@ -382,6 +386,10 @@ body {
   align-items: center;
   gap: 0.75rem;
   padding: 0.25rem 0;
+  /* Wrap when the label + control group exceeds row width (e.g. large
+     font-size). The control group keeps margin-left: auto so it stays
+     right-aligned on its own line after wrapping. */
+  flex-wrap: wrap;
 }
 
 /* Right-align the control group so every row shares a clean right edge. */
@@ -418,6 +426,7 @@ body {
   align-items: center;
   justify-content: center;
   line-height: 1;
+  white-space: nowrap;
 }
 .settings-action-btn:hover {
   background: var(--accent);
@@ -430,6 +439,8 @@ body {
 
 .btn-group {
   display: flex;
+  /* Keep the segmented group intact when the row wraps. */
+  flex-shrink: 0;
 }
 
 .btn-group .toolbar-btn {
@@ -464,6 +475,7 @@ body {
   align-items: center;
   justify-content: center;
   line-height: 1;
+  white-space: nowrap;
   transition: background 0.15s;
 }
 
@@ -2470,6 +2482,7 @@ html.cite-sheet-open {
   justify-content: center;
   gap: 0.3em;
   line-height: 1;
+  white-space: nowrap;
   transition: background 0.15s, color 0.15s;
 }
 


### PR DESCRIPTION
## 문제

글자 크기를 키우면 설정 팝오버 안의 라벨·세그먼티드 버튼이 팝오버 박스 밖(뷰포트 오른쪽 끝)으로 잘려나가 "첫 페이지", "구약에 포함", "표시" 등이 보이지 않았다.

원인:
- `.settings-popover`의 너비가 `280px` 고정 픽셀이라 루트 폰트 크기 변경과 무관하게 그대로 유지됨
- 컨테이너 전체에 `white-space: nowrap`이 걸려 있어 행이 줄바꿈되지도 못함
- 결과적으로 내부 콘텐츠가 박스(그리고 뷰포트)를 넘어가도 시각적으로 잘려 나갔음

## 변경

`css/style.css`만 수정한 작은 패치:

- `.settings-popover` 너비를 `280px` → `17.5rem`(루트 폰트 크기에 비례해 스케일) + `max-width: calc(100vw - 1rem)`(뷰포트를 절대 넘지 않음)
- `.settings-popover`의 `white-space: nowrap` 제거 → 라벨·행이 필요 시 자연스럽게 줄바꿈
- `.settings-row`에 `flex-wrap: wrap` 추가 → 라벨+버튼 그룹이 한 줄에 안 들어가면 버튼 그룹이 다음 줄로 내려가 우측 정렬 유지
- `.btn-group`에 `flex-shrink: 0` 추가 → 세그먼티드 컨트롤이 쪼그라들지 않음
- `.toolbar-btn` / `.settings-action-btn` / `.cache-clear-btn`에 `white-space: nowrap` 개별 적용 → 버튼 라벨은 끊기지 않음

기본 글자 크기에서는 기존과 픽셀 단위로 동일(16px × 17.5 = 280px). 글자를 키울 때만 동작이 달라진다.

## 테스트

- `node --test tests/unit/*.test.js` — 537/537 통과
- `npx tsc -p tsconfig.json --noEmit` — 기존 deprecation 경고만 (코드 에러 0)
- 시각 검증: 이 환경에 Playwright가 설치되어 있지 않아 수동 확인이 필요합니다. 글자 크기를 A+로 키운 뒤 설정 팝오버를 열어 라벨/버튼이 잘리지 않고 행이 자연스럽게 줄바꿈되는지 확인해 주세요.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QBrJKL3mu6Nuer7dFQQwS6)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only presentation changes to the settings popover; no logic, auth, or data handling.
> 
> **Overview**
> Fixes the **settings popover** clipping off the right edge when users increase text size. The popover no longer uses a fixed **280px** width and container-wide **nowrap**; it now scales with root font size (**17.5rem**) and is capped with **`max-width: calc(100vw - 1rem)`**.
> 
> **Settings rows** can wrap (**`flex-wrap`** on `.settings-row`), with segmented controls staying intact (**`flex-shrink: 0`** on `.btn-group`). Button labels keep a single line via **`white-space: nowrap`** on individual toolbar/action buttons instead of the whole popover.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee36ec167e1cde3d8d84bd7b2570a1936a6a864d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->