### PR TITLE
style: 설정 팝오버 너비 17.5rem→19rem (인용 본문·주석 줄바꿈 해소)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -227,8 +227,11 @@ body {
   /* rem-based so the popover scales with the user's font-size choice;
      capped to the viewport so it never overflows on the right at large
      fonts. White-space wrapping is opt-in per child (buttons set nowrap
-     individually) so labels and rows can wrap when content doesn't fit. */
-  width: 17.5rem;
+     individually) so labels and rows can wrap when content doesn't fit.
+     Width sized so the longest label (인용 본문·주석, ~5.5em at 0.92rem
+     ≈ 5.1rem) + 0.75rem gap + 11rem btn-group fit on one row inside
+     the 0.5rem horizontal padding (≈ 17.85rem content). */
+  width: 19rem;
   max-width: calc(100vw - 1rem);
 }
 


### PR DESCRIPTION
## Summary

기본 글꼴 크기에서 설정 팝오버의 "인용 본문·주석" 라벨이 표시·숨김 토글과 같은 줄에 들어가지 않고 줄바꿈되던 문제를 해결합니다.

- `.settings-popover` 너비를 17.5rem → 19rem 으로 확대
- 라벨 5.5em(≈ 5.1rem) + 0.75rem gap + 11rem 토글 그룹이 0.5rem 좌우 패딩 안에 들어가도록 산정
- `max-width: calc(100vw - 1rem)` 보호는 그대로 유지되어 좁은 뷰포트에서는 자동 축소

## 측정 (390px 뷰포트, Noto Sans KR 로드 후)

| 너비 | "인용 본문·주석" 행 높이 | 결과 |
|---|---|---|
| 17.5rem (이전) | 74px | WRAP (라벨/토글 두 줄) |
| 19rem (변경) | 36px | single (다른 행과 동일) |

다른 행("시작 화면", "외경", "글자 크기", "테마") 높이는 36px로 동일하게 유지됨.

## Test plan

- [x] JS 유닛 537 케이스 통과 (`node --test tests/unit/*.test.js`)
- [x] 로컬에서 팝오버 직접 띄워 라벨/토글이 한 줄에 표시되는지 확인 (스크린샷 첨부)
- [ ] 다양한 글자 크기(A-/A+)에서도 줄바꿈 정책 정상 동작 확인 — `.settings-row { flex-wrap: wrap }` 가 보호하므로 큰 폰트에서는 기존처럼 줄바꿈됨


---
_Generated by [Claude Code](https://claude.ai/code/session_012rdwu9xwteEZFX5QJULzNT)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only layout change to `.settings-popover` width; no logic, auth, or data impact.
> 
> **Overview**
> **설정 팝오버** (`.settings-popover`) **너비를 `17.5rem`에서 `19rem`으로 늘려**, 기본 글꼴 크기에서 **「인용 본문·주석」** 라벨과 표시·숨김 토글 그룹이 **한 줄**에 맞도록 합니다.
> 
> 주석은 라벨·간격·`11rem` 버튼 그룹·패딩 기준으로 너비를 잡았다고 설명합니다. **`max-width: calc(100vw - 1rem)`** 은 그대로라 좁은 화면에서는 여전히 줄어듭니다.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90560c93670401ee3e283d27cce39034ed3254d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->