### PR TITLE
fix: 인용·주석 설정이 Drive 동기화 후 리셋되는 문제 수정

### DIFF
--- a/js/app/storage.js
+++ b/js/app/storage.js
@@ -29,7 +29,7 @@ window.appStorage = (() => {
   const BOOK_ORDER_KEY = "bible-book-order";
   const COLOR_SCHEME_KEY = "bible-color-scheme";
   const STARTUP_BEHAVIOR_KEY = "bible-startup"; // "resume" | "home"
-  const CITE_SHOW_KEY = "bible-cite-show"; // "1" = show, "0" = hide (default "1")
+  const CITE_SHOW_KEY = "bible-cite-show"; // "1"/"0" (saveCiteShow) or "true"/"false" (sync applyToLegacyKeys); default ON when unset
   const AUDIO_POS_KEY = "bible-audio-pos";
   const BOOKMARK_KEY = "bible-bookmarks";
   const INSTALL_NUDGE_KEY = "bible-install-nudge";
@@ -192,7 +192,12 @@ window.appStorage = (() => {
   function loadCiteShow() {
     const v = localStorage.getItem(CITE_SHOW_KEY);
     if (v === null) return true;  // default ON (ADR-022 §6)
-    return v === "1";
+    // Accept both this module's "1"/"0" save format and the JSON-serialized
+    // "true"/"false" written by sync's applyToLegacyKeys (which always passes
+    // non-string values through JSON.stringify). Without this, a cite=true
+    // value round-tripped through Drive sync is read back as false on next
+    // cold start, causing the setting to appear to reset.
+    return v === "1" || v === "true";
   }
 
   /** @param {boolean} on */

--- a/tests/unit/storage.test.js
+++ b/tests/unit/storage.test.js
@@ -475,6 +475,46 @@ test("saveStartupBehavior: writes value and notifies sync + drive", () => {
   assert.equal(h.driveSync._calls.scheduleUpload, 1);
 });
 
+// ── cite/note visibility (ADR-022) ───────────────────────────────────────────
+
+test("loadCiteShow: defaults to true when unset", () => {
+  const h = loadStorage();
+  assert.equal(h.appStorage.loadCiteShow(), true);
+});
+
+test("loadCiteShow: reads '1' as true and '0' as false (save format)", () => {
+  const hOn  = loadStorage({ localStorageInit: { "bible-cite-show": "1" } });
+  const hOff = loadStorage({ localStorageInit: { "bible-cite-show": "0" } });
+  assert.equal(hOn.appStorage.loadCiteShow(), true);
+  assert.equal(hOff.appStorage.loadCiteShow(), false);
+});
+
+// Sync's applyToLegacyKeys writes JSON.stringify(boolean), producing
+// "true"/"false". Without this tolerance, citeShow appears to reset on the
+// next cold start whenever Drive sync has run.
+test("loadCiteShow: reads 'true'/'false' written by sync applyToLegacyKeys", () => {
+  const hOn  = loadStorage({ localStorageInit: { "bible-cite-show": "true" } });
+  const hOff = loadStorage({ localStorageInit: { "bible-cite-show": "false" } });
+  assert.equal(hOn.appStorage.loadCiteShow(), true);
+  assert.equal(hOff.appStorage.loadCiteShow(), false);
+});
+
+test("saveCiteShow: writes '1'/'0' and notifies sync + drive", () => {
+  const h = loadStorage();
+  h.appStorage.saveCiteShow(false);
+  assert.equal(h.localStorage._raw["bible-cite-show"], "0");
+  h.appStorage.saveCiteShow(true);
+  assert.equal(h.localStorage._raw["bible-cite-show"], "1");
+  assert.deepEqual(h.syncStoreV2._calls.saveSetting,
+    [{ key: "citeShow", val: false }, { key: "citeShow", val: true }]);
+  assert.equal(h.driveSync._calls.scheduleUpload, 2);
+});
+
+test("saveCiteShow: swallows localStorage errors", () => {
+  const h = loadStorage({ localStorageThrowOn: "all" });
+  assert.doesNotThrow(() => h.appStorage.saveCiteShow(false));
+});
+
 // ── font size ────────────────────────────────────────────────────────────────
 
 test("loadFontSize: defaults to DEFAULT_FONT_SIZE (18) when unset", () => {


### PR DESCRIPTION
## 증상

설정 → "인용 본문·주석" 토글을 바꾼 뒤 앱을 닫았다 다시 열면 설정이 항상 "숨김"으로 표시되는 문제. Drive 동기화가 활성화된 사용자에게서만 재현됨.

## 원인

`bible-cite-show` localStorage 키에 대해 두 곳에서 서로 다른 포맷으로 저장한다:

- `js/app/storage.js`의 `saveCiteShow` → `"1"`/`"0"`
- `js/sync/store-v2.js`의 `applyToLegacyKeys` → `JSON.stringify(boolean)` 결과인 `"true"`/`"false"`

`loadCiteShow`가 `v === "1"`로만 true를 판정하던 탓에, Drive 동기화가 한 번 돈 뒤 cold start 시 `"true"`가 false로 잘못 읽혔다. 다른 설정(fontSize, theme 등)은 `JSON.stringify(value)`와 save 포맷이 우연히 일치해 문제 없었고 boolean인 `citeShow`만 어긋났다.

## 수정

`loadCiteShow`가 `"1"` 또는 `"true"`를 모두 true로 인식하도록 허용. 저장 포맷은 그대로 두어 기존 사용자의 localStorage 호환을 유지.

## Test plan

- [x] `node --test tests/unit/storage.test.js` — 88 케이스 통과 (신규 5개 포함: 기본값/`"1"`·`"0"` 라운드트립/`"true"`·`"false"` 호환/저장 후 sync hook 호출/quota 에러 무시)
- [x] `node --test tests/unit/*.test.js` — 542 케이스 통과 (이전 537 + 신규 5)
- [x] `npx tsc -p tsconfig.json --noEmit --ignoreDeprecations 6.0` — 0 error
- [ ] 수동 확인: Drive 동기화 켠 상태에서 "표시"/"숨김" 토글 → 앱 종료 → 재실행 → 토글 상태 유지되는지 확인

https://claude.ai/code/session_01NVkM2BJMR4Xjj1XeMwVKna

---
_Generated by [Claude Code](https://claude.ai/code/session_01NVkM2BJMR4Xjj1XeMwVKna)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow read-path compatibility fix for one settings key plus unit tests; no auth, sync protocol, or write-format changes.
> 
> **Overview**
> Fixes the **인용 본문·주석** (`citeShow`) toggle appearing to reset to hidden after a cold start when **Google Drive sync** has run.
> 
> `loadCiteShow` previously treated only `"1"` as enabled, while `saveCiteShow` still writes `"1"`/`"0"` but sync’s `applyToLegacyKeys` writes booleans as `"true"`/`"false"` on `bible-cite-show`. The loader now accepts **both** encodings; save behavior is unchanged for existing localStorage.
> 
> Adds focused unit coverage for defaults, `"1"`/`"0"`, sync-style `"true"`/`"false"`, and `saveCiteShow` side effects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6d4cc1840d10c3015ac3fad063af322cdabf285. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->