### PR TITLE
feat: 설정에 오디오북 켜기/끄기 토글 추가

### DIFF
--- a/js/app/settings-ui.js
+++ b/js/app/settings-ui.js
@@ -25,6 +25,7 @@ window.appSettings = (() => {
     loadTheme, saveTheme,
     loadBookOrder, saveBookOrder,
     loadCiteShow, saveCiteShow,
+    loadAudioShow, saveAudioShow,
   } = window.appStorage;
 
   const $settingsAnchor = _$("settings-anchor");
@@ -320,9 +321,37 @@ window.appSettings = (() => {
       }
       citeRow.appendChild(citeGroup);
 
+      // Audiobook visibility — when off, audio bar is hidden and the FAB
+      // falls back to its lower default position (CSS sibling rule keys off
+      // #audio-bar[hidden]).
+      const audioRow = el("div", { className: "settings-row" });
+      audioRow.appendChild(el("span", { className: "settings-label" }, "오디오북"));
+      const audioCurrent = loadAudioShow();
+      const audioGroup = el("div", { className: "btn-group", role: "group", "aria-label": "오디오북 선택" });
+      for (const { val, label, announceLabel } of [
+        { val: true,  label: "켜기", announceLabel: "오디오북 켜기" },
+        { val: false, label: "끄기", announceLabel: "오디오북 끄기" },
+      ]) {
+        const audioBtn = el("button", {
+          className: "toolbar-btn",
+          "aria-pressed": String(audioCurrent === val),
+        }, label);
+        audioBtn.addEventListener("click", () => {
+          saveAudioShow(val);
+          if (typeof window.applyAudioShow === "function") window.applyAudioShow(val);
+          audioGroup.querySelectorAll(".toolbar-btn").forEach((b) =>
+            b.setAttribute("aria-pressed", String(b === audioBtn))
+          );
+          announce(announceLabel);
+        });
+        audioGroup.appendChild(audioBtn);
+      }
+      audioRow.appendChild(audioGroup);
+
       section1.appendChild(startupRow);
       section1.appendChild(orderRow);
       section1.appendChild(citeRow);
+      section1.appendChild(audioRow);
       popover.appendChild(section1);
 
       // ── Section 2: Typography & appearance ──

--- a/js/app/storage.js
+++ b/js/app/storage.js
@@ -30,6 +30,7 @@ window.appStorage = (() => {
   const COLOR_SCHEME_KEY = "bible-color-scheme";
   const STARTUP_BEHAVIOR_KEY = "bible-startup"; // "resume" | "home"
   const CITE_SHOW_KEY = "bible-cite-show"; // "1"/"0" (saveCiteShow) or "true"/"false" (sync applyToLegacyKeys); default ON when unset
+  const AUDIO_SHOW_KEY = "bible-audio-show"; // "1"/"0" or "true"/"false" via sync; default ON when unset
   const AUDIO_POS_KEY = "bible-audio-pos";
   const BOOKMARK_KEY = "bible-bookmarks";
   const INSTALL_NUDGE_KEY = "bible-install-nudge";
@@ -209,6 +210,26 @@ window.appStorage = (() => {
     } catch (_) {}
   }
 
+  // ── Audio player visibility ──
+
+  /** @returns {boolean} */
+  function loadAudioShow() {
+    const v = localStorage.getItem(AUDIO_SHOW_KEY);
+    if (v === null) return true;  // default ON
+    // Mirrors loadCiteShow's tolerance for the JSON-serialized "true"/"false"
+    // shape that sync's applyToLegacyKeys writes back.
+    return v === "1" || v === "true";
+  }
+
+  /** @param {boolean} on */
+  function saveAudioShow(on) {
+    try {
+      localStorage.setItem(AUDIO_SHOW_KEY, on ? "1" : "0");
+      window.syncStoreV2?.saveSetting("audioShow", on);
+      if (window.driveSync) window.driveSync.scheduleUpload();
+    } catch (_) {}
+  }
+
   // ── Font size ──
 
   /** @returns {number} */
@@ -359,6 +380,7 @@ window.appStorage = (() => {
     pushSearchHistory, removeSearchHistory, clearSearchHistory,
     loadStartupBehavior, saveStartupBehavior,
     loadCiteShow, saveCiteShow,
+    loadAudioShow, saveAudioShow,
     loadFontSize, saveFontSize,
     loadColorScheme, saveColorScheme,
     loadTheme, saveTheme,

--- a/js/app/views-routing.js
+++ b/js/app/views-routing.js
@@ -23,6 +23,7 @@ const {
   loadBookOrder, loadStartupBehavior,
   loadReadingPosition, saveReadingPosition, clearReadingPosition,
   loadAudioTime, saveAudioTime, clearAudioTime,
+  loadAudioShow,
   _maybeRequestPersist,
 } = window.appStorage;
 const { dismissLaunchScreen } = window.appSettings;
@@ -1967,6 +1968,7 @@ function hideAudioBar() {
 
 /** @param {string} bookId @param {number} chapter */
 function showAudioPlayer(bookId, chapter) {
+  if (!loadAudioShow()) { hideAudioBar(); return; }
   _teardownAudio();
   _audioController = new AbortController();
   const { signal } = _audioController;
@@ -2123,6 +2125,18 @@ function showAudioUnavailable() {
   $audioBar.appendChild(msg);
   $audioBar.hidden = false;
 }
+
+// Live-toggle the audio player from the settings popover. Off: tear it down
+// so the FAB's audio-bar CSS sibling rule drops it back to the lower default
+// position. On: rebuild for the chapter currently in view (no-op on non-chapter
+// routes — next chapter navigation will pick the toggle up via showAudioPlayer).
+/** @param {boolean} on */
+function applyAudioShow(on) {
+  if (!on) { hideAudioBar(); return; }
+  const parsed = parsePath();
+  if (parsed.view === "chapter") showAudioPlayer(parsed.bookId, parsed.chapter);
+  else if (parsed.view === "prologue") showAudioPlayer(parsed.bookId, 0);
+}
 // ── Window facade ──
 // Both an `appViewsRouting` aggregate and per-name globals so app.js's
 // Phase 7b territory (Views/Routing/Audio Player) can call setTitle / loadBooks
@@ -2135,7 +2149,7 @@ const appViewsRouting = {
   setTitle, setBreadcrumb, setTitleWithDivisionPicker, setTitleWithChapterPicker,
   buildDivisionBreadcrumb, divisionLabels, divisionOrder, effectiveDivision,
   initCompactHeader,
-  parsePath, route, navigate, hideAudioBar, renderError,
+  parsePath, route, navigate, hideAudioBar, applyAudioShow, renderError,
   _verseSelectionUnit,
 };
 window.appViewsRouting = appViewsRouting;
@@ -2164,6 +2178,7 @@ window.parsePath = parsePath;
 window.route = route;
 window.navigate = navigate;
 window.hideAudioBar = hideAudioBar;
+window.applyAudioShow = applyAudioShow;
 window.renderError = renderError;
 
 // Audio Player module state read accessor — app.js's Accessibility keydown

--- a/js/sync/state-machine.js
+++ b/js/sync/state-machine.js
@@ -581,6 +581,7 @@ function createSyncMachine({ onStateChange } = {}) {
       if (s.colorScheme?.v != null && typeof window.applyColorScheme === "function") window.applyColorScheme(/** @type {string} */ (s.colorScheme.v));
       if (s.theme?.v       != null && typeof window.applyTheme       === "function") window.applyTheme(/** @type {string} */ (s.theme.v));
       if (s.citeShow?.v    != null && typeof window.applyCiteShow    === "function") window.applyCiteShow(/** @type {boolean} */ (s.citeShow.v));
+      if (s.audioShow?.v   != null && typeof window.applyAudioShow   === "function") window.applyAudioShow(/** @type {boolean} */ (s.audioShow.v));
       _snackbar("다른 기기에서 변경된 데이터를 불러왔습니다.");
     }
   }

--- a/js/sync/store-v2.js
+++ b/js/sync/store-v2.js
@@ -25,6 +25,7 @@ const _SETTING_LS_KEYS = {
   bookOrder:       "bible-book-order",
   startupBehavior: "bible-startup",
   citeShow:        "bible-cite-show",
+  audioShow:       "bible-audio-show",
 };
 const _LR_KEY = "bible-last-read";
 
@@ -125,6 +126,7 @@ function _emptyDoc() {
       bookOrder:       { v: null, _u: 0 },
       startupBehavior: { v: null, _u: 0 },
       citeShow:        { v: null, _u: 0 },
+      audioShow:       { v: null, _u: 0 },
     },
     lastRead: { v: null, _u: 0 },
   };

--- a/js/types.d.ts
+++ b/js/types.d.ts
@@ -73,7 +73,8 @@ export type SettingKey =
   | "theme"
   | "bookOrder"
   | "startupBehavior"
-  | "citeShow";
+  | "citeShow"
+  | "audioShow";
 
 // Per-setting value type. All settings store one MTimed wrapper; the inner
 // value type is intentionally `unknown` so that store-v2 can index by a
@@ -823,6 +824,7 @@ declare global {
     applyColorScheme?: (scheme: string) => void;
     applyTheme?: (theme: string) => void;
     applyCiteShow?: (on: boolean) => void;
+    applyAudioShow?: (on: boolean) => void;
     // Manual SW update check — set by app.js inside registerServiceWorker()
     // so it can capture the registration and reuse showUpdateToast(). Returns
     // a status object the caller can surface as transient feedback.

--- a/tests/unit/storage.test.js
+++ b/tests/unit/storage.test.js
@@ -515,6 +515,44 @@ test("saveCiteShow: swallows localStorage errors", () => {
   assert.doesNotThrow(() => h.appStorage.saveCiteShow(false));
 });
 
+// ── audio player visibility ──────────────────────────────────────────────────
+
+test("loadAudioShow: defaults to true when unset", () => {
+  const h = loadStorage();
+  assert.equal(h.appStorage.loadAudioShow(), true);
+});
+
+test("loadAudioShow: reads '1' as true and '0' as false (save format)", () => {
+  const hOn  = loadStorage({ localStorageInit: { "bible-audio-show": "1" } });
+  const hOff = loadStorage({ localStorageInit: { "bible-audio-show": "0" } });
+  assert.equal(hOn.appStorage.loadAudioShow(), true);
+  assert.equal(hOff.appStorage.loadAudioShow(), false);
+});
+
+// Mirrors loadCiteShow tolerance for sync's JSON-serialized "true"/"false".
+test("loadAudioShow: reads 'true'/'false' written by sync applyToLegacyKeys", () => {
+  const hOn  = loadStorage({ localStorageInit: { "bible-audio-show": "true" } });
+  const hOff = loadStorage({ localStorageInit: { "bible-audio-show": "false" } });
+  assert.equal(hOn.appStorage.loadAudioShow(), true);
+  assert.equal(hOff.appStorage.loadAudioShow(), false);
+});
+
+test("saveAudioShow: writes '1'/'0' and notifies sync + drive", () => {
+  const h = loadStorage();
+  h.appStorage.saveAudioShow(false);
+  assert.equal(h.localStorage._raw["bible-audio-show"], "0");
+  h.appStorage.saveAudioShow(true);
+  assert.equal(h.localStorage._raw["bible-audio-show"], "1");
+  assert.deepEqual(h.syncStoreV2._calls.saveSetting,
+    [{ key: "audioShow", val: false }, { key: "audioShow", val: true }]);
+  assert.equal(h.driveSync._calls.scheduleUpload, 2);
+});
+
+test("saveAudioShow: swallows localStorage errors", () => {
+  const h = loadStorage({ localStorageThrowOn: "all" });
+  assert.doesNotThrow(() => h.appStorage.saveAudioShow(false));
+});
+
 // ── font size ────────────────────────────────────────────────────────────────
 
 test("loadFontSize: defaults to DEFAULT_FONT_SIZE (18) when unset", () => {


### PR DESCRIPTION
## Summary
- 설정 팝오버의 "인용 본문·주석" 행 아래에 "오디오북 — 켜기/끄기" 토글 추가
- 끄면 `hideAudioBar()`로 오디오 바를 즉시 내리고, 켜면 현재 chapter/prologue에 맞춰 `showAudioPlayer()`를 재호출
- FAB은 별도 처리 불필요 — 기존 CSS의 `#audio-bar:not([hidden]) ~ #search-fab` 형제 셀렉터로 audio-bar가 `hidden` 상태가 되면 FAB이 하단 기본 위치(`1.5rem + safe-area-inset-bottom`)로 자동 복귀
- `audioShow` 설정 키를 Drive 동기화 스키마(`SettingKey`, `_SETTING_LS_KEYS`, `_emptyDoc`, `applyToLegacyKeys`)에도 추가 — 기본값 ON, `citeShow` 와 동일하게 `'1'/'0'` 및 sync round-trip 의 `'true'/'false'` 양쪽 모두 허용

## 변경 파일
| 파일 | 내용 |
| --- | --- |
| `js/app/storage.js` | `AUDIO_SHOW_KEY` + `loadAudioShow` / `saveAudioShow` |
| `js/app/views-routing.js` | `showAudioPlayer` 진입부에서 토글 확인 + 새 `applyAudioShow(on)` |
| `js/app/settings-ui.js` | 토글 행 UI |
| `js/sync/store-v2.js` · `js/sync/state-machine.js` · `js/types.d.ts` | Drive 동기화 연동 |
| `tests/unit/storage.test.js` | 신규 테스트 5건 |

## Test plan
- [x] `npx tsc -p tsconfig.json --noEmit` — 0 error
- [x] `npx tsc -p tsconfig.worker.json --noEmit` — 0 error
- [x] `node --test tests/unit/*.test.js` — 547 통과 (신규 5건 포함)
- [ ] 브라우저 수기 검증: 설정 팝오버에서 토글 → 오디오 바 즉시 나타남/사라짐, FAB 위치가 함께 이동
- [ ] 챕터 이동 시에도 OFF 상태 유지

https://claude.ai/code/session_01TkZyeqmcFEvYXB2rwHE2Uz

---
_Generated by [Claude Code](https://claude.ai/code/session_01TkZyeqmcFEvYXB2rwHE2Uz)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI preference only, patterned on citeShow; no auth or data-model changes beyond a new synced setting key.
> 
> **Overview**
> Adds an **오디오북** on/off control in the settings popover (default **on**), mirroring the existing cite-visibility pattern.
> 
> **Persistence & sync:** `loadAudioShow` / `saveAudioShow` use `bible-audio-show` (`1`/`0`, with `true`/`false` from Drive round-trips). `audioShow` is wired through sync v2 (`SettingKey`, store, empty doc) and remote merges call `applyAudioShow` like other settings.
> 
> **Runtime:** `showAudioPlayer` bails out when the setting is off. `applyAudioShow` hides the bar immediately when off, or rebuilds audio for the current chapter/prologue when on. The search FAB position still follows existing CSS on `#audio-bar[hidden]`—no FAB-specific code.
> 
> Unit tests cover load/save defaults and sync side effects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 108829e15f4916b855b6af5b0934cbe3229b3857. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->