### PR TITLE
feat: 설정 상위 4개 옵션을 OS별 네이티브 토글 스위치로 전환

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -64,6 +64,14 @@
   --shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
   --radius: 8px;
   --max-width: 720px;
+
+  /* Toggle switch (settings panel). OFF-state colours only — the ON state
+     always uses --accent so it tracks the chosen colour scheme. iOS uses the
+     grey track; Material 3 uses the outline/surface-variant trio. */
+  --switch-off-track: #d6d2cc;
+  --switch-m3-off-track: #e7e0ec;
+  --switch-m3-outline: #79747e;
+  --switch-m3-off-thumb: #79747e;
 }
 
 [data-theme="dark"] {
@@ -77,6 +85,12 @@
   --verse-num: #8ab4d8;
   --paragraph-mark: #6a94b8;
   --shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+
+  /* Lighter than --bg-card so the OFF track never disappears into the panel. */
+  --switch-off-track: #50506a;
+  --switch-m3-off-track: #3a3a55;
+  --switch-m3-outline: #938f99;
+  --switch-m3-off-thumb: #cfcad6;
 }
 
 /* ── Color schemes ── */
@@ -524,6 +538,130 @@ body {
 .toolbar-btn:disabled {
   opacity: 0.35;
   cursor: default;
+}
+
+/* ── Settings toggle switch (top 4 options) ── */
+
+/* The whole row is the tap target: the <label> wraps both the text block and
+   the switch. align-items:flex-start keeps the switch pinned to the top-right
+   when the label wraps to two lines at large font sizes. */
+.settings-toggle-label {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+  width: 100%;
+  cursor: pointer;
+}
+
+.settings-toggle-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  min-width: 0;
+}
+
+/* Dynamic caption (제2경전): always present so toggling never shifts layout.
+   Fixed to one line height; both phrases fit on a single line. */
+.settings-toggle-caption {
+  font-size: 0.75rem;
+  line-height: 1.3;
+  min-height: 1.3em;
+  color: var(--text-secondary);
+}
+
+/* Switch shell. Width/height set per-OS below; the input is an invisible
+   overlay that keeps native focus/checked semantics while the track + thumb
+   provide the visuals. */
+.switch {
+  position: relative;
+  display: inline-block;
+  flex-shrink: 0;
+  /* Nudge down so a single-line label optically centres against the switch. */
+  margin-top: 0.05rem;
+}
+
+.switch-input {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  opacity: 0;
+  cursor: pointer;
+  z-index: 1;
+}
+
+.switch-track {
+  display: block;
+  width: 100%;
+  height: 100%;
+  border-radius: 999px;
+  background: var(--switch-off-track);
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.switch-thumb {
+  position: absolute;
+  background: #fff;
+  border-radius: 50%;
+  transition: transform 0.2s ease, width 0.2s ease, height 0.2s ease, background 0.2s ease;
+}
+
+.switch-input:checked + .switch-track {
+  background: var(--accent);
+}
+
+.switch-input:focus-visible + .switch-track {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+/* iOS — UISwitch look: 51×31 pill, 27px white thumb, 20px travel. */
+.os-ios .switch { width: 51px; height: 31px; }
+.os-ios .switch-track { border-radius: 31px; }
+.os-ios .switch-thumb {
+  top: 2px;
+  left: 2px;
+  width: 27px;
+  height: 27px;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.25), 0 2px 4px rgba(0, 0, 0, 0.18);
+}
+.os-ios .switch-input:checked + .switch-track .switch-thumb {
+  transform: translateX(20px);
+}
+
+/* Android — Material 3 Switch look: 52×32 outlined track, small (16px) thumb
+   when OFF growing to a larger (24px) filled thumb when ON. */
+.os-android .switch { width: 52px; height: 32px; }
+.os-android .switch-track {
+  border-radius: 16px;
+  background: var(--switch-m3-off-track);
+  border: 2px solid var(--switch-m3-outline);
+}
+.os-android .switch-thumb {
+  top: 50%;
+  left: 0;
+  width: 16px;
+  height: 16px;
+  transform: translate(6px, -50%);
+  background: var(--switch-m3-off-thumb);
+}
+.os-android .switch-input:checked + .switch-track {
+  border-color: var(--accent);
+}
+.os-android .switch-input:checked + .switch-track .switch-thumb {
+  width: 24px;
+  height: 24px;
+  transform: translate(22px, -50%);
+  background: #fff;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .switch-track,
+  .switch-thumb {
+    transition: none;
+  }
 }
 
 #breadcrumb {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -458,6 +458,7 @@ OAuth 측면 (가장 큰 공격 표면):
 | [020](decisions/020-monorepo-split.md)                  | 모노레포 4분할 (app·data·audio·server)                     |
 | [021](decisions/021-pwa-versioning-content-hash.md)     | SHELL_CACHE = version.json 파생, DATA/AUDIO 콘텐츠 해시 매니페스트 |
 | [022](decisions/022-citations-and-annotations.md)       | 본문 인용(`<cite>`) + 주석(footnote) 표현과 단일 토글 렌더  |
+| [023](decisions/023-settings-toggle-switches.md)        | 설정 상위 4개 옵션 → OS별 네이티브 토글 스위치             |
 
 ## 부록 B. 자주 보게 되는 파일 빠른 참조
 

--- a/docs/decisions/023-settings-toggle-switches.md
+++ b/docs/decisions/023-settings-toggle-switches.md
@@ -1,0 +1,117 @@
+# ADR-023: 설정 패널 상위 4개 옵션 — OS별 네이티브 토글 스위치
+
+- 일시: 2026-05-29
+- 상태: 승인됨 — 구현 완료
+- 관련 ADR: ADR-005(설정 UI 세그먼트 컨트롤 도입 맥락), ADR-018(`js/app/settings-ui.js` 위치), ADR-022(인용·주석 표시 토글)
+
+## 맥락
+
+설정 패널 상위 4개 옵션(시작 화면 · 외경 배치 · 인용·주석 표시 · 오디오북)은
+각각 양쪽 상태를 모두 명시하는 **2분할 세그먼트 컨트롤**(`.btn-group` +
+`.toolbar-btn[aria-pressed]`)로 렌더되고 있었다(예: `읽던 곳 | 첫 페이지`).
+
+이 네 항목은 모두 **boolean 설정**(켜짐/꺼짐)이다. 세그먼트 컨트롤은 세 개 이상의
+선택지(테마 `라이트 | 시스템 | 다크`, 글자 크기 `A- | A | A+`)에는 적합하지만,
+2분할 boolean 에는 토글 스위치가 모바일 OS 관행에 더 부합하고 한 눈에 상태를
+읽기 쉽다. 패널을 사용하는 주 환경이 iOS/Android PWA 인 점을 고려해, 각 OS의
+네이티브 룩(iOS UISwitch / Android Material 3 Switch)으로 렌더한다.
+
+세 개 이상 선택지인 하위 항목(글자 크기 · 테마 · 색상)과 액션 행(앱 설치 ·
+백업&동기화 · 업데이트 · 캐시)은 **변경하지 않는다**.
+
+## 결정
+
+### 1. 재사용 컴포넌트 — `makeToggleRow`
+
+`js/app/settings-ui.js` 에 라벨·캡션·상태키를 인자로 받는 단일 팩토리
+`makeToggleRow({ labelText, checked, onToggle, getCaption? })` 를 두고, 네 옵션이
+이를 호출한다. 반환 구조:
+
+```
+<div class="settings-row settings-toggle-row">
+  <label class="settings-toggle-label">       ← 행 전체가 탭 타깃
+    <div class="settings-toggle-text">
+      <span class="settings-label">…</span>
+      <span class="settings-toggle-caption" id="…">…</span>  ← getCaption 있을 때만
+    </div>
+    <span class="switch">
+      <input type="checkbox" role="switch" aria-label="…" aria-describedby="…">
+      <span class="switch-track" aria-hidden="true"><span class="switch-thumb"></span></span>
+    </span>
+  </label>
+</div>
+```
+
+- 토글은 상태를 **제자리에서** 갱신한다 — 세그먼트 컨트롤이 하던 `rebuild()`
+  전체 재렌더를 호출하지 않으므로 포커스가 스위치에 유지된다. (외경 토글만
+  본문 재렌더가 필요해 `route()` 는 그대로 호출하되 팝오버는 재구축하지 않음.)
+
+### 2. 라벨·상태 매핑 (하위호환)
+
+기존 localStorage 키·값을 **그대로 재사용**하고 토글 ON/OFF ↔ 값만 매핑한다.
+
+| 라벨(신규)        | 키                  | ON          | OFF        | 캡션                       |
+| ----------------- | ------------------- | ----------- | ---------- | -------------------------- |
+| 읽던 페이지에서 시작 | `bible-startup`     | `resume`    | `home`     | 없음                       |
+| 제2경전           | `bible-book-order`  | `vulgate`   | `canonical`| **동적**: 구약에 포함 / 별도 섹션에 표시 |
+| 인용·주석 표시    | `bible-cite-show`   | `1`(true)   | `0`(false) | 없음                       |
+| 오디오북          | `bible-audio-show`  | `1`(true)   | `0`(false) | 없음                       |
+
+기본값은 storage.js 의 기존 로더가 그대로 결정(시작=resume, 외경=canonical,
+인용=ON, 오디오=ON). 라벨 텍스트는 외경→"제2경전", 시작 화면→"읽던 페이지에서
+시작", 인용 본문·주석→"인용·주석 표시" 로 다듬었으나 저장 값은 불변.
+
+제2경전 캡션은 **항상 표시**하고 상태에 따라 문구만 교체한다. 두 문구 모두 한 줄
+글꼴에 들어가고 `min-height: 1.3em` 으로 한 줄 높이를 고정해 토글 시 layout shift 가
+없다.
+
+### 3. OS 감지 + 네이티브 스타일
+
+`detectOS()` 가 `navigator` 로 iOS(iPhone/iPad/iPod 또는 iPadOS 위장:
+`platform === "MacIntel" && maxTouchPoints > 1`) 와 그 외(Material 기본값)를
+구분해 `<html>` 에 `.os-ios` / `.os-android` 클래스를 부여하고, CSS 가 분기한다.
+install.js 의 `detectPlatform()` 과 별도 — 그쪽은 standalone 일 때 `"installed"`
+를 반환하지만 토글 룩은 설치 여부와 무관하게 네이티브 OS 를 따라야 하기 때문.
+
+- **iOS (UISwitch)**: 51×31 알약 트랙, 27px 흰 썸 + 그림자, 20px 슬라이드.
+- **Android (Material 3)**: 52×32 윤곽선 트랙, OFF 16px 작은 썸 → ON 24px 큰
+  흰 썸 + 채워진 트랙, 썸 크기·위치 트랜지션.
+
+### 4. 색상·테마 연동
+
+ON 상태 채움은 새 색을 만들지 않고 기존 `--accent`(색상 스킴 4종 + 라이트/다크
+파생)를 그대로 쓴다. OFF 트랙 색만 신규 변수로 분리:
+`--switch-off-track`(iOS), `--switch-m3-off-track`·`--switch-m3-outline`·
+`--switch-m3-off-thumb`(Material). 다크에서 OFF 트랙이 `--bg-card` 에 묻히지
+않도록 패널보다 밝은 값을 사용.
+
+### 5. 접근성
+
+- `<input type="checkbox" role="switch">` — checked ↔ aria-checked 자동 매핑.
+- 명시적 `aria-label`(라벨 텍스트)로 접근 이름을 고정하고, 캡션은
+  `aria-describedby` 로 연결(캡션이 이름에 섞이지 않도록).
+- `<label>` 이 텍스트·스위치를 모두 감싸 **행 전체가 탭 타깃**.
+- 키보드: 포커스 가능 + Space(네이티브) + Enter(`keydown` 핸들러로 보강,
+  switch role 관행).
+- 포커스 링은 `:focus-visible + .switch-track` 로 트랙에 그린다.
+- `prefers-reduced-motion: reduce` 에서 트랜지션 제거.
+
+## 대안
+
+- **세그먼트 컨트롤 유지**: boolean 에는 토글이 더 직관적이고 모바일 관행에 부합.
+- **단일 OS-중립 토글 룩**: 네이티브 룩이 사용자에게 더 익숙하고 학습 비용이 낮음.
+  CSS 분기 비용은 작음.
+- **`role="switch"` div(커스텀)**: 네이티브 checkbox 가 Space·label 연결·폼
+  시맨틱을 무료로 제공하므로 채택하지 않음.
+
+## 구현
+
+- `js/app/settings-ui.js` — `detectOS()`, `makeToggleRow()`, 섹션 1 네 행을
+  토글로 교체.
+- `css/style.css` — `--switch-*` 변수(라이트/다크) + `.settings-toggle-*` /
+  `.switch*` / `.os-ios` / `.os-android` 스타일.
+- `tests/e2e/test_settings.py` — 시작 화면·외경 테스트를 `role="switch"` +
+  `is_checked()` 기반으로 갱신(로컬 전용).
+
+바닐라 JS/CSS, 빌드 단계 0(ADR-019). 셸 자산(js/css) 변경이므로 다음 릴리스
+`release.py` 가 SHELL_CACHE 를 자동 무효화(ADR-021).

--- a/js/app/settings-ui.js
+++ b/js/app/settings-ui.js
@@ -222,9 +222,95 @@ window.appSettings = (() => {
     });
   }
 
+  // ── OS detection (toggle look) ──
+  // Drives the iOS (UISwitch) vs Material 3 toggle styling. Kept independent
+  // of install.js's detectPlatform(), which returns "installed" when running
+  // standalone — here we always want the native OS look regardless of install
+  // state. iPadOS 13+ masquerades as desktop Safari, so fall back to the
+  // touch-points heuristic.
+  /** @returns {"ios" | "android"} */
+  function detectOS() {
+    const ua = navigator.userAgent;
+    const isIOS = /iPad|iPhone|iPod/.test(ua) ||
+      (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1);
+    return isIOS ? "ios" : "android";
+  }
+
+  // ── Toggle switch component ──
+  // Monotonic id source for caption ↔ aria-describedby wiring; survives
+  // rebuild() since each rebuild discards the previous nodes.
+  let _toggleIdSeq = 0;
+
+  /**
+   * Build a settings row: text label (+ optional dynamic caption) on the left,
+   * an OS-styled toggle switch on the right. The entire row is the tap target —
+   * the <label> wraps both text and switch, so a click anywhere toggles it. The
+   * input carries role="switch"; an explicit aria-label keeps the accessible
+   * name to the bare label (the caption is linked via aria-describedby instead).
+   * @param {Object} opts
+   * @param {string} opts.labelText
+   * @param {boolean} opts.checked
+   * @param {(on: boolean) => void} opts.onToggle
+   * @param {(on: boolean) => string} [opts.getCaption] — when given, a caption is rendered and updated on toggle
+   * @returns {HTMLDivElement}
+   */
+  function makeToggleRow({ labelText, checked, onToggle, getCaption }) {
+    const row = el("div", { className: "settings-row settings-toggle-row" });
+    const label = el("label", { className: "settings-toggle-label" });
+
+    const textWrap = el("div", { className: "settings-toggle-text" });
+    textWrap.appendChild(el("span", { className: "settings-label" }, labelText));
+
+    /** @type {string | null} */
+    let captionId = null;
+    /** @type {HTMLElement | null} */
+    let captionEl = null;
+    if (getCaption) {
+      captionId = `settings-toggle-cap-${++_toggleIdSeq}`;
+      captionEl = el("span", { className: "settings-toggle-caption", id: captionId }, getCaption(checked));
+      textWrap.appendChild(captionEl);
+    }
+    label.appendChild(textWrap);
+
+    const sw = el("span", { className: "switch" });
+    /** @type {Record<string, string>} */
+    const inputAttrs = { type: "checkbox", role: "switch", className: "switch-input", "aria-label": labelText };
+    if (captionId) inputAttrs["aria-describedby"] = captionId;
+    const input = el("input", inputAttrs);
+    input.checked = !!checked;
+    const track = el("span", { className: "switch-track", "aria-hidden": "true" });
+    track.appendChild(el("span", { className: "switch-thumb" }));
+    sw.appendChild(input);
+    sw.appendChild(track);
+    label.appendChild(sw);
+    row.appendChild(label);
+
+    input.addEventListener("change", () => {
+      const on = input.checked;
+      if (captionEl && getCaption) captionEl.textContent = getCaption(on);
+      onToggle(on);
+    });
+    // role="switch" should toggle on Enter as well as Space (native checkbox
+    // only handles Space). Mirror the Space behaviour for Enter.
+    input.addEventListener("keydown", (e) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        input.checked = !input.checked;
+        input.dispatchEvent(new Event("change", { bubbles: true }));
+      }
+    });
+
+    return row;
+  }
+
   // ── Settings popover ──
   function initSettings() {
     clearNode($settingsAnchor);
+
+    // Tag the document with the OS look so toggle styling can branch in CSS.
+    const os = detectOS();
+    document.documentElement.classList.remove("os-ios", "os-android");
+    document.documentElement.classList.add(os === "ios" ? "os-ios" : "os-android");
 
     const wrapper = el("div", { className: "settings-wrapper" });
     const btn = el("button", { className: "settings-btn", "aria-label": "설정", "aria-expanded": "false" });
@@ -253,100 +339,59 @@ window.appSettings = (() => {
     function rebuild() {
       clearNode(popover);
 
-      // ── Section 1: Book order (deuterocanon placement) ──
+      // ── Section 1: Reading-experience toggles ──
+      // Four boolean settings rendered as OS-native toggle switches (see
+      // makeToggleRow). Toggling updates state in place — no popover rebuild —
+      // so focus stays on the switch and the segmented re-render is avoided.
       const section1 = el("section", { className: "settings-section" });
-      const orderRow = el("div", { className: "settings-row" });
-      orderRow.appendChild(el("span", { className: "settings-label" }, "외경"));
-      const currentOrder = loadBookOrder();
-      const orderGroup = el("div", { className: "btn-group", role: "group", "aria-label": "외경 배치 선택" });
-      for (const [value, label, announceLabel] of [
-        ["canonical", "분리", "외경 분리"],
-        ["vulgate", "구약에 포함", "구약에 외경 포함"],
-      ]) {
-        const orderBtn = el("button", { className: "toolbar-btn", "aria-pressed": String(currentOrder === value) }, label);
-        orderBtn.addEventListener("click", () => {
-          saveBookOrder(value);
+
+      // Startup behavior: ON = resume last reading position, OFF = home.
+      const startupRow = makeToggleRow({
+        labelText: "읽던 페이지에서 시작",
+        checked: loadStartupBehavior() === "resume",
+        onToggle: (on) => {
+          saveStartupBehavior(on ? "resume" : "home");
+          announce(on ? "마지막 읽던 페이지로 시작" : "첫 페이지로 시작");
+        },
+      });
+
+      // Deuterocanon placement: ON = mixed into the OT (vulgate order),
+      // OFF = separate section (canonical). Caption reflects the active state.
+      const orderRow = makeToggleRow({
+        labelText: "제2경전",
+        checked: loadBookOrder() === "vulgate",
+        getCaption: (on) => (on ? "구약에 포함" : "별도 섹션에 표시"),
+        onToggle: (on) => {
+          saveBookOrder(on ? "vulgate" : "canonical");
           const { view } = parsePath();
           if (view !== "chapter" && view !== "prologue") route();
-          rebuild();
-          announce(announceLabel);
-        });
-        orderGroup.appendChild(orderBtn);
-      }
-      orderRow.appendChild(orderGroup);
+          announce(on ? "구약에 외경 포함" : "외경 분리");
+        },
+      });
 
-      // Startup behavior
-      const startupRow = el("div", { className: "settings-row" });
-      startupRow.appendChild(el("span", { className: "settings-label" }, "시작 화면"));
-      const startupCurrent = loadStartupBehavior();
-      const startupGroup = el("div", { className: "btn-group", role: "group", "aria-label": "앱 시작 화면 선택" });
-      for (const { val, label } of [{ val: "resume", label: "읽던 곳" }, { val: "home", label: "첫 페이지" }]) {
-        const startupBtn = el("button", {
-          className: "toolbar-btn",
-          "aria-pressed": String(startupCurrent === val),
-        }, label);
-        startupBtn.addEventListener("click", () => {
-          saveStartupBehavior(val);
-          startupGroup.querySelectorAll(".toolbar-btn").forEach((b) =>
-            b.setAttribute("aria-pressed", String(b === startupBtn))
-          );
-          announce(`시작 화면: ${label}`);
-        });
-        startupGroup.appendChild(startupBtn);
-      }
-      startupRow.appendChild(startupGroup);
-
-      // Cite/note visibility (ADR-022)
-      const citeRow = el("div", { className: "settings-row" });
-      citeRow.appendChild(el("span", { className: "settings-label" }, "인용 본문·주석"));
-      const citeCurrent = loadCiteShow();
-      const citeGroup = el("div", { className: "btn-group", role: "group", "aria-label": "인용 본문·주석 선택" });
-      for (const { val, label, announceLabel } of [
-        { val: true,  label: "표시", announceLabel: "인용 본문·주석 표시" },
-        { val: false, label: "숨김", announceLabel: "인용 본문·주석 숨김" },
-      ]) {
-        const citeBtn = el("button", {
-          className: "toolbar-btn",
-          "aria-pressed": String(citeCurrent === val),
-        }, label);
-        citeBtn.addEventListener("click", () => {
-          saveCiteShow(val);
-          applyCiteShow(val);
-          citeGroup.querySelectorAll(".toolbar-btn").forEach((b) =>
-            b.setAttribute("aria-pressed", String(b === citeBtn))
-          );
-          announce(announceLabel);
-        });
-        citeGroup.appendChild(citeBtn);
-      }
-      citeRow.appendChild(citeGroup);
+      // Cite/note visibility (ADR-022): ON = show inline citations & notes.
+      const citeRow = makeToggleRow({
+        labelText: "인용·주석 표시",
+        checked: loadCiteShow(),
+        onToggle: (on) => {
+          saveCiteShow(on);
+          applyCiteShow(on);
+          announce(on ? "인용 본문·주석 표시" : "인용 본문·주석 숨김");
+        },
+      });
 
       // Audiobook visibility — when off, audio bar is hidden and the FAB
       // falls back to its lower default position (CSS sibling rule keys off
       // #audio-bar[hidden]).
-      const audioRow = el("div", { className: "settings-row" });
-      audioRow.appendChild(el("span", { className: "settings-label" }, "오디오북"));
-      const audioCurrent = loadAudioShow();
-      const audioGroup = el("div", { className: "btn-group", role: "group", "aria-label": "오디오북 선택" });
-      for (const { val, label, announceLabel } of [
-        { val: true,  label: "켜기", announceLabel: "오디오북 켜기" },
-        { val: false, label: "끄기", announceLabel: "오디오북 끄기" },
-      ]) {
-        const audioBtn = el("button", {
-          className: "toolbar-btn",
-          "aria-pressed": String(audioCurrent === val),
-        }, label);
-        audioBtn.addEventListener("click", () => {
-          saveAudioShow(val);
-          if (typeof window.applyAudioShow === "function") window.applyAudioShow(val);
-          audioGroup.querySelectorAll(".toolbar-btn").forEach((b) =>
-            b.setAttribute("aria-pressed", String(b === audioBtn))
-          );
-          announce(announceLabel);
-        });
-        audioGroup.appendChild(audioBtn);
-      }
-      audioRow.appendChild(audioGroup);
+      const audioRow = makeToggleRow({
+        labelText: "오디오북",
+        checked: loadAudioShow(),
+        onToggle: (on) => {
+          saveAudioShow(on);
+          if (typeof window.applyAudioShow === "function") window.applyAudioShow(on);
+          announce(on ? "오디오북 켜기" : "오디오북 끄기");
+        },
+      });
 
       section1.appendChild(startupRow);
       section1.appendChild(orderRow);

--- a/tests/e2e/test_settings.py
+++ b/tests/e2e/test_settings.py
@@ -20,33 +20,38 @@ def _html_attr(page, attr):
 # ── 시작 화면 ─────────────────────────────────────────────────────────────────
 
 def test_startup_home(browser):
-    """'첫 페이지' 클릭 → bible-startup = 'home', aria-pressed 업데이트."""
+    """토글 OFF → bible-startup = 'home', 스위치 미체크."""
     ctx = browser.new_context()
     ctx.add_init_script(CLEAR_APP_STORAGE)
     page = ctx.new_page()
     try:
         _open(page)
         pop = open_settings(page)
-        pop.get_by_role("button", name="첫 페이지").click()
+        sw = pop.get_by_role("switch", name="읽던 페이지에서 시작")
+        # 기본값은 resume(ON); 끄면 home.
+        assert sw.is_checked() is True
+        sw.click()
         page.wait_for_timeout(100)
         assert _ls(page, "bible-startup") == "home"
-        assert pop.get_by_role("button", name="첫 페이지").get_attribute("aria-pressed") == "true"
-        assert pop.get_by_role("button", name="읽던 곳").get_attribute("aria-pressed") == "false"
+        assert sw.is_checked() is False
     finally:
         ctx.close()
 
 
 def test_startup_resume(browser):
-    """'읽던 곳' 클릭 → bible-startup = 'resume'."""
+    """토글 OFF 후 다시 ON → bible-startup = 'resume'."""
     ctx = browser.new_context()
     ctx.add_init_script(CLEAR_APP_STORAGE)
     page = ctx.new_page()
     try:
         _open(page)
         pop = open_settings(page)
-        pop.get_by_role("button", name="읽던 곳").click()
+        sw = pop.get_by_role("switch", name="읽던 페이지에서 시작")
+        sw.click()  # → home
+        sw.click()  # → resume
         page.wait_for_timeout(100)
         assert _ls(page, "bible-startup") == "resume"
+        assert sw.is_checked() is True
     finally:
         ctx.close()
 
@@ -54,34 +59,40 @@ def test_startup_resume(browser):
 # ── 책 순서 ──────────────────────────────────────────────────────────────────
 
 def test_book_order_vulgate(browser):
-    """'구약에 포함' 클릭 → bible-book-order = 'vulgate'."""
+    """제2경전 토글 ON → bible-book-order = 'vulgate', 캡션 '구약에 포함'."""
     ctx = browser.new_context()
     ctx.add_init_script(CLEAR_APP_STORAGE)
     page = ctx.new_page()
     try:
         _open(page)
         pop = open_settings(page)
-        pop.get_by_role("button", name="구약에 포함").click()
+        sw = pop.get_by_role("switch", name="제2경전")
+        # 기본값은 canonical(OFF); 켜면 vulgate.
+        assert sw.is_checked() is False
+        sw.click()
         page.wait_for_timeout(100)
         assert _ls(page, "bible-book-order") == "vulgate"
-        assert pop.get_by_role("button", name="구약에 포함").get_attribute("aria-pressed") == "true"
+        assert sw.is_checked() is True
+        assert pop.locator(".settings-toggle-caption").first.inner_text() == "구약에 포함"
     finally:
         ctx.close()
 
 
 def test_book_order_canonical(browser):
-    """'분리' 클릭 → bible-book-order = 'canonical'."""
+    """제2경전 토글 ON 후 OFF → bible-book-order = 'canonical', 캡션 '별도 섹션에 표시'."""
     ctx = browser.new_context()
     ctx.add_init_script(CLEAR_APP_STORAGE)
     page = ctx.new_page()
     try:
         _open(page)
         pop = open_settings(page)
-        # Set vulgate first, then switch back
-        pop.get_by_role("button", name="구약에 포함").click()
-        pop.get_by_role("button", name="분리").click()
+        sw = pop.get_by_role("switch", name="제2경전")
+        sw.click()  # → vulgate
+        sw.click()  # → canonical
         page.wait_for_timeout(100)
         assert _ls(page, "bible-book-order") == "canonical"
+        assert sw.is_checked() is False
+        assert pop.locator(".settings-toggle-caption").first.inner_text() == "별도 섹션에 표시"
     finally:
         ctx.close()
 


### PR DESCRIPTION
## 목표

설정 패널 상위 4개 boolean 옵션을 2분할 세그먼트 컨트롤(`읽던 곳 | 첫 페이지`)에서
**단일 토글 스위치**로 전환. 토글은 실행 중인 OS에 맞는 네이티브 룩(iOS UISwitch /
Android Material 3 Switch)으로 렌더한다.

하위 항목(글자 크기 · 테마 · 색상)과 액션 행(앱 설치 · 백업&동기화 · 업데이트 ·
캐시)은 건드리지 않음.

## 변경 내용

**`js/app/settings-ui.js`**
- `detectOS()` — `navigator` 기반 iOS / 기타(Material) 분기 → `<html>`에 `.os-ios`/`.os-android` 부여 (install.js의 `detectPlatform()`과 별도; standalone 여부와 무관하게 네이티브 룩 적용)
- `makeToggleRow({ labelText, checked, onToggle, getCaption? })` — 라벨/캡션/상태키를 인자로 받는 재사용 컴포넌트
- 섹션 1의 네 행을 토글로 교체. 토글은 제자리 갱신(팝오버 `rebuild()` 미호출 → 포커스 유지). 외경만 본문 재렌더용 `route()` 유지

**`css/style.css`**
- OFF 트랙 색 변수 신설(라이트/다크) — ON 채움은 기존 `--accent` 그대로
- `.settings-toggle-*` / `.switch*` / `.os-ios` / `.os-android` 스타일 + `prefers-reduced-motion` 가드

**ADR-023 신설 + 아키텍처 인덱스 갱신, e2e 설정 테스트 토글 기반으로 갱신**

## 토글 정의 / 하위호환

기존 localStorage 키·값을 그대로 재사용하고 ON/OFF만 매핑:

| 라벨 | 키 | ON | OFF | 캡션 |
|---|---|---|---|---|
| 읽던 페이지에서 시작 | `bible-startup` | `resume` | `home` | 없음 |
| 제2경전 | `bible-book-order` | `vulgate` | `canonical` | **동적**: 구약에 포함 / 별도 섹션에 표시 |
| 인용·주석 표시 | `bible-cite-show` | `1` | `0` | 없음 |
| 오디오북 | `bible-audio-show` | `1` | `0` | 없음 |

제2경전 캡션은 항상 표시, `min-height` 한 줄 고정으로 토글 시 layout shift 없음.

## 접근성

- `<input type="checkbox" role="switch">` (checked↔aria-checked 자동), 명시적 `aria-label`, 캡션은 `aria-describedby`
- `<label>`이 텍스트+스위치를 감싸 **행 전체가 탭 타깃**
- 포커스 가능 + Space(네이티브) + Enter(보강), `:focus-visible` 링은 트랙에

## 검증

- `npx tsc`(app + worker) 0 error
- 유닛 547/547 통과
- e2e는 로컬 전용 — 토글 셀렉터(`role="switch"` + `is_checked()`)로 갱신

> ⚠️ OS별 토글 룩(iOS/Android 실기기)과 색상 스킴 4종 × 라이트/시스템/다크 대비는 로컬 e2e/실기기 확인 권장.

https://claude.ai/code/session_01ECpJoLajCYBieGoEfanRSg

---
_Generated by [Claude Code](https://claude.ai/code/session_01ECpJoLajCYBieGoEfanRSg)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only settings change with backward-compatible localStorage; main behavioral nuance is deuterocanon toggle still triggering route() without full popover rebuild.
> 
> **Overview**
> The settings panel’s top four **boolean** choices (resume on launch, deuterocanon placement, citations/notes, audiobook) move from **two-option segment buttons** to **single toggle switches** styled like native controls on iOS (UISwitch) and Android (Material 3).
> 
> **`js/app/settings-ui.js`** adds `detectOS()` (separate from install detection) to set `.os-ios` / `.os-android` on `<html>`, a shared **`makeToggleRow()`** factory (`role="switch"`, optional dynamic caption for 제2경전), and wires the four rows through it. Toggles update **in place** without rebuilding the whole popover (focus stays on the switch); book-order changes still call **`route()`** when not on a chapter view. **localStorage keys and stored values are unchanged**—only labels/copy were refined.
> 
> **`css/style.css`** adds OFF-track theme variables and switch layout/styles per OS, plus reduced-motion handling.
> 
> **ADR-023** documents the decision; **`tests/e2e/test_settings.py`** startup and book-order cases now target switches via `role="switch"` and `is_checked()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4dc7f610583f94976258668e804c26892301998d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->