### PR TITLE
style: 성서 목록 화면 헤더 구분선 제거 + 탭 위 여백 추가

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -191,6 +191,12 @@ body {
   background: linear-gradient(to right, transparent, var(--border) 20%, var(--border) 80%, transparent);
 }
 
+/* On the book-list page (the only view with division tabs) the title sits
+   directly above the tab strip, so the header divider line is redundant. */
+#sticky-group:has(#division-tabs-slot:not(:empty)) #app-header::after {
+  display: none;
+}
+
 
 #breadcrumb-row {
   display: flex;
@@ -1924,7 +1930,8 @@ mark.search-highlight {
   font-family: -apple-system, BlinkMacSystemFont, "Apple SD Gothic Neo", "Noto Sans KR", sans-serif;
   position: relative; /* positioning context for the sliding indicator */
   display: flex;
-  margin: 0.1rem 0 0;
+  /* Breathing room below the (now line-less) header. */
+  margin: 0.5rem 0 0;
   border: 1px solid var(--border);
   border-radius: var(--radius);
   background: var(--bg-card);


### PR DESCRIPTION
## 변경 사항

성서 목록(첫 페이지 / 구약·외경·신약 탭) 화면에서만 헤더 아래 구분선을 제거하고, 구분 탭이 헤더에 너무 붙지 않도록 탭 위 여백을 조금 늘렸습니다.

### 세부 내용

1. **헤더 구분선 제거** — `#app-header::after`(1px 그라데이션 라인)를 탭이 있는 유일한 뷰(성서 목록)에서만 숨김. 읽기 화면 헤더에는 영향 없음.
   - 코드베이스가 이미 쓰는 `:has()` 패턴 사용 (`#sticky-group:has(#division-tabs-slot:not(:empty))`).
2. **탭 위 여백** — 라인이 사라지면서 탭이 제목에 너무 붙는 문제 해소. `.division-tabs` 위쪽 여백 `0.1rem → 0.5rem`.

`css/style.css`만 변경.

https://claude.ai/code/session_01VPoemztNbwiauVvY1FUoem

---
_Generated by [Claude Code](https://claude.ai/code/session_01VPoemztNbwiauVvY1FUoem)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only CSS scoped to the book-list header/tabs layout; no logic, auth, or data changes.
> 
> **Overview**
> On the **성서 목록** screen (when `#division-tabs-slot` has content), the sticky header’s gradient divider (`#app-header::after`) is hidden so the title and 구약/외경/신약 tabs don’t get a redundant line between them. **Reading views** keep the divider unchanged.
> 
> **`.division-tabs`** top margin increases from `0.1rem` to `0.5rem` to add space under the header after the line is removed. Only **`css/style.css`** is touched; detection uses the existing `:has(#division-tabs-slot:not(:empty))` pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0789a67f3a439feec402db43b6e2a3304ae5f8b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->