### PR TITLE
fix: 긴 인용 칩이 행 중간에서 줄바꿈되도록 span 으로 변경

### DIFF
--- a/docs/decisions/022-citations-and-annotations.md
+++ b/docs/decisions/022-citations-and-annotations.md
@@ -6,6 +6,8 @@
 
 > **현재 상태 (2026-05-27 기준).** Phase 1 데이터 파이프라인 — `common-bible-data/src/parser.py` 가 `<cite>` segment 와 `[^id]` 주석을 추출해 절 JSON 의 `segments`·`notes` 필드에 보존. Phase 2 앱 UI — `js/app/citations.js` (~940줄) 가 인용 칩을 중복되지 않게 렌더, 인용 본문 바텀 시트 (`이 장 전체 보기` 확장 + 인용 절 강조, 드래그 핸들로 리사이즈·닫기, 다중 ref / parallels / 다중 장 지원), 주석 ※ 위첨자 + 클릭 툴팁(인쇄 시 하단 footnote), 첫 진입 코치마크를 모두 담당. 설정에서 칩·주석 각각 토글 (`bible-cite-show` / `bible-note-show` localStorage, 기본 ON). GitHub 이슈 #134/#135/#136 으로 Phase 1/2/3 진행 추적. 유닛 테스트는 `tests/unit/citations.test.js` 20 케이스 + 보고서 `docs/qa/2026-05-23-unit-citations.md`. Phase 3 는 사목·신학 자문으로 NT 전 본문에 `<cite>` + 주석을 수기로 다는 콘텐츠 작업이라 별도 일정.
 
+> **개정 (2026-05-29): 인용 칩 줄바꿈.** 인용 칩을 native `<button>` 대신 `<span role="button" tabindex="0">` 로 렌더한다. 브라우저가 `<button>` 을 `display:inline-block` 으로 강제해 칩 라벨(tradition + src + parallels 다수)이 길어지면 행 중간에서 줄바꿈되지 못하고 한 덩어리로 다음 줄에 떨어지는 문제가 있었다. span 은 주변 본문처럼 인라인으로 흘러 긴 라벨이 `·` 구분자 지점에서 자연스럽게 줄바꿈된다. 이미 주석 anchor(`_wrapAnchor`)가 같은 사유로 span 을 쓰던 선례를 따른 것. span 은 Enter/Space 기본 활성화가 없으므로 `initCiteSheet` 의 keydown 핸들러에서 칩 활성화를 수기로 처리한다.
+
 ## 맥락
 
 공동번역성서 본문에는 두 종류의 보조 정보가 자연스럽게 따라온다.

--- a/js/app/citations.js
+++ b/js/app/citations.js
@@ -91,8 +91,14 @@ window.appCitations = (() => {
    *   - "poetry" → block-style chip on its own line (ADR-022 §6 운문 예외)
    *   - "prose"  → inline chip following the segment text
    *
-   * The chip is a `<button>` for keyboard accessibility. Data attributes
-   * carry src/tradition/parallels for the C3 click delegation.
+   * Rendered as `<span role="button">` rather than a native `<button>`: the
+   * browser forces `<button>` to display:inline-block, so a long chip label
+   * (tradition + src + several parallels) can never break across lines — it
+   * wraps as one atomic box and drops wholesale to the next line. A span flows
+   * inline like the surrounding text, so a long label wraps mid-label at the
+   * ` · ` separators. Keyboard activation (Enter/Space) is wired manually in
+   * `initCiteSheet` since a span gets none for free. Data attributes carry
+   * src/tradition/parallels for the click delegation.
    *
    * @param {string} src
    * @param {ReadonlyArray<string> | null | undefined} parallels
@@ -105,14 +111,15 @@ window.appCitations = (() => {
     const cls = segmentType === "poetry" ? "cite-chip cite-chip--poetry" : "cite-chip";
     /** @type {Record<string, string>} */
     const attrs = {
-      type: "button",
+      role: "button",
+      tabindex: "0",
       className: cls,
       "data-cite-src": src,
       "aria-label": `인용 출처 ${label} — 본문 보기`,
     };
     if (tradition) attrs["data-cite-tradition"] = tradition;
     if (parallels && parallels.length) attrs["data-cite-parallels"] = parallels.join(";");
-    return el("button", attrs, label);
+    return el("span", attrs, label);
   }
 
   /**
@@ -941,11 +948,24 @@ window.appCitations = (() => {
         }
         return;
       }
-      // Enter / Space activates a focused note anchor (span role=button needs
-      // manual key handling; a native <button> would do this for us).
+      // Enter / Space activates a focused cite chip or note anchor (both are
+      // span role=button and need manual key handling; a native <button> would
+      // do this for us).
       if (e.key === "Enter" || e.key === " ") {
         const target = e.target;
-        if (target instanceof HTMLElement && target.classList.contains("note-anchor")) {
+        if (!(target instanceof HTMLElement)) return;
+        if (target.classList.contains("cite-chip")) {
+          e.preventDefault();
+          const src = target.getAttribute("data-cite-src");
+          if (!src) return;
+          const parallelsRaw = target.getAttribute("data-cite-parallels") || "";
+          const parallels = parallelsRaw
+            ? parallelsRaw.split(";").map((p) => p.trim()).filter(Boolean)
+            : null;
+          const tradition = target.getAttribute("data-cite-tradition") || null;
+          _markCoachmarkSeen();
+          openCiteSheet(src, parallels, tradition, target);
+        } else if (target.classList.contains("note-anchor")) {
           e.preventDefault();
           const anchor = target.getAttribute("data-note-anchor") || target.textContent || "";
           const body   = target.getAttribute("data-note-body")   || "";

--- a/tests/unit/citations.test.js
+++ b/tests/unit/citations.test.js
@@ -204,8 +204,9 @@ test("chipText: empty parallels array treated as no parallels", () => {
 test("buildCiteChip: prose → inline class only", () => {
   const c = loadCitations();
   const node = c.buildCiteChip("이사 53:5", null, null, "prose");
-  assert.equal(node.tag, "button");
-  assert.equal(node.attrs.type, "button");
+  assert.equal(node.tag, "span");
+  assert.equal(node.attrs.role, "button");
+  assert.equal(node.attrs.tabindex, "0");
   assert.equal(node.attrs.className, "cite-chip");
   assert.equal(node.attrs["data-cite-src"], "이사 53:5");
   assert.equal(node.attrs["data-cite-tradition"], undefined);


### PR DESCRIPTION
## 문제

인용 칩이 길어지면(예: tradition + src + parallels 여러 개) 칩이 **통째로 다음 줄로** 떨어지고, 행 중간에서 줄바꿈되지 않았습니다.

## 원인

칩이 native `<button>` 요소였습니다. 브라우저는 `<button>` 을 `display:inline-block` 으로 강제하므로, 라벨이 길어도 atomic한 박스로 취급돼 내부에서 줄바꿈되지 못하고 통째로 다음 줄에 떨어집니다.

같은 파일의 주석 anchor(`_wrapAnchor`)는 이미 똑같은 이유로 `<button>` 대신 `<span role="button">` 을 쓰고 있었습니다 (코드 주석에 명시).

## 변경

- `buildCiteChip` 이 `<button>` 대신 `<span role="button" tabindex="0">` 을 렌더. span 은 주변 본문처럼 인라인으로 흘러 긴 라벨이 `·` 구분자 지점에서 자연스럽게 줄바꿈됩니다.
- span 은 Enter/Space 기본 활성화가 없으므로 `initCiteSheet` 의 keydown 핸들러에서 칩 활성화(시트 열기)를 수기로 처리.
- 유닛 테스트(`tests/unit/citations.test.js`)의 태그·속성 기대값 갱신.
- ADR-022 에 개정 블록 추가.

## 검증

- `node --test tests/unit/*.test.js` → 535 케이스 통과
- `npx tsc -p tsconfig.json --noEmit` → 신규 타입 에러 없음 (기존 config deprecation 경고만)

키보드/포커스 동작과 시각 변화는 로컬 e2e 로 추가 확인 권장.

https://claude.ai/code/session_01NB7e6eKBBV5tPJ24B5aBTo

---
_Generated by [Claude Code](https://claude.ai/code/session_01NB7e6eKBBV5tPJ24B5aBTo)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> 표시·접근성 마크업과 키보드 핸들러만 바뀌며, 클릭 위임·시트 동작은 기존과 동일합니다.
> 
> **Overview**
> **인용 칩**이 긴 라벨(tradition + 출처 + 병행 구절)일 때 행 중간에서 줄바꿈되지 않고 통째로 다음 줄로 떨어지던 문제를 고칩니다. `buildCiteChip`이 native `<button>` 대신 `<span role="button" tabindex="0">`를 쓰도록 바꿔, 주석 anchor와 같이 인라인 흐름에서 `·` 구분자 지점에서 자연스럽게 줄바꿈되게 합니다.
> 
> `initCiteSheet`의 keydown 처리에 **포커스된 cite 칩**에 대한 Enter/Space → 인용 시트 열기를 추가하고, ADR-022에 2026-05-29 개정을, 유닛 테스트의 태그·속성 기대값을 span 기준으로 갱신합니다.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b33b1dca87aa3bee23f7278b32cb980cfc25d5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->