### PR TITLE
fix: 읽기 헤더 긴 책 제목 모바일 줄이기 동작 복구

### DIFF
--- a/js/app/views-routing.js
+++ b/js/app/views-routing.js
@@ -698,15 +698,24 @@ function measureTitleCompactness() {
   // to right: 2.4rem, so the right side reserves ~4.6rem, not 2.2rem. The old
   // fixed 5.2rem matched only the desktop layout, leaving mobile titles to
   // collide with the bookmark/gear.
+  //
+  // Use getBoundingClientRect, not getComputedStyle left/right: for an
+  // abs-positioned element the browser resolves *both* insets to used pixels
+  // even when only one was authored, so a left-anchored button would report a
+  // right inset of ~full width and bogusly inflate the opposite side. Geometry
+  // sidesteps that — classify each button by whichever container edge it sits
+  // closer to, then take only that side's inward intrusion.
+  const titleRect = $title.getBoundingClientRect();
   let leftReserve = 0;
   let rightReserve = 0;
   for (const b of $title.querySelectorAll(".title-back-btn, .title-bookmark-btn, .title-settings-btn")) {
-    const cs = getComputedStyle(b);
-    const w = /** @type {HTMLElement} */ (b).offsetWidth;
-    const left = parseFloat(cs.left);
-    const right = parseFloat(cs.right);
-    if (Number.isFinite(left)) leftReserve = Math.max(leftReserve, left + w);
-    if (Number.isFinite(right)) rightReserve = Math.max(rightReserve, right + w);
+    const r = b.getBoundingClientRect();
+    if (r.width === 0) continue; // hidden at this breakpoint (e.g. desktop gear)
+    if (r.left - titleRect.left <= titleRect.right - r.right) {
+      leftReserve = Math.max(leftReserve, r.right - titleRect.left);
+    } else {
+      rightReserve = Math.max(rightReserve, titleRect.right - r.left);
+    }
   }
   const breathing = 0.8 * rem;
   const sideReserve = Math.max(leftReserve, rightReserve) + breathing;

--- a/js/app/views-routing.js
+++ b/js/app/views-routing.js
@@ -652,6 +652,20 @@ function applyTitleCompactness() {
     _titleResizeObs.observe($title);
   }
 
+  // Defer the actual measurement to the next frame. Several render paths append
+  // the settings gear *after* calling setTitle/setTitleWithChapterPicker, and on
+  // mobile that gear is part of the right-side reservation — measuring before
+  // it lands would undercount the reserved space. rAF also lets layout and web
+  // fonts settle so offsetWidth reflects the final rendered title.
+  if (typeof requestAnimationFrame === "function") {
+    requestAnimationFrame(measureTitleCompactness);
+  } else {
+    measureTitleCompactness();
+  }
+}
+
+function measureTitleCompactness() {
+  if (!$title) return;
   const full = /** @type {HTMLElement | null} */ ($title.querySelector(".title-text-full"));
   const mobile = $title.querySelector(".title-text-mobile");
   if (!full || !mobile) {
@@ -673,11 +687,32 @@ function applyTitleCompactness() {
   full.style.display = prevDisplay;
 
   const rem = parseFloat(getComputedStyle(document.documentElement).fontSize) || 16;
-  // 2.2rem back + 2.2rem bookmark + 0.8rem breathing on either side.
-  const reserved = 5.2 * rem;
+  // The title text is centered (text-align: center) while the home / bookmark /
+  // settings buttons are absolute-positioned at the edges. A centered string
+  // overruns whichever side reaches furthest inward, symmetrically — so the room
+  // for the text is clientWidth − 2 × (largest side reservation). Measure the
+  // real buttons from the live DOM rather than hardcoding, because the layout
+  // differs by breakpoint: on desktop the bookmark sits flush right (right: 0)
+  // and the settings gear lives in the top row (absent here); on mobile the
+  // settings gear is minted into this row at right: 0 and the bookmark is inset
+  // to right: 2.4rem, so the right side reserves ~4.6rem, not 2.2rem. The old
+  // fixed 5.2rem matched only the desktop layout, leaving mobile titles to
+  // collide with the bookmark/gear.
+  let leftReserve = 0;
+  let rightReserve = 0;
+  for (const b of $title.querySelectorAll(".title-back-btn, .title-bookmark-btn, .title-settings-btn")) {
+    const cs = getComputedStyle(b);
+    const w = /** @type {HTMLElement} */ (b).offsetWidth;
+    const left = parseFloat(cs.left);
+    const right = parseFloat(cs.right);
+    if (Number.isFinite(left)) leftReserve = Math.max(leftReserve, left + w);
+    if (Number.isFinite(right)) rightReserve = Math.max(rightReserve, right + w);
+  }
+  const breathing = 0.8 * rem;
+  const sideReserve = Math.max(leftReserve, rightReserve) + breathing;
   // Picker button has a ~0.4em chevron after the label — allow for it.
   const chevronAllowance = container.classList.contains("title-picker-btn") ? 0.8 * rem : 0;
-  const availableWidth = $title.clientWidth - reserved;
+  const availableWidth = $title.clientWidth - 2 * sideReserve;
 
   if (naturalWidth + chevronAllowance > availableWidth + 0.5) {
     $title.classList.add("compact");


### PR DESCRIPTION
## 문제

읽기 헤더에서 책 이름이 길 때 짧은 이름으로 줄여주는 기능이 **모바일에서 동작하지 않아** 레이아웃이 깨졌다. 예: `히브리인들에게 보낸 편지 10장` 이 `히브리서 10장` 으로 줄지 않고 책갈피·설정 버튼과 겹침.

[깨진 레이아웃: 긴 제목이 책갈피·톱니 아이콘과 겹침]

## 원인

`applyTitleCompactness`(`js/app/views-routing.js`)가 제목이 들어갈 폭을 계산할 때:

1. **비대칭 차감** — 제목은 `text-align: center` 인데, 예약 폭을 `clientWidth − 5.2rem` 으로 한 번만 뺐다. 가운데 정렬 텍스트는 좌/우 버튼 중 더 안쪽까지 들어온 쪽과 대칭으로 겹치므로 `clientWidth − 2 × max(좌, 우 예약)` 이 맞다.
2. **하드코딩한 5.2rem 이 데스크탑 전용** — `2.2(홈) + 2.2(책갈피) + 0.8(여백)` 은 데스크탑 배치에만 우연히 맞았다. 모바일은 제목 행에 설정 톱니(`right: 0`)와 책갈피(`right: 2.4rem`)가 **둘 다** 들어가 우측 예약이 약 `4.6rem` 으로 훨씬 크다. JS는 공간이 충분하다고 오판해 `.compact` 를 붙이지 않았다.
3. **측정 시점** — 일부 렌더 경로가 `setTitle`/`setTitleWithChapterPicker` **이후**에 설정 톱니를 append 해서, 동기 측정 시점엔 모바일 톱니가 아직 DOM에 없었다.

## 수정

- 예약 폭을 **실제 버튼**(`.title-back-btn` / `.title-bookmark-btn` / `.title-settings-btn`)의 `left/right + offsetWidth` 에서 측정 → breakpoint별 배치(데스크탑 톱니는 top row·`display:none`, 모바일 톱니는 제목 행)를 자동 반영.
- 가운데 정렬 기준에 맞춰 `availableWidth = clientWidth − 2 × max(좌, 우 예약)` 로 계산.
- 측정을 `requestAnimationFrame` 으로 지연 → 설정 톱니 append 이후의 최종 레이아웃·웹폰트가 반영된 상태에서 판정.

데스크탑 동작은 유지(기존 5.2rem ≈ 새 공식의 데스크탑 결과 2×2.2+0.8). 모바일에서는 긴 NT 서간 제목이 `NT_MOBILE_NAME` 짧은 이름으로 정상 축약된다.

## 테스트

- `node --test tests/unit/*.test.js` → **536 통과 / 0 실패**
- `npx tsc -p tsconfig.json --noEmit` → 0 error
- DOM 기하 측정 로직이라 유닛에서는 stub 처리(기존과 동일) — 실기기 검증 권장.

https://claude.ai/code/session_01Fc1jyawaxFhc3TdALs82xJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fc1jyawaxFhc3TdALs82xJ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized header layout/overflow logic in views-routing.js with no auth, data, or API impact; desktop behavior should stay equivalent.
> 
> **Overview**
> Restores **long reading-header titles** switching to the shortened mobile label on narrow viewports by fixing how `#page-title` decides to add `.compact`.
> 
> **Measurement timing:** the overflow check runs in a new `measureTitleCompactness` step, scheduled with `requestAnimationFrame` from `applyTitleCompactness`, so layout includes the settings gear when some routes append it after `setTitle` / `setTitleWithChapterPicker`, and font/layout can settle before measuring.
> 
> **Available width:** replaces a single fixed `5.2rem` deduction with live geometry from `.title-back-btn`, `.title-bookmark-btn`, and `.title-settings-btn` via `getBoundingClientRect`, classifying each control to the left or right edge. For centered title text, usable width is now `clientWidth − 2 × (max side reserve + breathing)`, which matches mobile’s larger right-side chrome (bookmark + settings) instead of desktop-only assumptions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit affaf61c90a7b09b851b498b2e4f5291a8857674. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->