### PR TITLE
style: 장 선택 팝오버 내부를 장 목록 화면과 동일한 카드 격자로 통일

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -838,7 +838,8 @@ body {
   left: 50%;
   transform: translateX(-50%);
   z-index: 20;
-  background: var(--bg-card);
+  /* 장 목록 화면과 동일한 figure/ground: 카드(--bg-card)가 격자 배경(--bg) 위에서 도드라지도록 */
+  background: var(--bg);
   border: 1px solid var(--border);
   border-radius: 12px;
   box-shadow: 0 8px 28px rgba(0, 0, 0, 0.18);
@@ -850,70 +851,69 @@ body {
   min-width: 15rem;
 }
 
+/* 장 목록 화면(.chapter-grid)과 동일한 카드 격자 언어를 공유 — 셀 크기만 팝오버 폭에 맞춤 */
 .popover-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(2.6rem, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(2.8rem, 1fr));
   gap: 0.4rem;
 }
 
-/* 머리말: 숫자 격자 위에 전체 폭 라벨 행으로 분리 — 점선 사각형 대신 알약형 버튼 */
-.popover-prologue {
-  grid-column: 1 / -1;
-  /* .popover-item 의 aspect-ratio:1 을 해제 — 전체 폭 행이 정사각형이 되지 않도록 */
-  aspect-ratio: auto;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.35em;
-  padding: 0.5rem;
-  margin-bottom: 0.15rem;
-  font-size: 0.8rem;
-  font-weight: 600;
-  color: var(--accent);
-  background: color-mix(in srgb, var(--accent) 8%, transparent);
-  border: 1px solid color-mix(in srgb, var(--accent) 30%, transparent);
-  border-radius: 8px;
-  text-decoration: none;
-  transition: background 0.12s;
-}
-
-.popover-prologue:hover,
-.popover-prologue:focus-visible {
-  background: color-mix(in srgb, var(--accent) 16%, transparent);
-}
-
+/* .chapter-grid a 와 동일한 카드: 흰 배경 + 테두리 + 공용 radius */
 .popover-item {
   display: flex;
   align-items: center;
   justify-content: center;
   aspect-ratio: 1;
-  font-size: 0.85rem;
+  font-size: 0.9rem;
   font-variant-numeric: tabular-nums;
   text-decoration: none;
   color: var(--text);
-  background: var(--bg);
-  border-radius: 8px;
-  transition: background 0.12s, color 0.12s;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  transition: background 0.15s;
 }
 
-/* hover/focus는 옅은 accent 틴트 — 현재 장(꽉 찬 accent)과 시각적으로 구분 */
+/* hover/focus: .chapter-grid a 와 동일한 꽉 찬 accent */
 .popover-item:hover,
 .popover-item:focus-visible {
-  background: color-mix(in srgb, var(--accent) 14%, transparent);
-  color: var(--accent);
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
 }
 
-/* 현재 보고 있는 장: 꽉 찬 accent + 링으로 "여기 있음"을 명확히 */
+/* 현재 보고 있는 장: 꽉 찬 accent + 링으로 "여기 있음"을 명확히 (팝오버 고유의 위치 표시) */
 .popover-item.current {
   background: var(--accent);
   color: #fff;
+  border-color: var(--accent);
   font-weight: 700;
-  box-shadow: 0 0 0 2px var(--bg-card), 0 0 0 4px color-mix(in srgb, var(--accent) 55%, transparent);
+  /* 링 안쪽 간격색은 팝오버 배경(--bg)과 맞춰 "띄운 링"처럼 보이게 함 */
+  box-shadow: 0 0 0 2px var(--bg), 0 0 0 4px color-mix(in srgb, var(--accent) 55%, transparent);
 }
 
 .popover-item.current:hover,
 .popover-item.current:focus-visible {
   background: var(--accent);
+  color: #fff;
+}
+
+/* 머리말: 숫자 격자 위에 전체 폭 라벨 행 — .chapter-grid 의 .prologue-link 와 동일 톤.
+   .popover-item 보다 뒤에 선언해 color/aspect-ratio override 가 확실히 적용되도록 함. */
+.popover-prologue {
+  grid-column: 1 / -1;
+  /* .popover-item 의 aspect-ratio:1 을 해제 — 전체 폭 행이 정사각형이 되지 않도록 */
+  aspect-ratio: auto;
+  gap: 0.35em;
+  padding: 0.5rem;
+  margin-bottom: 0.15rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.popover-prologue:hover,
+.popover-prologue:focus-visible {
   color: #fff;
 }
 


### PR DESCRIPTION
## 배경

읽기 헤더의 장 제목을 탭하면 열리는 **장 선택 팝오버**(`.chapter-popover`)의 내부 디자인이, 각 책으로 들어갔을 때 보이는 **장 목록 화면**(`.chapter-grid`)과 달랐다.

| | 장 목록 화면 | 팝오버(기존) |
|---|---|---|
| 카드 배경 | 흰색 `--bg-card` | 옅은 크림 `--bg` |
| 테두리 | `1px solid --border` | 없음 |
| hover/focus | 꽉 찬 accent + 흰 글자 | 옅은 accent 틴트 |
| 모서리 | `--radius` (8px) | 8px (하드코딩) |

같은 "장을 고르는" 격자인데 두 화면의 시각 언어가 달라 일관성이 떨어졌다.

## 변경 내용

장 선택 팝오버 내부를 `.chapter-grid`와 동일한 카드 격자 언어로 통일했다 (CSS only, `css/style.css`).

- **`.popover-item`** — 테두리 없는 타일 → 흰 카드(`--bg-card`) + `1px solid --border` + 공용 `--radius`. hover/focus도 꽉 찬 accent 채움으로 `.chapter-grid a`와 일치.
- **`.chapter-popover` 컨테이너 배경** — `--bg-card` → `--bg`(크림). 흰 카드가 도드라지는 figure/ground 관계를 장 목록 화면과 동일하게 재현 (라이트·다크 테마 모두 성립).
- **`.popover-prologue`(머리말)** — `.popover-item` 뒤로 선언 순서를 옮겨 `color`/`aspect-ratio` override가 확실히 적용되도록 하고, 장 목록의 `.prologue-link` 톤과 일치시킴.
- **현재 장 링** — 안쪽 간격색을 새 컨테이너 배경(`--bg`)에 맞춰 "띄운 링" 효과 유지. 현재 보고 있는 장을 명확히 표시하는 역할은 팝오버 고유 기능이라 유지.

## 검증

- `node --test tests/unit/*.test.js` — 536 케이스 전부 통과 (스타일 전용 변경)
- 시각 확인은 dev 서버에서 라이트/다크 + 외경 설정 토글로 권장

ADR-024(헤더 내비 재설계) 맥락의 후속 UI 일관성 작업입니다.

https://claude.ai/code/session_01KSuuWzQy8SmGDcfbKuEGpA

---
_Generated by [Claude Code](https://claude.ai/code/session_01KSuuWzQy8SmGDcfbKuEGpA)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only CSS for the chapter popover; no logic, data, or auth paths touched.
> 
> **Overview**
> The reading header **chapter picker popover** (`.chapter-popover` / `.popover-grid`) is restyled in `css/style.css` so it matches the book **chapter list** (`.chapter-grid`): cream popover surface (`--bg`), white bordered cells (`--bg-card`), shared `--radius`, and solid accent on hover/focus instead of light tint tiles.
> 
> **`.popover-prologue`** is moved below `.popover-item` in the stylesheet so full-width prologue rows inherit the right overrides and align with `.prologue-link` on the chapter screen. The **current chapter** ring shadow uses `--bg` so it still reads correctly on the new background. Grid min cell width is bumped slightly (`2.6rem` → `2.8rem`). No JS or markup changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4699112d6bf4ecd0da8b1a8934abbb1dec2a2615. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->