### PR TITLE
style: 헤더 아이콘 확대·설정/배속 버튼 테마색·FAB 그림자 보강

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -256,7 +256,7 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  color: var(--text-secondary);
+  color: var(--accent);
   background: none;
   border: none;
   cursor: pointer;
@@ -265,7 +265,7 @@ body {
 }
 
 .settings-btn:hover {
-  color: var(--accent);
+  opacity: 0.7;
 }
 
 .settings-popover {
@@ -778,8 +778,8 @@ body {
 }
 
 .title-back-icon {
-  width: 1.25rem;
-  height: 1.25rem;
+  width: 1.45rem;
+  height: 1.45rem;
 }
 
 /* ── Chapter Picker ── */
@@ -1154,7 +1154,7 @@ body {
   background: var(--accent);
   color: var(--bg);
   cursor: pointer;
-  box-shadow: 0 3px 12px rgba(0, 0, 0, 0.25);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.18), 0 8px 20px rgba(0, 0, 0, 0.3);
   align-items: center;
   justify-content: center;
   transition: transform 0.15s ease, box-shadow 0.15s ease, bottom 0.25s ease;
@@ -1162,7 +1162,7 @@ body {
 
 #search-fab:hover {
   transform: scale(1.08);
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.22), 0 12px 28px rgba(0, 0, 0, 0.35);
 }
 
 #search-fab:active {
@@ -3027,19 +3027,18 @@ html.cite-sheet-open {
   width: 3rem;
   text-align: center;
   padding: 0.15rem 0;
-  border: 1px solid var(--border);
+  border: 1px solid var(--accent);
   border-radius: 0.3rem;
   background: transparent;
-  color: var(--text-secondary);
+  color: var(--accent);
   font-size: 0.72rem;
   font-variant-numeric: tabular-nums;
   cursor: pointer;
-  transition: color 0.15s ease, border-color 0.15s ease;
+  transition: color 0.15s ease, border-color 0.15s ease, background-color 0.15s ease;
 }
 
 .audio-speed-btn:hover {
-  color: var(--text);
-  border-color: var(--text-secondary);
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
 }
 
 /* Unavailable message — sized to match .audio-player so the sticky bar

--- a/css/style.css
+++ b/css/style.css
@@ -777,7 +777,14 @@ body {
   opacity: 0.4;
 }
 
-.title-back-icon {
+/* All header-row icons (home/back, bookmark, settings gear) are sized here in
+   rem so they scale together with the user's font-size setting (applyFontSize
+   sets the root font-size). Sizing lives in CSS only — the SVGs must NOT carry
+   width/height attributes in JS, or they'd lock to px and drift from the text
+   scale, leaving the three icons mismatched at large font sizes. */
+.title-back-icon,
+.title-bookmark-btn svg,
+.settings-btn svg {
   width: 1.45rem;
   height: 1.45rem;
 }

--- a/js/app/bookmark.js
+++ b/js/app/bookmark.js
@@ -805,8 +805,8 @@ function buildBookmarkHeaderBtn(bookId, chapter) {
     btn.classList.add("has-bookmark");
   }
   const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
-  svg.setAttribute("width", "22");
-  svg.setAttribute("height", "22");
+  svg.setAttribute("width", "25");
+  svg.setAttribute("height", "25");
   svg.setAttribute("viewBox", "0 -960 960 960");
   svg.setAttribute("fill", "currentColor");
   svg.setAttribute("aria-hidden", "true");

--- a/js/app/bookmark.js
+++ b/js/app/bookmark.js
@@ -805,8 +805,7 @@ function buildBookmarkHeaderBtn(bookId, chapter) {
     btn.classList.add("has-bookmark");
   }
   const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
-  svg.setAttribute("width", "25");
-  svg.setAttribute("height", "25");
+  // Size comes from CSS (.title-bookmark-btn svg) in rem — see style.css header-icon rule.
   svg.setAttribute("viewBox", "0 -960 960 960");
   svg.setAttribute("fill", "currentColor");
   svg.setAttribute("aria-hidden", "true");

--- a/js/app/settings-ui.js
+++ b/js/app/settings-ui.js
@@ -329,8 +329,8 @@ window.appSettings = (() => {
     function makeGearBtn() {
       const b = el("button", { className: "settings-btn", type: "button", "aria-label": "설정", "aria-expanded": "false" });
       const settingsSvg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
-      settingsSvg.setAttribute("width", "18");
-      settingsSvg.setAttribute("height", "18");
+      settingsSvg.setAttribute("width", "21");
+      settingsSvg.setAttribute("height", "21");
       settingsSvg.setAttribute("viewBox", "0 0 24 24");
       settingsSvg.setAttribute("fill", "none");
       settingsSvg.setAttribute("stroke", "currentColor");

--- a/js/app/settings-ui.js
+++ b/js/app/settings-ui.js
@@ -329,8 +329,7 @@ window.appSettings = (() => {
     function makeGearBtn() {
       const b = el("button", { className: "settings-btn", type: "button", "aria-label": "설정", "aria-expanded": "false" });
       const settingsSvg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
-      settingsSvg.setAttribute("width", "21");
-      settingsSvg.setAttribute("height", "21");
+      // Size comes from CSS (.settings-btn svg) in rem — see style.css header-icon rule.
       settingsSvg.setAttribute("viewBox", "0 0 24 24");
       settingsSvg.setAttribute("fill", "none");
       settingsSvg.setAttribute("stroke", "currentColor");


### PR DESCRIPTION
## 요약

읽기 화면의 UI 디테일을 다듬고, 헤더 아이콘 크기 지정 방식을 일원화했습니다.

## 변경 내용

### 1. 설정 버튼 · 오디오 배속 버튼 아웃라인에 테마색 적용
- 설정 기어 아이콘을 `--text-secondary` → `--accent`(테마색)로 변경, hover는 opacity로 처리
- 배속(1x) 버튼 테두리·글자를 `--accent`로, hover 시 옅은 accent 배경

### 2. 헤더 아이콘 확대 + 크기 지정 방식 일원화
- 홈/뒤로·북마크·설정 기어 세 아이콘을 **rem 기반 CSS 한 곳**(`.title-back-icon` 그룹 규칙)으로 통합, `1.45rem`으로 통일
- 북마크·기어 SVG의 **인라인 px `width/height` 속성 제거** → 크기는 CSS가 담당, JS는 `viewBox`만 설정
- 효과: 설정에서 글자 크기를 바꾸면 세 아이콘이 **함께 스케일**됨 (이전엔 홈만 rem이라 따라 커지고 북마크·기어는 px 고정이라 어긋났음)

### 3. 검색 FAB 그림자 보강
- 단일 그림자 → 2단 elevation 그림자(`0 4px 8px` + `0 8px 20px`)로 아래쪽 입체감 강화, hover도 함께 강화

## 검증

- `node --test` 영향 모듈(settings-ui, bookmark, views-routing) 158 케이스 통과
- 순수 CSS/아이콘 크기 변경, 기능 로직 변화 없음

## 커밋

1. `style:` 헤더 아이콘 확대·설정/배속 버튼 테마색·FAB 그림자 보강
2. `refactor:` 헤더 아이콘 크기 지정 방식 rem 기반 CSS로 일원화

https://claude.ai/code/session_01RpVN4zEG9LX7Pxa2NhWLd8