### PR TITLE
chore: sync-data 워크플로를 PR + auto-merge 흐름으로 전환

### DIFF
--- a/.github/workflows/sync-data.yml
+++ b/.github/workflows/sync-data.yml
@@ -94,5 +94,8 @@ jobs:
             --base main \
             --head "$BRANCH" \
             --title 'data: 서브모듈 포인터 + sitemap 갱신' \
-            --body 'data 저장소 build.yml 산출물 commit 직후 자동 생성된 PR. Unit tests 통과 시 자동 squash 머지 + 브랜치 삭제.'
-          gh pr merge "$BRANCH" --auto --squash --delete-branch
+            --body 'data 저장소 build.yml 산출물 commit 직후 자동 생성된 PR. Unit tests 통과 시 자동 squash 머지.'
+          # --delete-branch 는 클라이언트 측 작업이라 --auto 의 서버 비동기 머지
+          # 시점에는 동작하지 않는다. 브랜치 정리는 repo 설정
+          # delete_branch_on_merge 가 처리한다.
+          gh pr merge "$BRANCH" --auto --squash

--- a/.github/workflows/sync-data.yml
+++ b/.github/workflows/sync-data.yml
@@ -1,23 +1,30 @@
-name: Sync data submodule and release
+name: Sync data submodule
 
-# data 저장소의 build.yml 이 산출물을 main에 푸시한 직후 호출하는
+# data 저장소의 build.yml 이 산출물을 main 에 푸시한 직후 호출하는
 # workflow_dispatch 를 받아, data 서브모듈 포인터를 최신 main 으로
-# 업데이트하고 release.py patch 로 셸 버전을 bump + 자동 commit + push.
-# 사람 손이 들어가지 않는다.
+# 업데이트하고 sitemap 을 재생성한다.
 #
-# repository_dispatch 대신 workflow_dispatch 를 쓰는 이유: PAT 권한 최소화.
-# repository_dispatch 는 Contents:Write 가 필요한데 common-bible 이 공개
-# 저장소라 PAT 누출 시 공개 push 위험. workflow_dispatch 는 Actions:Write
-# 만으로 충분하며 트리거 대상이 이 워크플로우 하나로 한정된다.
+# 브랜치 보호(2026-05-29 적용) 때문에 main 직접 push 가 거부된다.
+# 따라서 sync/data-<run_id> 토픽 브랜치로 push 한 뒤 PR 을 만들고,
+# Unit tests CI 통과 시 자동 squash 머지하도록 한다 (auto-merge).
+#
+# PAT 두 개 분리:
+#   - SUBMODULE_AND_DISPATCH_PAT — common-bible-data·audio Contents:Read +
+#     common-bible Actions:Write (workflow_dispatch 트리거). 누출 시 영향
+#     범위를 좁히기 위해 PR 관련 권한은 부여하지 않는다.
+#   - SYNC_DATA_PR_PAT — common-bible 의 Contents:Write + Pull requests:Write.
+#     PR 생성·auto-merge 활성화 전용. GITHUB_TOKEN 으로 만든 PR 은
+#     pull_request 트리거를 발화하지 않아 Unit tests 가 실행되지 않으므로
+#     PAT 가 필수.
 #
 # main push 자체는 production 이 아님 (ADR-020: server 저장소의 deploy.sh
-# 가 별도 promote 단계). 따라서 자동 push 도 안전.
+# 가 별도 promote 단계). 따라서 자동 PR 머지도 안전.
 
 on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   sync:
@@ -25,9 +32,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          # self-checkout 은 기본 GITHUB_TOKEN 사용 — workflow 의 permissions:
-          # contents:write 와 결합해 push 까지 처리. data·audio 서브모듈은 private
-          # 이라 GITHUB_TOKEN 으로 클론 불가 → 아래 별도 step 에서 PAT 로 처리.
+          # PR 흐름용 PAT 로 체크아웃 — 이후 토픽 브랜치 push 가 pull_request
+          # 트리거를 발화시켜 Unit tests CI 가 PR 에서 실행되도록 한다.
+          token: ${{ secrets.SYNC_DATA_PR_PAT }}
           submodules: false
           fetch-depth: 0
 
@@ -38,8 +45,8 @@ jobs:
       - name: data + audio 서브모듈을 PAT 로 별도 클론
         env:
           SUBMODULE_PAT: ${{ secrets.SUBMODULE_AND_DISPATCH_PAT }}
-          # audio mp3 본 바이너리는 필요 없음 — release.py 는 서브모듈 포인터만
-          # 다루고, manifest 는 data 저장소 CI 가 이미 갱신해놓은 상태.
+          # audio mp3 바이너리는 필요 없음 — release.py 가 더 이상 호출되지
+          # 않고 sitemap 생성에도 LFS 본 바이트가 필요 없음.
           GIT_LFS_SKIP_SMUDGE: "1"
         run: |
           git config --global \
@@ -56,16 +63,36 @@ jobs:
       - name: sitemap.xml 재생성
         run: python scripts/build_sitemap.py
 
-      - name: 서브모듈 포인터 + sitemap commit
+      - name: 변경 여부 확인
+        id: check
+        run: |
+          if git diff --quiet data sitemap.xml; then
+            echo "변경 없음 — 워크플로 종료"
+            echo "changed=false" >> $GITHUB_OUTPUT
+          else
+            echo "changed=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: 토픽 브랜치 생성 + commit + push
+        if: steps.check.outputs.changed == 'true'
         run: |
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          BRANCH="sync/data-${{ github.run_id }}"
+          git checkout -b "$BRANCH"
           git add data sitemap.xml
-          if git diff --cached --quiet; then
-            echo "no changes to commit"
-            exit 0
-          fi
           git commit -m 'data: 서브모듈 포인터 + sitemap 갱신'
+          git push -u origin "$BRANCH"
+          echo "BRANCH=$BRANCH" >> $GITHUB_ENV
 
-      - name: push
-        run: git push
+      - name: PR 생성 + auto-merge 활성화
+        if: steps.check.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_DATA_PR_PAT }}
+        run: |
+          gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title 'data: 서브모듈 포인터 + sitemap 갱신' \
+            --body 'data 저장소 build.yml 산출물 commit 직후 자동 생성된 PR. Unit tests 통과 시 자동 squash 머지 + 브랜치 삭제.'
+          gh pr merge "$BRANCH" --auto --squash --delete-branch

--- a/docs/decisions/021-pwa-versioning-content-hash.md
+++ b/docs/decisions/021-pwa-versioning-content-hash.md
@@ -185,3 +185,29 @@ DATA_CACHE / AUDIO_CACHE는 이제 rev 없는 고정 이름 (`"data"`, `"audio"`
 >
 > 회복 경로: 1.5.4 stale 에 갇힌 사용자는 1.5.5 SW install·activate
 > 시점에 자동 회복. 즉시 회복은 설정 → "캐시 초기화".
+
+> **개정 (2026-05-30):** sync-data.yml 을 PR 흐름으로 전환
+>
+> 2026-05-29 main 브랜치 보호 적용 후 sync-data.yml 의 직접 push 가
+> `Required status check "Unit tests" is expected` 로 거부되면서 webhook
+> 자동화가 깨졌다 (5월 30일 두 차례 sync 실패로 노출). 브랜치 보호는 유지하고
+> 자동화를 PR 흐름에 맞게 조정한다.
+>
+> 변경:
+>
+> 1. **sync/data-<run_id> 토픽 브랜치 + PR + auto-merge.** sync-data.yml 이
+>    main 직접 push 대신 토픽 브랜치로 push 한 뒤 `gh pr create` 로 PR 을
+>    만들고 `gh pr merge --auto --squash --delete-branch` 로 auto-merge 활성화.
+>    Unit tests 통과 시 자동 squash 머지 + 브랜치 삭제. 사람 손 여전히 안 들어감.
+>
+> 2. **PAT 분리.** 기존 `SUBMODULE_AND_DISPATCH_PAT` 은 권한 최소화 의도를
+>    유지하기 위해 그대로 두고, common-bible 의 Contents:Write +
+>    Pull requests:Write 만 가진 신규 `SYNC_DATA_PR_PAT` 을 추가. 토픽 브랜치
+>    push 와 PR 생성에 사용. `GITHUB_TOKEN` 으로 만든 PR 은 pull_request
+>    이벤트를 트리거하지 않아 Unit tests 가 발화하지 않으므로 PAT 가 필수.
+>
+> 3. **repo 설정 `allow_auto_merge: true`.** `gh pr merge --auto` 동작 조건.
+>
+> 4. **워크플로 이름 정리.** `Sync data submodule and release` →
+>    `Sync data submodule`. 2026-05-23 개정에서 release.py 호출이 이미
+>    제거되어 "and release" 가 실태와 어긋나 있었다.


### PR DESCRIPTION
## 요약

- 브랜치 보호(2026-05-29) 적용 후 sync-data.yml 의 main 직접 push 가 `Required status check "Unit tests" is expected` 로 거부되며 webhook 자동화가 깨졌다 (오늘 두 차례 sync 실패로 노출).
- 토픽 브랜치 push → `gh pr create` → `gh pr merge --auto --squash --delete-branch` 흐름으로 전환. Unit tests 통과 시 자동 머지.
- PAT 분리: 기존 `SUBMODULE_AND_DISPATCH_PAT` 권한 최소화 의도 유지, common-bible Contents:Write + Pull requests:Write 만 가진 신규 `SYNC_DATA_PR_PAT` 추가.
- repo 설정 `allow_auto_merge: true` 활성화 (이미 적용).
- ADR-021 개정 동봉.

## 머지 후 후속 작업

1. **(사용자 작업)** `SYNC_DATA_PR_PAT` Fine-grained PAT 발급 + secret 등록
   - Repository: `anglican-kr/common-bible` 만
   - Permissions: Contents R/W + Pull requests R/W (+ Metadata R 자동)
   - `gh secret set SYNC_DATA_PR_PAT --repo anglican-kr/common-bible`
2. 실패한 두 sync workflow 재실행 (workflow_dispatch) → 자동 PR 생성·머지 확인
3. dev 배포로 진행

## Test plan

- [ ] PR CI (Unit tests) 통과
- [ ] 머지 후 sync-data.yml workflow_dispatch 수동 트리거
- [ ] 새 PR 생성 + Unit tests 통과 + auto-merge 동작 확인
- [ ] `data` 서브모듈 포인터가 origin/main 의 최신 commit 으로 이동했는지 확인

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI/CD automation and introduces a new PAT with Contents/PR write on common-bible; misconfiguration could block data sync or weaken least-privilege if the secret is over-scoped.
> 
> **Overview**
> **Branch protection** on `main` (required **Unit tests**) blocked the data sync workflow’s direct pushes; this PR routes updates through **PR + auto-merge** instead.
> 
> `sync-data.yml` now checks out with **`SYNC_DATA_PR_PAT`**, updates the `data` submodule and regenerates `sitemap.xml`, and **exits early** when nothing changed. When there are changes, it pushes to **`sync/data-<run_id>`**, opens a PR with `gh pr create`, and enables **`gh pr merge --auto --squash`** so **Unit tests** can run and merge without human action. Submodule cloning still uses **`SUBMODULE_AND_DISPATCH_PAT`**; PR write/push uses the new PAT because **`GITHUB_TOKEN`** PRs do not fire `pull_request` CI. Workflow permissions drop to **`contents: read`** on the job token; the workflow name drops the obsolete “and release” suffix.
> 
> **ADR-021** adds a 2026-05-30 revision documenting this flow, PAT split, `allow_auto_merge`, and the rename.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc6b05addcb9d40904c55ebde5df7ce84b2696d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->