### PR TITLE
data: 서브모듈 포인터 + sitemap 갱신

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,23 +2,23 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://bible.anglican.kr/</loc>
-    <lastmod>2026-05-28T14:46:14Z</lastmod>
+    <lastmod>2026-05-30T07:46:17Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/privacy.html</loc>
-    <lastmod>2026-05-04T20:57:38+09:00</lastmod>
+    <lastmod>2026-05-30T00:42:30+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/gen</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T07:46:17Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/gen/1</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T07:46:17Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/gen/2</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T07:46:17Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/gen/3</loc>
@@ -26,7 +26,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/gen/4</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T07:46:17Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/gen/5</loc>
@@ -38,7 +38,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/gen/7</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T07:46:17Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/gen/8</loc>
@@ -50,11 +50,11 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/gen/10</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T07:46:17Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/gen/11</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T07:46:17Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/gen/12</loc>
@@ -86,7 +86,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/gen/19</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T07:46:17Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/gen/20</loc>
@@ -98,7 +98,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/gen/22</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T07:46:17Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/gen/23</loc>
@@ -118,11 +118,11 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/gen/27</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T07:46:17Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/gen/28</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T07:46:17Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/gen/29</loc>
@@ -130,15 +130,15 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/gen/30</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T07:46:17Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/gen/31</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T07:46:17Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/gen/32</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T07:46:17Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/gen/33</loc>
@@ -146,11 +146,11 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/gen/34</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T07:46:17Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/gen/35</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T07:46:17Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/gen/36</loc>
@@ -174,7 +174,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/gen/41</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T07:46:17Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/gen/42</loc>
@@ -186,7 +186,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/gen/44</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T07:46:17Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/gen/45</loc>
@@ -206,7 +206,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/gen/49</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T07:46:17Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/gen/50</loc>
@@ -214,7 +214,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/exod</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T07:46:17Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/exod/1</loc>
@@ -230,7 +230,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/exod/4</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T07:46:17Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/exod/5</loc>
@@ -242,7 +242,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/exod/7</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T07:46:17Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/exod/8</loc>
@@ -282,7 +282,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/exod/17</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T07:46:17Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/exod/18</loc>
@@ -298,7 +298,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/exod/21</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T07:46:17Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/exod/22</loc>
@@ -350,7 +350,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/exod/34</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T07:46:17Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/exod/35</loc>
@@ -378,7 +378,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/lev</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T07:46:17Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/lev/1</loc>
@@ -398,7 +398,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/lev/5</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T07:46:17Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/lev/6</loc>
@@ -422,7 +422,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/lev/11</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T07:46:17Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/lev/12</loc>
@@ -434,7 +434,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/lev/14</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T07:46:17Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/lev/15</loc>
@@ -442,7 +442,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/lev/16</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T07:46:17Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/lev/17</loc>
@@ -490,11 +490,11 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/num</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T07:46:17Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/num/1</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T07:46:17Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/num/2</loc>
@@ -502,7 +502,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/num/3</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T07:46:17Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/num/4</loc>
@@ -510,7 +510,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/num/5</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T07:46:17Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/num/6</loc>
@@ -530,11 +530,11 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/num/10</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T07:46:17Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/num/11</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T07:46:17Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/num/12</loc>
@@ -542,7 +542,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/num/13</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T07:46:17Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/num/14</loc>
@@ -558,7 +558,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/num/17</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T07:46:17Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/num/18</loc>
@@ -574,7 +574,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/num/21</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T07:46:17Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/num/22</loc>
@@ -610,7 +610,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/num/30</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T07:46:17Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/num/31</loc>
@@ -626,7 +626,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/num/34</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T07:46:17Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/num/35</loc>
@@ -638,7 +638,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/deut</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T07:46:17Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/deut/1</loc>
@@ -690,7 +690,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/deut/13</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T07:46:17Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/deut/14</loc>
@@ -730,11 +730,11 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/deut/23</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T07:46:17Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/deut/24</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T07:46:17Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/deut/25</loc>
@@ -750,11 +750,11 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/deut/28</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T07:46:17Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/deut/29</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T07:46:17Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/deut/30</loc>
@@ -766,11 +766,11 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/deut/32</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T07:46:17Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/deut/33</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T07:46:17Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/deut/34</loc>
@@ -778,11 +778,11 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/josh</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T07:46:17Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/josh/1</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T07:46:17Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/josh/2</loc>
@@ -798,7 +798,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/josh/5</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T07:46:17Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/josh/6</loc>
@@ -806,19 +806,19 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/josh/7</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T07:46:17Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/josh/8</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T07:46:17Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/josh/9</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T07:46:17Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/josh/10</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T07:46:17Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/josh/11</loc>
@@ -830,7 +830,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/josh/13</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T07:46:17Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/josh/14</loc>
@@ -838,7 +838,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/josh/15</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T07:46:17Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/josh/16</loc>
@@ -846,7 +846,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/josh/17</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T07:46:17Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/josh/18</loc>
@@ -866,11 +866,11 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/josh/22</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T07:46:17Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/josh/23</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T07:46:17Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/josh/24</loc>
@@ -3898,11 +3898,11 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/ezek</loc>
-    <lastmod>2026-05-23T06:10:02Z</lastmod>
+    <lastmod>2026-05-30T05:37:01Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/ezek/1</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T05:37:01Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/ezek/2</loc>
@@ -5414,67 +5414,67 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/jas</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T05:37:01Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/jas/1</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T05:37:01Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/jas/2</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T05:37:01Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/jas/3</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T05:37:01Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/jas/4</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T05:37:01Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/jas/5</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T05:37:01Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/1pet</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T05:37:01Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/1pet/1</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T05:37:01Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/1pet/2</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T05:37:01Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/1pet/3</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T05:37:01Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/1pet/4</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T05:37:01Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/1pet/5</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T05:37:01Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/2pet</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T05:37:01Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/2pet/1</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T05:37:01Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/2pet/2</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T05:37:01Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/2pet/3</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T05:37:01Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/1john</loc>
@@ -5518,31 +5518,31 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/jude</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T05:37:01Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/jude/1</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T05:37:01Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/rev</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T05:37:01Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/rev/1</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T05:37:01Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/rev/2</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T05:37:01Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/rev/3</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T05:37:01Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/rev/4</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T05:37:01Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/rev/5</loc>
@@ -5550,11 +5550,11 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/rev/6</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T05:37:01Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/rev/7</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T05:37:01Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/rev/8</loc>
@@ -5566,7 +5566,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/rev/10</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T05:37:01Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/rev/11</loc>
@@ -5574,11 +5574,11 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/rev/12</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T05:37:01Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/rev/13</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T05:37:01Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/rev/14</loc>
@@ -5602,7 +5602,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/rev/19</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T05:37:01Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/rev/20</loc>
@@ -5610,10 +5610,10 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/rev/21</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T05:37:01Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/rev/22</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T05:37:01Z</lastmod>
   </url>
 </urlset>


### PR DESCRIPTION
data 저장소 build.yml 산출물 commit 직후 자동 생성된 PR. Unit tests 통과 시 자동 squash 머지.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> SEO metadata-only sitemap timestamp updates with no application or auth changes.
> 
> **Overview**
> **`sitemap.xml`** only: many `<lastmod>` values are bumped to reflect pages that changed after the latest **data** build, not a change to URL list or sitemap structure.
> 
> Updates cluster around **2026-05-30T07:46:17Z** (home, privacy, and scattered **Pentateuch / historical** chapters through **Joshua**) and **2026-05-30T05:37:01Z** (**Ezekiel** plus **James** through **Revelation**). Unchanged entries keep older timestamps.
> 
> This matches the automated **sync-data** flow (`scripts/build_sitemap.py` after submodule refresh).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3b99fa806c2db39150e515bce6f8d62677c1c09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->