### PR TITLE
data: 서브모듈 포인터 + sitemap 갱신

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://bible.anglican.kr/</loc>
-    <lastmod>2026-05-30T07:46:17Z</lastmod>
+    <lastmod>2026-05-30T14:20:14Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/privacy.html</loc>
@@ -878,11 +878,11 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/judg</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T14:20:14Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/judg/1</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T14:20:14Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/judg/2</loc>
@@ -934,11 +934,11 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/judg/14</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T14:20:14Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/judg/15</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T14:20:14Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/judg/16</loc>
@@ -958,7 +958,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/judg/20</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T14:20:14Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/judg/21</loc>
@@ -966,15 +966,15 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/ruth</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T14:20:14Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/ruth/1</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T14:20:14Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/ruth/2</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T14:20:14Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/ruth/3</loc>
@@ -982,11 +982,11 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/ruth/4</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T14:20:14Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/1sam</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T14:20:14Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/1sam/1</loc>
@@ -994,7 +994,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/1sam/2</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T14:20:14Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/1sam/3</loc>
@@ -1038,11 +1038,11 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/1sam/13</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T14:20:14Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/1sam/14</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T14:20:14Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/1sam/15</loc>
@@ -1082,11 +1082,11 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/1sam/24</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T14:20:14Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/1sam/25</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T14:20:14Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/1sam/26</loc>
@@ -1114,7 +1114,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/2sam</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T14:20:14Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/2sam/1</loc>
@@ -1126,7 +1126,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/2sam/3</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T14:20:14Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/2sam/4</loc>
@@ -1134,19 +1134,19 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/2sam/5</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T14:20:14Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/2sam/6</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T14:20:14Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/2sam/7</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T14:20:14Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/2sam/8</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T14:20:14Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/2sam/9</loc>
@@ -1154,7 +1154,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/2sam/10</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T14:20:14Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/2sam/11</loc>
@@ -1190,31 +1190,31 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/2sam/19</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T14:20:14Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/2sam/20</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T14:20:14Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/2sam/21</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T14:20:14Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/2sam/22</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T14:20:14Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/2sam/23</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T14:20:14Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/2sam/24</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T14:20:14Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/1kgs</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T14:20:14Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/1kgs/1</loc>
@@ -1234,11 +1234,11 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/1kgs/5</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T14:20:14Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/1kgs/6</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T14:20:14Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/1kgs/7</loc>
@@ -1306,7 +1306,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/2kgs</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T14:20:14Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/2kgs/1</loc>
@@ -1366,7 +1366,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/2kgs/15</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T14:20:14Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/2kgs/16</loc>
@@ -1390,7 +1390,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/2kgs/21</loc>
-    <lastmod>2026-05-11T19:23:31+09:00</lastmod>
+    <lastmod>2026-05-30T14:20:14Z</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/2kgs/22</loc>


### PR DESCRIPTION
data 저장소 build.yml 산출물 commit 직후 자동 생성된 PR. Unit tests 통과 시 자동 squash 머지.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> SEO-only sitemap metadata updates with no application logic, auth, or deployment behavior changes in the diff.
> 
> **Overview**
> This PR refreshes **`sitemap.xml`** after the automated data sync workflow (aligned with the PR title’s submodule pointer bump, even though the provided diff only shows the sitemap file).
> 
> **`lastmod`** values are updated from chapter JSON commit times in the **`data`** submodule via `scripts/build_sitemap.py`. The site root moves to **`2026-05-30T14:20:14Z`**. A contiguous block of URLs from **Judges through 2 Kings**—book landing pages and individual chapters that were rebuilt in the latest data pipeline run—pick up that timestamp instead of older **`2026-05-11`** (or prior) values. Unchanged chapters keep their existing **`lastmod`**.
> 
> There is no runtime or UI change in this diff; crawlers simply see fresher modification dates for the affected Bible routes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a892bfc45018194978f5721ac758fba12f7127a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->