### PR TITLE
style: 읽기 헤더·책 목록 헤더 모바일 UI 폴리시

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -749,10 +749,17 @@ body {
 /* Title swap: NT chapter/prologue headers emit .title-text-full and
    .title-text-mobile spans. JS adds .compact to #page-title when the full
    title would overflow the room remaining between the absolute-positioned
-   back and bookmark buttons. */
+   back and bookmark buttons. On touch devices we also force the mobile
+   variant unconditionally (mirrors `.book-list` below) — measurement alone
+   often left the full "○○의 복음서 N장" form intact on phones because it
+   technically fit, which felt verbose in the tight header. */
 .title-text-mobile { display: none; }
 #page-title.compact .title-text-full { display: none; }
 #page-title.compact .title-text-mobile { display: inline; }
+@media (hover: none) and (pointer: coarse) {
+  #page-title .title-text-full { display: none; }
+  #page-title .title-text-mobile { display: inline; }
+}
 
 /* ── Chapter Title Back Button ── */
 .title-back-btn {

--- a/css/style.css
+++ b/css/style.css
@@ -188,6 +188,14 @@ body {
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.25);
 }
 
+/* Book-list page: the tab strip already provides a strong visual base for
+   the sticky group, and the scrolled elevation shadow read as visual noise
+   against the tabs. Opt out of the shadow when division tabs are mounted. */
+#sticky-group:has(#division-tabs-slot:not(:empty)).scrolled,
+[data-theme="dark"] #sticky-group:has(#division-tabs-slot:not(:empty)).scrolled {
+  box-shadow: none;
+}
+
 #app-header {
   font-family: -apple-system, BlinkMacSystemFont, "Apple SD Gothic Neo", "Noto Sans KR", sans-serif;
   background: var(--bg);
@@ -213,6 +221,13 @@ body {
 
 #sticky-group:has(#division-tabs-slot:not(:empty)) #app-header::after {
   display: none;
+}
+
+/* Book-list page only: give the header row breathing room before the banner /
+   tab strip. Other screens leave padding-bottom at 0 so the hairline sits
+   tight against the title. */
+#sticky-group:has(#division-tabs-slot:not(:empty)) #app-header {
+  padding-bottom: 0.5rem;
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -1932,7 +1947,7 @@ mark.search-highlight {
   display: flex;
   align-items: center;
   /* Gap to the division tabs below; only present when the banner is shown. */
-  margin-bottom: 0.6rem;
+  margin-bottom: 0.8rem;
   background: var(--accent);
   border-radius: var(--radius);
   overflow: hidden;
@@ -2003,7 +2018,7 @@ mark.search-highlight {
   position: relative; /* positioning context for the sliding indicator */
   display: flex;
   /* Breathing room below the (now line-less) header. */
-  margin: 0.5rem 0 0;
+  margin: 0.8rem 0 0;
   border: 1px solid var(--border);
   border-radius: var(--radius);
   background: var(--bg-card);

--- a/css/style.css
+++ b/css/style.css
@@ -3333,14 +3333,13 @@ html.cite-sheet-open {
   background: none;
   border: none;
   cursor: pointer;
-  color: var(--text-secondary);
-  transition: color 0.15s;
+  color: var(--accent);
+  transition: opacity 0.15s;
   padding: 0;
 }
 
-.title-bookmark-btn:hover,
-.title-bookmark-btn.has-bookmark {
-  color: var(--accent);
+.title-bookmark-btn:hover {
+  opacity: 0.7;
 }
 
 /* Desktop: the settings gear lives in the top row (#settings-anchor), not the

--- a/js/app/bookmark.js
+++ b/js/app/bookmark.js
@@ -794,6 +794,13 @@ function buildHomeBtn(target, ariaLabel) {
   return btn;
 }
 
+// Material Symbols "bookmarks" — outlined for the empty state, filled for the
+// has-bookmark state. The icon now uses var(--accent) in both states (matches
+// the other header icons); the outline ↔ fill swap is the only "this chapter
+// is bookmarked" visual cue.
+const BOOKMARK_ICON_OUTLINE = "M160-80v-560q0-33 23.5-56.5T240-720h320q33 0 56.5 23.5T640-640v560L400-200 160-80Zm80-121 160-86 160 86v-439H240v439Zm480-39v-560H280v-80h440q33 0 56.5 23.5T800-800v560h-80ZM240-640h320-320Z";
+const BOOKMARK_ICON_FILLED = "M160-80v-560q0-33 23.5-56.5T240-720h320q33 0 56.5 23.5T640-640v560L400-200 160-80Zm560-160v-560H280v-80h440q33 0 56.5 23.5T800-800v560h-80Z";
+
 // Build the bookmark icon SVG button for the chapter header
 function buildBookmarkHeaderBtn(bookId, chapter) {
   const btn = el("button", {
@@ -801,7 +808,8 @@ function buildBookmarkHeaderBtn(bookId, chapter) {
     "aria-label": "북마크",
     type: "button",
   });
-  if (findExistingChapterBookmarks(bookId, chapter).length > 0) {
+  const hasBookmark = findExistingChapterBookmarks(bookId, chapter).length > 0;
+  if (hasBookmark) {
     btn.classList.add("has-bookmark");
   }
   const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
@@ -810,7 +818,7 @@ function buildBookmarkHeaderBtn(bookId, chapter) {
   svg.setAttribute("fill", "currentColor");
   svg.setAttribute("aria-hidden", "true");
   const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
-  path.setAttribute("d", "M160-80v-560q0-33 23.5-56.5T240-720h320q33 0 56.5 23.5T640-640v560L400-200 160-80Zm80-121 160-86 160 86v-439H240v439Zm480-39v-560H280v-80h440q33 0 56.5 23.5T800-800v560h-80ZM240-640h320-320Z");
+  path.setAttribute("d", hasBookmark ? BOOKMARK_ICON_FILLED : BOOKMARK_ICON_OUTLINE);
   svg.appendChild(path);
   btn.appendChild(svg);
   btn.addEventListener("click", () => openBookmarkDrawer(bookId, chapter));
@@ -820,10 +828,10 @@ function buildBookmarkHeaderBtn(bookId, chapter) {
 function refreshBookmarkHeaderBtn() {
   const btn = document.querySelector(".title-bookmark-btn");
   if (!btn || !readingContext.bookId || !readingContext.chapter) return;
-  btn.classList.toggle(
-    "has-bookmark",
-    findExistingChapterBookmarks(readingContext.bookId, readingContext.chapter).length > 0
-  );
+  const hasBookmark = findExistingChapterBookmarks(readingContext.bookId, readingContext.chapter).length > 0;
+  btn.classList.toggle("has-bookmark", hasBookmark);
+  const path = btn.querySelector("svg path");
+  if (path) path.setAttribute("d", hasBookmark ? BOOKMARK_ICON_FILLED : BOOKMARK_ICON_OUTLINE);
 }
 
 function openBookmarkDrawer(bookId, chapter) {


### PR DESCRIPTION
## Summary

읽기 헤더 + 책 목록 헤더의 작은 시각 정돈 3건.

- **읽기 헤더 북마크 아이콘 테마색 적용** — `.title-bookmark-btn` 기본색이 `--text-secondary`(회색)이라 옆의 홈/뒤로·설정 아이콘(`--accent`)과 어울리지 않았다. 기본색을 `--accent` 로 통일하고, "북마크 있음" 상태 구분은 색 대비 → 윤곽선 ↔ 채움 SVG path 교체로 옮겼다.
- **모바일 읽기 헤더에서 복음서 축약형 항상 표시** — 제목 swap이 JS 측정 기반 `.compact` 에만 의존했는데 "요한의 복음서 1장"은 모바일 너비에도 들어맞아 풀 네임이 그대로 노출됐다. `.book-list` 와 같은 `@media (hover: none) and (pointer: coarse)` 규칙을 추가해 터치 기기에서는 항상 모바일 축약형(마태오/마르코/루가/요한)을 보이게 한다. 데스크탑 좁은 뷰포트 / 큰 글꼴은 기존 측정 폴백이 처리.
- **책 목록 헤더 그림자 제거 + 여백 확장** — ADR-025 스크롤 elevation 그림자가 책 목록 페이지에서는 탭 띠와 겹쳐 잡음으로 보였다. 기존 `#sticky-group:has(#division-tabs-slot:not(:empty))` 패턴(hairline 숨김에 사용 중)으로 책 목록에서만 그림자를 끄고, 같은 페이지 한정으로 `#app-header` padding-bottom · 이어읽기 배너 · 구분 탭 여백을 살짝 키워 숨막힘 완화. 읽기·머리말 화면 elevation 신호는 그대로.

## Test plan

- [ ] 모바일(iOS Safari)에서 4복음서 chapter 진입 시 헤더 제목이 "○○ N장" (마태오/마르코/루가/요한)으로 보이는지
- [ ] 모바일에서 다른 NT 책(로마서 등) 진입 시에도 기존 NT_MOBILE_NAME 축약형으로 보이는지
- [ ] 데스크탑에서 큰 글꼴/좁은 창으로 줄여도 측정 폴백이 동작해 풀 네임 ↔ 축약형이 swap 되는지
- [ ] 읽기 화면 헤더 북마크 아이콘이 다른 헤더 아이콘과 같은 accent 색인지, 북마크 있는 장에서 채움 ribbon 으로 바뀌는지
- [ ] 책 목록 페이지를 스크롤해도 헤더 아래 그림자가 안 생기는지 (라이트/다크 모두)
- [ ] 읽기/머리말 화면은 스크롤 시 그림자 elevation 그대로 들어오는지 (ADR-025 회귀 없음)
- [ ] 책 목록 페이지에서 검색바·제목 행 → 이어읽기 배너 → 구분 탭 사이 여백이 너무 붙지 않는지

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS and header bookmark SVG path swaps only; no auth, data, or routing logic changes.
> 
> **Overview**
> **Reading header:** The chapter bookmark control now uses **`--accent`** like other header icons; bookmarked vs empty is shown by switching between **outlined and filled** Material Symbols paths in `bookmark.js`, not by toggling gray vs accent in CSS.
> 
> **Touch devices:** Gospel/NT chapter titles always use the **mobile short form** (e.g. 마태오/요한 + chapter) via `@media (hover: none) and (pointer: coarse)`, matching the book list—so full names like “요한의 복음서 1장” no longer appear when they technically fit without overflow measurement.
> 
> **Book list sticky chrome:** When division tabs are present, **scroll elevation shadow is disabled** on `#sticky-group` (same `:has(#division-tabs-slot:not(:empty))` pattern as the hidden hairline). **Spacing** under the header, resume banner, and tab strip is slightly increased.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 862bbfc86124dc6b4bc5013625e2db74e477b71c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->