### PR TITLE
data: 서브모듈 포인터 + sitemap 갱신

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://bible.anglican.kr/</loc>
-    <lastmod>2026-05-30T14:20:14Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/privacy.html</loc>
@@ -966,7 +966,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/ruth</loc>
-    <lastmod>2026-05-30T14:20:14Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/ruth/1</loc>
@@ -974,7 +974,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/ruth/2</loc>
-    <lastmod>2026-05-30T14:20:14Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/ruth/3</loc>
@@ -1114,7 +1114,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/2sam</loc>
-    <lastmod>2026-05-30T14:20:14Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/2sam/1</loc>
@@ -1134,7 +1134,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/2sam/5</loc>
-    <lastmod>2026-05-30T14:20:14Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/2sam/6</loc>
@@ -4470,7 +4470,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/matt</loc>
-    <lastmod>2026-05-26T01:41:44+09:00</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/matt/1</loc>
@@ -4490,7 +4490,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/matt/5</loc>
-    <lastmod>2026-05-24T14:27:15Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/matt/6</loc>
@@ -4498,7 +4498,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/matt/7</loc>
-    <lastmod>2026-05-24T05:42:53Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/matt/8</loc>
@@ -4530,11 +4530,11 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/matt/15</loc>
-    <lastmod>2026-05-24T14:27:15Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/matt/16</loc>
-    <lastmod>2026-05-24T05:42:53Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/matt/17</loc>
@@ -4546,7 +4546,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/matt/19</loc>
-    <lastmod>2026-05-24T14:27:15Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/matt/20</loc>
@@ -4554,7 +4554,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/matt/21</loc>
-    <lastmod>2026-05-24T15:25:19Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/matt/22</loc>
@@ -4574,7 +4574,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/matt/26</loc>
-    <lastmod>2026-05-24T15:49:08Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/matt/27</loc>
@@ -4586,11 +4586,11 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/mark</loc>
-    <lastmod>2026-05-25T13:28:29Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/mark/1</loc>
-    <lastmod>2026-05-25T13:28:29Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/mark/2</loc>
@@ -4610,15 +4610,15 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/mark/6</loc>
-    <lastmod>2026-05-25T13:28:29Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/mark/7</loc>
-    <lastmod>2026-05-25T13:28:29Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/mark/8</loc>
-    <lastmod>2026-05-25T13:28:29Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/mark/9</loc>
@@ -4626,7 +4626,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/mark/10</loc>
-    <lastmod>2026-05-25T13:28:29Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/mark/11</loc>
@@ -4634,7 +4634,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/mark/12</loc>
-    <lastmod>2026-05-25T13:28:29Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/mark/13</loc>
@@ -4642,7 +4642,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/mark/14</loc>
-    <lastmod>2026-05-25T13:28:29Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/mark/15</loc>
@@ -4654,11 +4654,11 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/luke</loc>
-    <lastmod>2026-05-26T01:41:44+09:00</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/luke/1</loc>
-    <lastmod>2026-05-26T01:41:44+09:00</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/luke/2</loc>
@@ -4666,7 +4666,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/luke/3</loc>
-    <lastmod>2026-05-25T13:28:29Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/luke/4</loc>
@@ -4690,11 +4690,11 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/luke/9</loc>
-    <lastmod>2026-05-25T13:28:29Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/luke/10</loc>
-    <lastmod>2026-05-25T13:28:29Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/luke/11</loc>
@@ -4726,7 +4726,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/luke/18</loc>
-    <lastmod>2026-05-25T13:28:29Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/luke/19</loc>
@@ -4754,7 +4754,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/john</loc>
-    <lastmod>2026-05-25T13:28:29Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/john/1</loc>
@@ -4778,7 +4778,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/john/6</loc>
-    <lastmod>2026-05-25T13:28:29Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/john/7</loc>
@@ -4802,7 +4802,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/john/12</loc>
-    <lastmod>2026-05-25T13:28:29Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/john/13</loc>
@@ -4814,7 +4814,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/john/15</loc>
-    <lastmod>2026-05-25T13:28:29Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/john/16</loc>
@@ -4830,7 +4830,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/john/19</loc>
-    <lastmod>2026-05-25T13:28:29Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/john/20</loc>
@@ -4842,7 +4842,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/acts</loc>
-    <lastmod>2026-05-26T01:41:44+09:00</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/acts/1</loc>
@@ -4850,7 +4850,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/acts/2</loc>
-    <lastmod>2026-05-26T01:41:44+09:00</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/acts/3</loc>
@@ -4870,7 +4870,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/acts/7</loc>
-    <lastmod>2026-05-25T16:12:49Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/acts/8</loc>
@@ -4894,11 +4894,11 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/acts/13</loc>
-    <lastmod>2026-05-25T16:12:49Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/acts/14</loc>
-    <lastmod>2026-05-25T16:12:49Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/acts/15</loc>
@@ -4910,7 +4910,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/acts/17</loc>
-    <lastmod>2026-05-25T16:12:49Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/acts/18</loc>
@@ -4958,7 +4958,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/rom</loc>
-    <lastmod>2026-05-27T13:35:35Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/rom/1</loc>
@@ -4966,11 +4966,11 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/rom/2</loc>
-    <lastmod>2026-05-26T13:32:29Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/rom/3</loc>
-    <lastmod>2026-05-27T13:35:35Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/rom/4</loc>
@@ -4986,7 +4986,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/rom/7</loc>
-    <lastmod>2026-05-26T13:32:29Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/rom/8</loc>
@@ -4994,15 +4994,15 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/rom/9</loc>
-    <lastmod>2026-05-26T13:32:29Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/rom/10</loc>
-    <lastmod>2026-05-26T13:32:29Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/rom/11</loc>
-    <lastmod>2026-05-26T13:32:29Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/rom/12</loc>
@@ -5010,7 +5010,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/rom/13</loc>
-    <lastmod>2026-05-26T13:32:29Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/rom/14</loc>
@@ -5018,7 +5018,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/rom/15</loc>
-    <lastmod>2026-05-26T13:32:29Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/rom/16</loc>
@@ -5026,7 +5026,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/1cor</loc>
-    <lastmod>2026-05-27T13:35:35Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/1cor/1</loc>
@@ -5066,7 +5066,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/1cor/10</loc>
-    <lastmod>2026-05-27T13:35:35Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/1cor/11</loc>
@@ -5082,7 +5082,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/1cor/14</loc>
-    <lastmod>2026-05-27T13:35:35Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/1cor/15</loc>
@@ -5094,7 +5094,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/2cor</loc>
-    <lastmod>2026-05-27T13:35:35Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/2cor/1</loc>
@@ -5118,7 +5118,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/2cor/6</loc>
-    <lastmod>2026-05-27T13:35:35Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/2cor/7</loc>
@@ -5130,7 +5130,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/2cor/9</loc>
-    <lastmod>2026-05-27T13:35:35Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/2cor/10</loc>
@@ -5150,11 +5150,11 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/gal</loc>
-    <lastmod>2026-05-27T13:35:35Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/gal/1</loc>
-    <lastmod>2026-05-27T13:35:35Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/gal/2</loc>
@@ -5178,7 +5178,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/eph</loc>
-    <lastmod>2026-05-27T13:35:35Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/eph/1</loc>
@@ -5186,7 +5186,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/eph/2</loc>
-    <lastmod>2026-05-27T13:35:35Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/eph/3</loc>
@@ -5202,7 +5202,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/eph/6</loc>
-    <lastmod>2026-05-27T13:35:35Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/phil</loc>
@@ -5270,15 +5270,15 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/2thess</loc>
-    <lastmod>2026-05-28T14:46:14Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/2thess/1</loc>
-    <lastmod>2026-05-28T14:46:14Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/2thess/2</loc>
-    <lastmod>2026-05-28T14:46:14Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/2thess/3</loc>
@@ -5286,7 +5286,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/1tim</loc>
-    <lastmod>2026-05-28T14:46:14Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/1tim/1</loc>
@@ -5306,7 +5306,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/1tim/5</loc>
-    <lastmod>2026-05-28T14:46:14Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/1tim/6</loc>
@@ -5334,7 +5334,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/titus</loc>
-    <lastmod>2026-05-28T14:46:14Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/titus/1</loc>
@@ -5342,7 +5342,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/titus/2</loc>
-    <lastmod>2026-05-28T14:46:14Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/titus/3</loc>
@@ -5358,7 +5358,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/heb</loc>
-    <lastmod>2026-05-28T14:46:14Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/heb/1</loc>
@@ -5366,7 +5366,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/heb/2</loc>
-    <lastmod>2026-05-28T14:46:14Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/heb/3</loc>
@@ -5414,7 +5414,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/jas</loc>
-    <lastmod>2026-05-30T05:37:01Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/jas/1</loc>
@@ -5422,7 +5422,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/jas/2</loc>
-    <lastmod>2026-05-30T05:37:01Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/jas/3</loc>
@@ -5434,19 +5434,19 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/jas/5</loc>
-    <lastmod>2026-05-30T05:37:01Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/1pet</loc>
-    <lastmod>2026-05-30T05:37:01Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/1pet/1</loc>
-    <lastmod>2026-05-30T05:37:01Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/1pet/2</loc>
-    <lastmod>2026-05-30T05:37:01Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/1pet/3</loc>
@@ -5526,7 +5526,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/rev</loc>
-    <lastmod>2026-05-30T05:37:01Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/rev/1</loc>
@@ -5538,11 +5538,11 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/rev/3</loc>
-    <lastmod>2026-05-30T05:37:01Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/rev/4</loc>
-    <lastmod>2026-05-30T05:37:01Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/rev/5</loc>
@@ -5554,7 +5554,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/rev/7</loc>
-    <lastmod>2026-05-30T05:37:01Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/rev/8</loc>
@@ -5566,7 +5566,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/rev/10</loc>
-    <lastmod>2026-05-30T05:37:01Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/rev/11</loc>
@@ -5578,7 +5578,7 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/rev/13</loc>
-    <lastmod>2026-05-30T05:37:01Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/rev/14</loc>
@@ -5610,10 +5610,10 @@
   </url>
   <url>
     <loc>https://bible.anglican.kr/rev/21</loc>
-    <lastmod>2026-05-30T05:37:01Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
   <url>
     <loc>https://bible.anglican.kr/rev/22</loc>
-    <lastmod>2026-05-30T05:37:01Z</lastmod>
+    <lastmod>2026-05-31T23:44:18+09:00</lastmod>
   </url>
 </urlset>


### PR DESCRIPTION
data 저장소 build.yml 산출물 commit 직후 자동 생성된 PR. Unit tests 통과 시 자동 squash 머지.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Automated SEO metadata only; no app logic, auth, or user data changes.
> 
> **Overview**
> This PR refreshes **`sitemap.xml`** after the automated data sync workflow runs **`scripts/build_sitemap.py`**. It does not add or remove URLs—only **`lastmod`** values change for entries whose underlying `data/bible/*.json` (or site root) picked up new git timestamps from the updated data submodule.
> 
> The bulk of edits set **`lastmod`** to **`2026-05-31T23:44:18+09:00`** on the homepage and on many book/chapter URLs (e.g. Ruth, 2 Samuel, and large stretches of the Gospels through Revelation and Pauline/epistolary books). Unaffected URLs keep their previous timestamps. This aligns search crawlers with recently rebuilt Bible content, consistent with the PR’s **data submodule pointer + sitemap** automation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0afa6fcaa9838da3e602e74a75029a0183302363. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->