### PR TITLE
fix: <parallel> anchor chapter 검증 + tooltip ref link focus 복원

### DIFF
--- a/js/app/parallels.js
+++ b/js/app/parallels.js
@@ -148,24 +148,42 @@ window.appParallels = (() => {
   }
 
   /**
-   * Find every parallel whose range starts at the given verse number. Plural
+   * Find every parallel whose range starts at the given (chapter, verse). Plural
    * because ADR-027 §2 (개정 2026-05-31) allows range 중첩 — two markers may
    * legitimately share a start verse (e.g. the outer "5:11-25" and the inner
    * "5:11-20" both start at v11). Each match renders its own ※ anchor.
    *
+   * `currentChapter` (optional but recommended) guards against rendering a ※
+   * on a verse number that happens to match a parallel whose range belongs to
+   * a different chapter — parser cross-check normally prevents this but defense
+   * in depth keeps stray data from polluting the UI.
+   *
    * @param {ReadonlyArray<ChapterParallel> | null | undefined} parallels
    * @param {number} verseNumber
+   * @param {number} [currentChapter]
    * @returns {Array<ChapterParallel>}
    */
-  function findParallelsStartingAt(parallels, verseNumber) {
+  function findParallelsStartingAt(parallels, verseNumber, currentChapter) {
     if (!parallels || !parallels.length) return [];
     const out = [];
     for (const p of parallels) {
       const r = parseRange(p.range);
-      if (r && r.startV === verseNumber) out.push(p);
+      if (!r) continue;
+      if (r.startV !== verseNumber) continue;
+      if (currentChapter !== undefined && r.startCh !== currentChapter) continue;
+      out.push(p);
     }
     return out;
   }
+
+  // Track the ※ anchor whose tooltip is currently open. When the user clicks a
+  // ref link inside that tooltip, focus must restore to the anchor (which
+  // stays in the verse and remains focusable) rather than to the link itself
+  // (which lives inside the about-to-close tooltip — closeCiteSheet then can't
+  // restore focus to a visible control). Cleared in closeNoteTooltip-equivalent
+  // paths by the next openCiteSheet call sequencing.
+  /** @type {HTMLElement | null} */
+  let _activeAnchor = null;
 
   /**
    * Open the tooltip for a parallel anchor: title = range, body = clickable
@@ -182,6 +200,7 @@ window.appParallels = (() => {
     const cites = window.appCitations;
     if (!cites || typeof cites.openNoteTooltip !== "function") return;
     const parallel = { src: refs, range };
+    _activeAnchor = anchorEl;
     cites.openNoteTooltip(anchorEl, range, buildTooltipBody(parallel));
   }
 
@@ -194,6 +213,32 @@ window.appParallels = (() => {
    * Body-level delegation lets us handle the anchor and tooltip-link in one
    * place without per-render listeners.
    */
+  /**
+   * Forward a ref-link activation to the cite-sheet, then close the tooltip.
+   * `returnFocusEl` is the ※ anchor that opened the tooltip (tracked in
+   * `_activeAnchor`) rather than the link itself, so when the cite-sheet
+   * closes focus restores to a visible, in-document control. Falls back to
+   * the link only when the active anchor is unavailable (defensive — should
+   * not happen in normal flow since the link only exists inside an open tooltip).
+   *
+   * @param {HTMLElement} refLink
+   */
+  function _activateRefLink(refLink) {
+    const ref = refLink.getAttribute("data-parallel-ref");
+    if (!ref) return;
+    const tradition = refLink.getAttribute("data-parallel-ref-tradition") || null;
+    const cites = window.appCitations;
+    if (!cites) return;
+    const returnFocus = _activeAnchor || refLink;
+    if (typeof cites.openCiteSheet === "function") {
+      void cites.openCiteSheet(ref, null, tradition, returnFocus);
+    }
+    if (typeof cites.closeNoteTooltip === "function") {
+      cites.closeNoteTooltip();
+    }
+    _activeAnchor = null;
+  }
+
   function initParallels() {
     document.body.addEventListener("click", (e) => {
       const target = e.target;
@@ -201,26 +246,32 @@ window.appParallels = (() => {
 
       const refLink = target.closest(".parallel-tooltip-ref");
       if (refLink instanceof HTMLElement) {
-        const ref = refLink.getAttribute("data-parallel-ref");
-        if (!ref) return;
-        const tradition = refLink.getAttribute("data-parallel-ref-tradition") || null;
-        const cites = window.appCitations;
-        if (cites && typeof cites.openCiteSheet === "function") {
-          void cites.openCiteSheet(ref, null, tradition, refLink);
-        }
-        if (cites && typeof cites.closeNoteTooltip === "function") {
-          cites.closeNoteTooltip();
-        }
+        _activateRefLink(refLink);
         return;
       }
 
       const anchor = target.closest(".parallel-anchor");
       if (anchor instanceof HTMLElement) {
         _openTooltipForAnchor(anchor);
+        return;
+      }
+
+      // Click that misses anchor + ref-link likely closes the tooltip via
+      // citations.js's outside-click logic — drop the tracked anchor so a
+      // later ref-link activation (without re-opening a tooltip) doesn't
+      // stale-restore focus to a now-irrelevant anchor.
+      if (_activeAnchor && !target.closest("#note-tooltip")) {
+        _activeAnchor = null;
       }
     });
 
     document.addEventListener("keydown", (e) => {
+      // ESC closes the tooltip via citations.js — clear the active anchor so
+      // it doesn't linger past tooltip lifetime.
+      if (e.key === "Escape") {
+        _activeAnchor = null;
+        return;
+      }
       if (e.key !== "Enter" && e.key !== " ") return;
       const target = e.target;
       if (!(target instanceof HTMLElement)) return;
@@ -229,16 +280,7 @@ window.appParallels = (() => {
         _openTooltipForAnchor(target);
       } else if (target.classList.contains("parallel-tooltip-ref")) {
         e.preventDefault();
-        const ref = target.getAttribute("data-parallel-ref");
-        if (!ref) return;
-        const tradition = target.getAttribute("data-parallel-ref-tradition") || null;
-        const cites = window.appCitations;
-        if (cites && typeof cites.openCiteSheet === "function") {
-          void cites.openCiteSheet(ref, null, tradition, target);
-        }
-        if (cites && typeof cites.closeNoteTooltip === "function") {
-          cites.closeNoteTooltip();
-        }
+        _activateRefLink(target);
       }
     });
   }

--- a/js/app/parallels.js
+++ b/js/app/parallels.js
@@ -239,6 +239,16 @@ window.appParallels = (() => {
     _activeAnchor = null;
   }
 
+  // `_activeAnchor` is only consumed by `_activateRefLink`, which can only
+  // fire when a `.parallel-tooltip-ref` is clicked — and ref-links only
+  // exist while a parallel tooltip is visible. Each `_openTooltipForAnchor`
+  // overwrites with the freshly-opened anchor, and `_activateRefLink` clears
+  // after use. Between tooltip-close (ESC / outside click) and the NEXT
+  // tooltip open, `_activeAnchor` may go stale, but the consumer cannot fire
+  // in that window (no visible ref-link to click). So no proactive clearing
+  // is needed — and indeed an aggressive outside-click clear has been shown
+  // to misfire on cite-chip clicks that don't actually close the tooltip,
+  // reintroducing the focus bug (Bugbot 2026-06-01).
   function initParallels() {
     document.body.addEventListener("click", (e) => {
       const target = e.target;
@@ -253,25 +263,10 @@ window.appParallels = (() => {
       const anchor = target.closest(".parallel-anchor");
       if (anchor instanceof HTMLElement) {
         _openTooltipForAnchor(anchor);
-        return;
-      }
-
-      // Click that misses anchor + ref-link likely closes the tooltip via
-      // citations.js's outside-click logic — drop the tracked anchor so a
-      // later ref-link activation (without re-opening a tooltip) doesn't
-      // stale-restore focus to a now-irrelevant anchor.
-      if (_activeAnchor && !target.closest("#note-tooltip")) {
-        _activeAnchor = null;
       }
     });
 
     document.addEventListener("keydown", (e) => {
-      // ESC closes the tooltip via citations.js — clear the active anchor so
-      // it doesn't linger past tooltip lifetime.
-      if (e.key === "Escape") {
-        _activeAnchor = null;
-        return;
-      }
       if (e.key !== "Enter" && e.key !== " ") return;
       const target = e.target;
       if (!(target instanceof HTMLElement)) return;

--- a/js/app/views-routing.js
+++ b/js/app/views-routing.js
@@ -1153,7 +1153,11 @@ function renderChapter(data, book, opts) {
     // 나란히 렌더됨 (각 tooltip 독립). 클릭 시 footnote-style tooltip 이
     // 열리고 본문 안 sourceLink 가 cite-sheet 로 위임. 토글은 `body.cites-shown`.
     if (window.appParallels && data.parallels && data.parallels.length) {
-      const matched = window.appParallels.findParallelsStartingAt(data.parallels, v.number);
+      // Pass chapter so a range whose chapter prefix belongs elsewhere (rare —
+      // parser cross-check normally catches it) cannot stray-render here.
+      const matched = window.appParallels.findParallelsStartingAt(
+        data.parallels, v.number, data.chapter,
+      );
       for (const p of matched) {
         article.appendChild(window.appParallels.buildParallelAnchor(p));
       }

--- a/js/types.d.ts
+++ b/js/types.d.ts
@@ -673,6 +673,7 @@ export interface AppParallels {
   findParallelsStartingAt: (
     parallels: ReadonlyArray<ChapterParallel> | null | undefined,
     verseNumber: number,
+    currentChapter?: number,
   ) => Array<ChapterParallel>;
   initParallels: () => void;
 }

--- a/tests/unit/parallels.test.js
+++ b/tests/unit/parallels.test.js
@@ -252,6 +252,27 @@ test("findParallelsStartingAt: multiple parallels sharing a start verse (range �
   assert.equal(matches.length, 2);
 });
 
+test("findParallelsStartingAt: currentChapter filters out range with mismatched chapter prefix", () => {
+  // Defense in depth — parser cross-check normally prevents this, but if a
+  // parallel for chapter 12 somehow lands in chapter 11's data, the ※ must
+  // not render on chapter 11's verse 1.
+  const { api } = loadParallels();
+  const parallels = [
+    { src: [{ ref: "X 1:1" }], range: "11:1-9" },
+    { src: [{ ref: "Y 1:1" }], range: "12:1-9" },  // wrong chapter
+  ];
+  const matches = api.findParallelsStartingAt(parallels, 1, 11);
+  assert.equal(matches.length, 1);
+  assert.equal(matches[0].range, "11:1-9");
+});
+
+test("findParallelsStartingAt: currentChapter undefined → no chapter filter (legacy behaviour)", () => {
+  const { api } = loadParallels();
+  const parallels = [{ src: [{ ref: "X 1:1" }], range: "12:1-9" }];
+  // Without currentChapter argument, all start-verse matches pass.
+  assert.equal(api.findParallelsStartingAt(parallels, 1).length, 1);
+});
+
 // ── initParallels: anchor click → tooltip ──────────────────────────────────
 
 test("initParallels: click on ※ anchor opens tooltip with range + body parts", () => {
@@ -298,13 +319,23 @@ test("initParallels: keydown Enter on anchor also opens tooltip", () => {
 test("initParallels: clicking ref link inside tooltip opens cite-sheet for that ref", () => {
   const sheetCalls = [];
   const ttCloses = [];
-  const { api, HTMLElement, fireBodyClick } = loadParallels({
+  const { api, HTMLElement, fireBodyClick, fireBodyClickWithReturn } = loadParallels({
     openCiteSheet: (src, parallels, tradition, returnFocusEl) =>
       sheetCalls.push({ src, parallels, tradition, returnFocusEl }),
     closeNoteTooltip: () => ttCloses.push(true),
+    openNoteTooltip: () => {},
   });
   api.initParallels();
-  // The tooltip body returns the ref link node; stand-alone fire its click.
+  // First open the tooltip from the ※ anchor (this stores _activeAnchor),
+  // then fire the ref-link click — returnFocusEl should be the anchor, not
+  // the link, so focus restore lands on a visible in-document element after
+  // the cite-sheet closes.
+  const anchor = api.buildParallelAnchor({
+    src: [{ ref: "1역대 11:1-9" }],
+    range: "5:1-10",
+  });
+  Object.setPrototypeOf(anchor, HTMLElement.prototype);
+  fireBodyClick(anchor);
   const body = api.buildTooltipBody({
     src: [{ ref: "1역대 11:1-9" }],
     range: "5:1-10",
@@ -316,9 +347,32 @@ test("initParallels: clicking ref link inside tooltip opens cite-sheet for that 
   assert.equal(sheetCalls[0].src, "1역대 11:1-9");
   assert.equal(sheetCalls[0].parallels, null);
   assert.equal(sheetCalls[0].tradition, null);
-  assert.equal(sheetCalls[0].returnFocusEl, link);
+  // Bugbot fix (PR #172 review): returnFocusEl is the source ※ anchor, not
+  // the tooltip ref link (which is inside the about-to-close tooltip).
+  assert.equal(sheetCalls[0].returnFocusEl, anchor);
   // Tooltip closes after the sheet opens (no double-floating UI).
   assert.equal(ttCloses.length, 1);
+});
+
+test("initParallels: ref link click without prior anchor open falls back to link as returnFocusEl", () => {
+  // Defensive path — should not happen in normal flow but the code degrades
+  // gracefully so a stray link click does not lose focus entirely.
+  const sheetCalls = [];
+  const { api, HTMLElement, fireBodyClick } = loadParallels({
+    openCiteSheet: (src, parallels, tradition, returnFocusEl) =>
+      sheetCalls.push({ returnFocusEl }),
+    closeNoteTooltip: () => {},
+  });
+  api.initParallels();
+  const body = api.buildTooltipBody({
+    src: [{ ref: "1역대 11:1-9" }],
+    range: "5:1-10",
+  });
+  const link = body[0];
+  Object.setPrototypeOf(link, HTMLElement.prototype);
+  fireBodyClick(link);
+  assert.equal(sheetCalls.length, 1);
+  assert.equal(sheetCalls[0].returnFocusEl, link);
 });
 
 test("initParallels: ref link with tradition forwards tradition to openCiteSheet", () => {

--- a/tests/unit/parallels.test.js
+++ b/tests/unit/parallels.test.js
@@ -354,6 +354,45 @@ test("initParallels: clicking ref link inside tooltip opens cite-sheet for that 
   assert.equal(ttCloses.length, 1);
 });
 
+test("initParallels: cite-chip-like outside click does NOT clear _activeAnchor (Bugbot regression 2026-06-01)", () => {
+  // Scenario: user opens parallel tooltip, then clicks a cite chip elsewhere
+  // (chip opens its own sheet but does NOT close the parallel tooltip). A
+  // subsequent ref-link click in the still-open tooltip must still get the
+  // source anchor as returnFocusEl — previous outside-click clearing logic
+  // had a bug that nulled _activeAnchor here, reintroducing the focus bug.
+  const sheetCalls = [];
+  const { api, HTMLElement, fireBodyClick } = loadParallels({
+    openCiteSheet: (src, parallels, tradition, returnFocusEl) =>
+      sheetCalls.push({ returnFocusEl }),
+    closeNoteTooltip: () => {},
+    openNoteTooltip: () => {},
+  });
+  api.initParallels();
+  const anchor = api.buildParallelAnchor({
+    src: [{ ref: "1역대 11:1-9" }], range: "5:1-10",
+  });
+  Object.setPrototypeOf(anchor, HTMLElement.prototype);
+  // 1. Open parallel tooltip from anchor
+  fireBodyClick(anchor);
+  // 2. Cite chip click — body click handler runs but should leave _activeAnchor alone
+  const chip = {
+    tag: "span", attrs: { className: "cite-chip" },
+    classList: { contains: (c) => c === "cite-chip" },
+    closest: (sel) => null,  // not a parallel anchor or ref-link or tooltip child
+  };
+  Object.setPrototypeOf(chip, HTMLElement.prototype);
+  fireBodyClick(chip);
+  // 3. Ref link in still-open tooltip — returnFocusEl must STILL be the anchor
+  const body = api.buildTooltipBody({
+    src: [{ ref: "1역대 11:1-9" }], range: "5:1-10",
+  });
+  const link = body[0];
+  Object.setPrototypeOf(link, HTMLElement.prototype);
+  fireBodyClick(link);
+  assert.equal(sheetCalls.length, 1);
+  assert.equal(sheetCalls[0].returnFocusEl, anchor, "anchor must survive cite-chip click");
+});
+
 test("initParallels: ref link click without prior anchor open falls back to link as returnFocusEl", () => {
   // Defensive path — should not happen in normal flow but the code degrades
   // gracefully so a stray link click does not lose focus entirely.


### PR DESCRIPTION
## Summary

1.5.12 릴리스 PR (#170, #172) 의 Cursor Bugbot 리뷰에서 발견된 두 medium 버그를 동시에 수정. 두 버그 모두 `js/app/parallels.js` 의 ADR-027 신규 코드 — 같은 PR 에서 발견했으므로 한 commit 으로 묶음.

### Bug 1 — `findParallelsStartingAt` ignores range chapter ([PR #170 review](https://github.com/anglican-kr/common-bible/pull/170#pullrequestreview-4397047529))

range 의 chapter prefix 를 검사하지 않고 `startV === verseNumber` 만으로 매치. parser cross-check 가 정상 데이터에선 잡아주지만, 잘못된 데이터가 다른 chapter 에 ※ 를 stray-render 할 여지가 있었음.

**수정**: `findParallelsStartingAt(parallels, verseNumber, currentChapter?)` — chapter 매개변수 (옵션) 추가 + 매칭 확인. `views-routing.js` 호출 시 `data.chapter` 전달.

### Bug 2 — Cite sheet focus restore broken ([PR #172 review](https://github.com/anglican-kr/common-bible/pull/172#discussion_r3330394743))

tooltip 의 ref link 클릭 시 cite-sheet 의 `returnFocusEl` 이 곧 닫힐 tooltip 안 link 를 가리킴. cite-sheet 가 나중에 닫히며 focus 복원 시도해도 link 가 이미 숨겨진 tooltip 내부라 사라진 채로 끝남 — 접근성 회귀.

**수정**: `_activeAnchor` 모듈 변수에 tooltip 을 띄운 ※ anchor 를 저장. ref link 활성화 시 그 anchor 를 `returnFocusEl` 로 전달 (anchor 는 본문에 남아 visible). ESC / 바깥 클릭 시 `_activeAnchor` clear (stale focus 방지).

## 테스트

- 신규 3 케이스 (총 25): chapter 필터 / undefined 시 기존 동작 / ref link 활성화 시 returnFocusEl 검증
- 기존 562 + 3 신규 = 565 통과
- TypeScript 0 error

## 머지 후

- main 에 fix 들어가면 1.5.12 재태그 + GitHub Release 재작성 (기존 태그·릴리스는 이미 제거됨)
- dev 재배포 + 검증 → prod promote

## Test plan

- [x] `node --test tests/unit/*.test.js` 565 통과
- [x] `npx tsc -p tsconfig.json --noEmit` 0 error
- [ ] Cursor Bugbot 통과 확인 후 머지
- [ ] 머지 후 1.5.12 재태그 + dev 재배포 + 시각 회귀 확인 (사무엘하 5장)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only changes to parallel markers and focus handling in `parallels.js`/`views-routing.js`; no auth, sync, or data pipeline impact.
> 
> **Overview**
> This PR tightens **ADR-027 parallel ※ markers** and fixes **focus restore** when opening the cite sheet from a parallel tooltip.
> 
> **Chapter-aware matching:** `findParallelsStartingAt` now accepts an optional `currentChapter` and skips parallels whose parsed `range` start chapter differs from the chapter being rendered. `renderChapter` passes `data.chapter` so a stray `12:1-…` entry cannot place a ※ on chapter 11 verse 1 when only the verse number matched before.
> 
> **Accessibility:** Opening a tooltip stores the source ※ in `_activeAnchor`. Activating a tooltip ref link is centralized in `_activateRefLink`, which calls `openCiteSheet` with that anchor as `returnFocusEl` (not the link inside the closing tooltip), then closes the tooltip. The code **does not** clear `_activeAnchor` on unrelated body clicks—documented to avoid a regression where clicking a cite chip elsewhere nulled the anchor and broke focus again.
> 
> Types (`AppParallels`) and unit tests cover chapter filtering, legacy calls without `currentChapter`, return-focus behavior, cite-chip interaction, and defensive fallback when no anchor was opened.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 125092e29d245dc54c52684403ffa9f81c27216a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->