### PR TITLE
style: 이어읽기 배너 표면 카드화 + 배너·탭바·책목록 간격 8pt 통일

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2018,17 +2018,20 @@ mark.search-highlight {
   align-items: center;
   /* Gap to the division tabs below; only present when the banner is shown. */
   margin-bottom: 0.8rem;
-  background: var(--accent);
+  /* Surface card matching the division-tab strip/chip directly below — raised
+     via border + elevation rather than a solid accent fill. */
+  background: var(--bg-card);
+  border: 1px solid var(--border);
   border-radius: var(--radius);
   overflow: hidden;
   transition: opacity 0.15s;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+  box-shadow: var(--shadow-2);
 }
 
 .resume-banner-link {
   flex: 1;
   padding: 0.7rem 1rem;
-  color: var(--bg);
+  color: var(--text);
   text-decoration: none;
   font-size: 0.9rem;
   text-align: center;
@@ -2053,9 +2056,9 @@ mark.search-highlight {
   justify-content: center;
   width: 2.2rem;
   border: none;
-  border-left: 1px solid rgba(255, 255, 255, 0.3);
+  border-left: 1px solid var(--border);
   background: transparent;
-  color: var(--bg);
+  color: var(--text-secondary);
   font-size: 1.1rem;
   cursor: pointer;
   padding: 0.7rem 0;
@@ -2063,7 +2066,7 @@ mark.search-highlight {
 }
 
 .resume-banner-close:hover {
-  background: rgba(0, 0, 0, 0.15);
+  background: color-mix(in srgb, var(--text) 10%, transparent);
 }
 
 /* ── Book List ── */

--- a/css/style.css
+++ b/css/style.css
@@ -2017,7 +2017,7 @@ mark.search-highlight {
   display: flex;
   align-items: center;
   /* Gap to the division tabs below; only present when the banner is shown. */
-  margin-bottom: 0.8rem;
+  margin-bottom: var(--space-4);
   /* Surface card matching the division-tab strip/chip directly below — raised
      via border + elevation rather than a solid accent fill. */
   background: var(--bg-card);
@@ -2090,8 +2090,8 @@ mark.search-highlight {
   font-family: -apple-system, BlinkMacSystemFont, "Apple SD Gothic Neo", "Noto Sans KR", sans-serif;
   position: relative; /* positioning context for the sliding indicator */
   display: flex;
-  /* Breathing room below the (now line-less) header. */
-  margin: 0.8rem 0 0;
+  /* Breathing room below the (now line-less) header — 8pt 그리드(16px). */
+  margin: var(--space-4) 0 0;
   border: 1px solid var(--border);
   border-radius: var(--radius);
   background: var(--bg-card);
@@ -2169,10 +2169,11 @@ mark.search-highlight {
 }
 
 /* Book-list view only: match the gap below the pinned division tabs to the
-   resume-banner ↔ tabs gap (0.8rem). #app's default 2rem padding-top is meant
-   for the reading view, so we scope this to views that render .division-panel. */
+   resume-banner ↔ tabs gap. All three use --space-4 (16px, 8pt 그리드 — DESIGN.md §4).
+   #app's default 2rem padding-top is for the reading view, so we scope this to
+   views that render .division-panel. */
 #app:has(.division-panel) {
-  padding-top: 0.8rem;
+  padding-top: var(--space-4);
 }
 
 .book-list {

--- a/css/style.css
+++ b/css/style.css
@@ -2168,6 +2168,13 @@ mark.search-highlight {
   font-family: -apple-system, BlinkMacSystemFont, "Apple SD Gothic Neo", "Noto Sans KR", sans-serif;
 }
 
+/* Book-list view only: match the gap below the pinned division tabs to the
+   resume-banner ↔ tabs gap (0.8rem). #app's default 2rem padding-top is meant
+   for the reading view, so we scope this to views that render .division-panel. */
+#app:has(.division-panel) {
+  padding-top: 0.8rem;
+}
+
 .book-list {
   list-style: none;
   display: grid;


### PR DESCRIPTION
## 변경

책 목록 화면 상단(이어읽기 배너 → 구분 탭 → 책 목록)의 시각 정리.

### 1. 이어읽기 배너를 구분 탭과 같은 표면 카드로
솔리드 차콜(`--accent`) 배너를 바로 아래 구분 탭 스트립/칩과 같은 계열로 통일:
- 배경 `--accent` → `--bg-card`
- `--border` 테두리 + `--shadow-2`(다크 자동 보강) 추가 → "떠 있는 카드"
- 글자 크림 → 본문색 `--text`, 닫기(✕)는 보조색, 구분선·hover 도 테마 토큰화

### 2. 간격을 8pt 그리드 토큰으로 통일 (DESIGN.md §4)
배너↔탭바·탭바↔책목록·헤더↔탭바 간격이 제각각(0.8rem / 2rem)이던 것을 모두 **`--space-4`(16px)** 로 통일:
- `.resume-banner` margin-bottom: `0.8rem` → `--space-4`
- `.division-tabs` margin-top: `0.8rem` → `--space-4`
- 책 목록 뷰 `#app:has(.division-panel)` padding-top: `2rem` → `--space-4` (읽기 화면 padding 은 그대로)

세 간격이 정확히 동일해지고 8pt 그리드에 정렬됩니다. ad-hoc rem 값을 토큰으로 수렴 — ADR-028 "점진 치환" 방향과 일치.

## 검증
- CSS 전용, JS/DOM 무변경 → tsc·유닛 영향 없음
- dev 배포 확인 완료 (라이트/다크)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only presentation on the book-list header stack; no logic, routing, or data changes.
> 
> **Overview**
> The **이어읽기 (resume) banner** on the book-list screen is restyled from a solid `--accent` bar to the same **raised card** language as the 구분 (division) tabs: `--bg-card`, `--border`, and `--shadow-2`, with link/close colors moved to `--text` / `--text-secondary` and theme-token borders/hover instead of hard-coded white overlays.
> 
> **Vertical rhythm** on that screen is unified to **`--space-4` (16px)** for banner→tabs, header→tabs margin on `.division-tabs`, and book grid top spacing via new `#app:has(.division-panel) { padding-top: var(--space-4) }`, replacing mixed `0.8rem` / `2rem` values while leaving the reading view’s default `#app` top padding unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 309894a2a4f76f57fe89bb595456056f7ed67b59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->