### PR TITLE
fix: 검색 모핑 — 닫기 X 키보드 게이팅 + 키보드 등장 시 페이지 팬 방지

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2834,7 +2834,10 @@ html.cite-sheet-open {
   position: fixed;
   left: 0;
   right: 0;
-  bottom: calc(var(--space-1) + env(safe-area-inset-bottom) * 0.75);
+  /* --kb-overlap 은 키보드가 떠 있을 때 tabbar.js 가 키보드 높이로 설정한다.
+     transform 이 아니라 실제 bottom 으로 올려야 입력의 레이아웃 사각형이 키보드
+     위로 가서 iOS 가 페이지를 팬하지 않는다(헤더·빈 상태가 제자리 유지). */
+  bottom: calc(var(--space-1) + env(safe-area-inset-bottom) * 0.75 + var(--kb-overlap, 0px));
   z-index: var(--nav-z);
   display: flex;
   align-items: center;
@@ -3088,9 +3091,10 @@ html.cite-sheet-open {
 #tab-dock.searching #tab-search-clear:active { transform: scale(0.9); }
 
 /* ── ADR-030 P3: 검색 닫기(X) 버튼 — 입력 pill 오른쪽 원형 ───────────────────
-   "키보드가 나타나면 한 번 더 모핑": 검색 진입 시 width 0→60px 로 모핑 인. 검색
-   세션 동안 유지(결과 화면 포함, screenshot 2), 닫으면(X) 전체 롤백. idle 상태는
-   접힘(width/opacity 0)이라 레이아웃·시각 비표시(collapse 탭과 동일 패턴). */
+   "키보드가 나타나면 한 번 더 모핑": 키보드가 떠 있는 동안에만 width 0→60px 로
+   모핑 인(body.tabbar-keyboard). 키보드가 내려간 결과 화면에선 홈 버튼과 동작이
+   겹치므로(둘 다 탭바 복구→홈) 숨긴다. idle/no-keyboard 상태는 접힘(width/opacity 0)
+   이라 레이아웃·시각 비표시(collapse 탭과 동일 패턴). 닫으면(X) 전체 롤백. */
 #tab-search-close {
   flex: 0 0 auto;
   display: flex;
@@ -3116,7 +3120,7 @@ html.cite-sheet-open {
 }
 #tab-search-close svg { width: 1.6rem; height: 1.6rem; }
 #tab-search-close:active { transform: scale(0.92); }
-#tab-dock.searching #tab-search-close {
+body.tabbar-keyboard #tab-dock.searching #tab-search-close {
   width: calc(var(--touch-target) + var(--space-2) * 2); /* 60px 원형 */
   opacity: 1;
   pointer-events: auto;
@@ -3127,7 +3131,7 @@ html.cite-sheet-open {
   border: 1px solid color-mix(in srgb, var(--text) 8%, transparent);
   box-shadow: var(--shadow-2);
 }
-[data-theme="dark"] #tab-dock.searching #tab-search-close {
+[data-theme="dark"] body.tabbar-keyboard #tab-dock.searching #tab-search-close {
   background: color-mix(in srgb, var(--bg-card) 80%, transparent);
 }
 

--- a/js/app/tabbar.js
+++ b/js/app/tabbar.js
@@ -27,16 +27,45 @@ function syncClearBtn() {
   if ($searchClear) $searchClear.hidden = !$searchInput?.value.trim();
 }
 
+// ── BEGIN KEYBOARD ── (tests/unit/tabbar.test.js 가 이 블록을 슬라이스해 검증)
+
+// 키보드 높이(키보드가 가린 px) = 레이아웃 뷰포트 − 비주얼 뷰포트 높이. search.js
+// 의 시트 보정과 동일하게 vv.offsetTop 은 의도적으로 무시 — offsetTop 은 핀치줌
+// 팬 등 in-page 스크롤 양이라 position:fixed 요소(레이아웃 뷰포트 기준)를 잘못 민다.
+function keyboardOverlap(innerHeight, vvHeight) {
+  return Math.max(0, innerHeight - vvHeight);
+}
+
+// 키보드가 떠 있는 동안에만 닫기(X) 버튼을 노출 + body 상태 클래스 토글.
+// X 는 홈 버튼과 동작이 겹치므로(둘 다 탭바 복구→홈) 키보드가 없을 땐 숨긴다.
+function setKeyboardState(up) {
+  document.body.classList.toggle("tabbar-keyboard", up);
+  if (!$searchClose) return;
+  // 키보드 없을 땐 a11y 트리에서도 제외(시각적으로도 collapse).
+  if (up) {
+    $searchClose.removeAttribute("aria-hidden");
+    $searchClose.removeAttribute("tabindex");
+  } else {
+    $searchClose.setAttribute("aria-hidden", "true");
+    $searchClose.setAttribute("tabindex", "-1");
+  }
+}
+
 // ── visualViewport: 키보드가 가리지 않게 dock 을 키보드 높이만큼 위로 ──
 function liftForKeyboard() {
   const vv = window.visualViewport;
   if (!vv || !$dock) return;
-  // 키보드 높이 = 레이아웃 뷰포트 − 비주얼 뷰포트 높이. search.js 의 시트 보정과
-  // 동일하게 vv.offsetTop 은 의도적으로 무시 — offsetTop 은 핀치줌 팬 등 in-page
-  // 스크롤 양이라 position:fixed 요소(레이아웃 뷰포트 기준)를 잘못 밀 수 있다.
-  const overlap = Math.max(0, window.innerHeight - vv.height);
-  $dock.style.transform = overlap > 1 ? `translateY(${-overlap}px)` : "";
+  const overlap = keyboardOverlap(window.innerHeight, vv.height);
+  // 1px 미만은 반올림 오차 — 키보드 없음으로 본다.
+  const up = overlap > 1;
+  // transform 대신 실제 레이아웃 위치(bottom)로 올린다. transform 은 레이아웃
+  // 사각형을 그대로 두므로 iOS 가 포커스 입력이 키보드에 가려졌다고 보고 페이지
+  // 전체를 위로 팬(헤더·빈 상태가 화면 밖으로 밀림)한다. 입력의 실제 사각형을
+  // 키보드 위로 올리면 iOS 가 팬할 이유가 없어져 sticky 헤더·본문이 제자리에 남는다.
+  $dock.style.setProperty("--kb-overlap", up ? `${overlap}px` : "0px");
+  setKeyboardState(up);
 }
+// ── END KEYBOARD ──
 function attachKeyboardTracking() {
   const vv = window.visualViewport;
   if (!vv) return;
@@ -50,7 +79,8 @@ function detachKeyboardTracking() {
     vv.removeEventListener("resize", liftForKeyboard);
     vv.removeEventListener("scroll", liftForKeyboard);
   }
-  if ($dock) $dock.style.transform = "";
+  if ($dock) $dock.style.setProperty("--kb-overlap", "0px");
+  setKeyboardState(false);
 }
 
 // dock 입력을 현재 URL 의 ?q= 로 맞춘다(in-page bar 가 숨겨져 dock 입력이 단일
@@ -72,9 +102,8 @@ function openSearch() {
   $dock.classList.add("searching");
   document.body.classList.add("tabbar-searching");
   $searchBtn?.setAttribute("aria-expanded", "true");
-  // 닫기(X) 버튼은 검색 중에만 접근 가능(idle 엔 collapsed → a11y 트리 제외).
-  $searchClose?.removeAttribute("aria-hidden");
-  $searchClose?.removeAttribute("tabindex");
+  // 닫기(X) 버튼 노출은 키보드 등장에 묶는다(setKeyboardState). 키보드가 없는
+  // 동안엔 홈 버튼과 동작이 겹쳐 중복이므로 숨겨 둔다.
   $searchInput.hidden = false;
   // /search 전체뷰로 진입(이미 검색 중이면 생략). route() → syncTabBarActive 가
   // active==='search' 를 보고 exitSearch 를 호출하지 않는다.

--- a/tests/unit/tabbar.test.js
+++ b/tests/unit/tabbar.test.js
@@ -1,0 +1,164 @@
+// ── Unit tests for js/app/tabbar.js ──────────────────────────────────────────
+// Run with: node --test tests/unit/tabbar.test.js
+//
+// tabbar.js is nav- and DOM-bound at module top level (getElementById +
+// click/visualViewport listeners), so the full morph/routing behavior is e2e's
+// responsibility (ADR-013). What IS unit-testable is the keyboard-up gating —
+// the crux of the bottom-dock keyboard handling: the overlap math plus the two
+// effects it drives. We slice the KEYBOARD block (mirrors search.test.js's
+// BEGIN/END approach) and run it in a vm with minimal window/element stubs.
+//
+// Coverage:
+//   - keyboardOverlap: 키보드 높이 = max(0, innerHeight − visualViewport.height)
+//   - setKeyboardState: body.tabbar-keyboard 토글 + 닫기(X) aria 게이팅
+//   - liftForKeyboard: 키보드 up 일 때만 --kb-overlap 설정 + X 노출, 1px 임계
+
+import test from "node:test";
+import assert from "node:assert";
+import vm from "node:vm";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const TABBAR_PATH = path.resolve(__dirname, "../../js/app/tabbar.js");
+const TABBAR_SOURCE = fs.readFileSync(TABBAR_PATH, "utf8");
+
+function extractBlock(name) {
+  const begin = `// ── BEGIN ${name} ──`;
+  const end = `// ── END ${name} ──`;
+  const startIdx = TABBAR_SOURCE.indexOf(begin);
+  const endIdx = TABBAR_SOURCE.indexOf(end);
+  if (startIdx < 0 || endIdx < 0) {
+    throw new Error(`marker block ${name} not found in js/app/tabbar.js`);
+  }
+  return TABBAR_SOURCE.slice(startIdx, endIdx + end.length);
+}
+
+const KEYBOARD_BLOCK = extractBlock("KEYBOARD");
+
+// ── Minimal stubs ────────────────────────────────────────────────────────────
+// classList tracking just `tabbar-keyboard`; element tracking only the attrs
+// and the --kb-overlap custom property the block touches.
+
+function makeClassList() {
+  const set = new Set();
+  return {
+    add: (c) => set.add(c),
+    remove: (c) => set.delete(c),
+    toggle: (c, force) => {
+      const want = typeof force === "boolean" ? force : !set.has(c);
+      if (want) set.add(c); else set.delete(c);
+      return want;
+    },
+    contains: (c) => set.has(c),
+  };
+}
+
+function makeEl() {
+  const attrs = new Map();
+  const props = new Map();
+  return {
+    attrs,
+    props,
+    setAttribute: (k, v) => attrs.set(k, String(v)),
+    removeAttribute: (k) => attrs.delete(k),
+    getAttribute: (k) => (attrs.has(k) ? attrs.get(k) : null),
+    style: {
+      setProperty: (k, v) => props.set(k, v),
+      getPropertyValue: (k) => props.get(k) ?? "",
+    },
+  };
+}
+
+// Build a vm context exposing the free variables the block references:
+// document.body, $searchClose, $dock, window. Returns the context plus handles.
+function makeCtx({ innerHeight = 800, vvHeight = 800, hasVV = true } = {}) {
+  const body = { classList: makeClassList() };
+  const $searchClose = makeEl();
+  const $dock = makeEl();
+  const window = {
+    innerHeight,
+    visualViewport: hasVV ? { height: vvHeight } : null,
+  };
+  const ctx = { document: { body }, $searchClose, $dock, window };
+  vm.createContext(ctx);
+  vm.runInContext(KEYBOARD_BLOCK, ctx);
+  return { ctx, body, $searchClose, $dock, window };
+}
+
+// ── keyboardOverlap ──────────────────────────────────────────────────────────
+
+test("keyboardOverlap: 키보드가 가린 높이 = innerHeight − vvHeight", () => {
+  const { ctx } = makeCtx();
+  assert.equal(ctx.keyboardOverlap(800, 500), 300);
+});
+
+test("keyboardOverlap: 음수는 0 으로 클램프(키보드 없음)", () => {
+  const { ctx } = makeCtx();
+  assert.equal(ctx.keyboardOverlap(800, 800), 0);
+  assert.equal(ctx.keyboardOverlap(800, 820), 0);
+});
+
+// ── setKeyboardState ─────────────────────────────────────────────────────────
+
+test("setKeyboardState(true): body 클래스 + X 버튼 a11y 노출", () => {
+  const { ctx, body, $searchClose } = makeCtx();
+  // 초기엔 X 가 a11y 트리에서 제외돼 있다고 가정.
+  $searchClose.setAttribute("aria-hidden", "true");
+  $searchClose.setAttribute("tabindex", "-1");
+
+  ctx.setKeyboardState(true);
+
+  assert.equal(body.classList.contains("tabbar-keyboard"), true);
+  assert.equal($searchClose.getAttribute("aria-hidden"), null);
+  assert.equal($searchClose.getAttribute("tabindex"), null);
+});
+
+test("setKeyboardState(false): 클래스 제거 + X 버튼 a11y 제외", () => {
+  const { ctx, body, $searchClose } = makeCtx();
+  ctx.setKeyboardState(true);
+
+  ctx.setKeyboardState(false);
+
+  assert.equal(body.classList.contains("tabbar-keyboard"), false);
+  assert.equal($searchClose.getAttribute("aria-hidden"), "true");
+  assert.equal($searchClose.getAttribute("tabindex"), "-1");
+});
+
+// ── liftForKeyboard ──────────────────────────────────────────────────────────
+
+test("liftForKeyboard: 키보드 up → --kb-overlap = 키보드 높이 + X 노출", () => {
+  const { ctx, body, $dock, $searchClose } = makeCtx({ innerHeight: 800, vvHeight: 500 });
+  ctx.liftForKeyboard();
+
+  // 실제 레이아웃 bottom 으로 올리는 값(transform 아님 → iOS 팬 방지).
+  assert.equal($dock.style.getPropertyValue("--kb-overlap"), "300px");
+  assert.equal(body.classList.contains("tabbar-keyboard"), true);
+  assert.equal($searchClose.getAttribute("aria-hidden"), null);
+});
+
+test("liftForKeyboard: 키보드 down → --kb-overlap 0 + X 숨김", () => {
+  const { ctx, body, $dock, $searchClose } = makeCtx({ innerHeight: 800, vvHeight: 800 });
+  ctx.liftForKeyboard();
+
+  assert.equal($dock.style.getPropertyValue("--kb-overlap"), "0px");
+  assert.equal(body.classList.contains("tabbar-keyboard"), false);
+  assert.equal($searchClose.getAttribute("aria-hidden"), "true");
+});
+
+test("liftForKeyboard: 1px 이하 차이는 키보드 없음으로 처리(반올림 오차)", () => {
+  const { ctx, body, $dock } = makeCtx({ innerHeight: 800, vvHeight: 799 });
+  ctx.liftForKeyboard();
+
+  // overlap === 1 은 up 아님(> 1 임계).
+  assert.equal($dock.style.getPropertyValue("--kb-overlap"), "0px");
+  assert.equal(body.classList.contains("tabbar-keyboard"), false);
+});
+
+test("liftForKeyboard: visualViewport 없으면 no-op(데스크탑/구형)", () => {
+  const { ctx, $dock } = makeCtx({ hasVV: false });
+  ctx.liftForKeyboard();
+  // 아무 속성도 설정하지 않음.
+  assert.equal($dock.style.getPropertyValue("--kb-overlap"), "");
+});


### PR DESCRIPTION
## 배경

`feat/morphing-tab-bar` 의 검색 모핑(ADR-030) 하단 dock 에서 보고된 두 가지 동작을 다듬습니다.

## 변경

### 1. 닫기(X) 버튼을 키보드가 떠 있는 동안에만 노출
키보드가 없는 상태(결과 화면·검색 진입 직후)의 원형 X 는 홈 버튼과 동작이 겹쳤습니다 — 둘 다 탭바를 복구하며 홈으로 이동. 중복을 제거하기 위해 `visualViewport` 로 키보드 상태를 추적하고 `body.tabbar-keyboard` 토글에 X 의 표시·a11y 노출을 묶었습니다. (index.html 의 기존 의도 주석 "키보드 등장과 함께 모핑 인" 과 일치)

### 2. 키보드 등장 시 헤더·빈 상태가 위로 밀려 올라가던 문제 수정
dock 을 `transform: translateY` 로 올리면 입력의 **레이아웃 사각형**은 키보드 뒤에 그대로 남아, iOS 가 "포커스 입력이 가려졌다"고 보고 페이지 전체를 위로 팬합니다(sticky 헤더·빈 상태가 화면 밖으로). `transform` 대신 실제 `bottom`(`--kb-overlap` 토큰)으로 올려 입력 사각형을 키보드 위에 두면 iOS 가 팬할 이유가 없어져 헤더와 기본 메시지가 제자리에 유지됩니다.

## 테스트

- 키보드 게이팅 로직(`keyboardOverlap` · `setKeyboardState` · `liftForKeyboard`)을 `BEGIN/END KEYBOARD` 블록으로 묶고 `tests/unit/tabbar.test.js` **8 케이스** 추가 (search.test.js 의 슬라이스 + vm 스텁 패턴).
- `node --test tests/unit/*.test.js` → **574 통과** (566 + 8).
- `npx tsc -p tsconfig.json --noEmit` 0 error.

> iOS 실기기 키보드 거동(시각 검증)은 e2e/수동 확인 영역(ADR-013)이라 유닛은 overlap 계산 + 상태 매핑까지 커버합니다.

https://claude.ai/code/session_01FoQkXBY4tFz5Ftskaighd2

---
_Generated by [Claude Code](https://claude.ai/code/session_01FoQkXBY4tFz5Ftskaighd2)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mobile-only tab bar/search UX and CSS custom property; logic is covered by new unit tests with no auth or data changes.
> 
> **Overview**
> Fixes two mobile search-morphing issues on the bottom **tab dock** (ADR-030).
> 
> **Keyboard lift:** The dock no longer uses `transform: translateY` to sit above the keyboard. **`tabbar.js`** now sets CSS **`--kb-overlap`** from `visualViewport` overlap math, and **`#tab-dock`** `bottom` includes that token so the input’s layout box moves above the keyboard—reducing iOS page pan that pushed the sticky header and empty state off-screen.
> 
> **Close (X) button:** The search close control is shown only while the keyboard is up (`body.tabbar-keyboard`), not for the whole search session—avoiding overlap with the home control when results are visible without a keyboard. A11y for X is gated in **`setKeyboardState`**.
> 
> **Tests:** New **`tests/unit/tabbar.test.js`** slices the `BEGIN/END KEYBOARD` block in **`tabbar.js`** (vm stubs) for overlap, keyboard state, and lift behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 265f9365cf7df957456870c004684f4913f3ff63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->