### PR TITLE
fix: 검색 닫기(X) 를 "키보드만 내리기"로 변경 — 홈 버튼과 역할 분리

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3090,11 +3090,11 @@ html.cite-sheet-open {
 #tab-dock.searching #tab-search-clear svg { width: 1.4rem; height: 1.4rem; }
 #tab-dock.searching #tab-search-clear:active { transform: scale(0.9); }
 
-/* ── ADR-030 P3: 검색 닫기(X) 버튼 — 입력 pill 오른쪽 원형 ───────────────────
+/* ── ADR-030 P3: 키보드 내리기 버튼 — 입력 pill 오른쪽 원형 ───────────────────
    "키보드가 나타나면 한 번 더 모핑": 키보드가 떠 있는 동안에만 width 0→60px 로
-   모핑 인(body.tabbar-keyboard). 키보드가 내려간 결과 화면에선 홈 버튼과 동작이
-   겹치므로(둘 다 탭바 복구→홈) 숨긴다. idle/no-keyboard 상태는 접힘(width/opacity 0)
-   이라 레이아웃·시각 비표시(collapse 탭과 동일 패턴). 닫으면(X) 전체 롤백. */
+   모핑 인(body.tabbar-keyboard). 탭하면 키보드만 내리고(blur) 검색 세션·입력값·
+   결과는 유지(grounded dock). 키보드가 내려간 결과 화면에선 접힘(width/opacity 0)
+   이라 레이아웃·시각 비표시(collapse 탭과 동일 패턴) — 검색 종료는 홈 버튼 담당. */
 #tab-search-close {
   flex: 0 0 auto;
   display: flex;

--- a/index.html
+++ b/index.html
@@ -167,10 +167,11 @@
       <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20zm3.5 12.1-1.4 1.4L12 13.4l-2.1 2.1-1.4-1.4L10.6 12 8.5 9.9l1.4-1.4L12 10.6l2.1-2.1 1.4 1.4L13.4 12l2.1 2.1z"/></svg>
     </button>
   </div>
-  <!-- ADR-030 P3: 검색 세션 종료(닫기) 버튼 — 입력 pill 오른쪽 원형(키보드 등장과 함께
-       모핑 인). 탭하면 검색 모드 전체 롤백 → 기본 탭 바. -->
-  <button id="tab-search-close" type="button" aria-label="검색 닫기" aria-hidden="true" tabindex="-1">
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M6 6 18 18M18 6 6 18"/></svg>
+  <!-- ADR-030 P3: 키보드 내리기 버튼 — 입력 pill 오른쪽 원형(키보드 등장과 함께 모핑 인,
+       키보드 표시 중에만 노출). 탭하면 키보드만 내리고 검색 세션은 유지(grounded dock).
+       아래쪽 chevron 으로 "키보드 접기"를 표상(검색 종료는 홈 버튼). -->
+  <button id="tab-search-close" type="button" aria-label="키보드 내리기" aria-hidden="true" tabindex="-1">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m6 10 6 6 6-6"/></svg>
   </button>
   </div><!-- /#tab-dock -->
   <noscript>

--- a/js/app/tabbar.js
+++ b/js/app/tabbar.js
@@ -167,8 +167,9 @@ $searchInput?.addEventListener("keydown", (e) => {
   if (e.key === "Enter") {
     e.preventDefault();
     W.commitTopSearch?.($searchInput.value);
-    // 검색 실행 → "이전 모드로 롤백": 키보드를 내려 dock 을 키보드 위 모핑(stage 2)에서
-    // 접지(grounded) 상태로 복귀. 검색 세션·닫기(X)는 유지(결과 화면, screenshot 2).
+    // 검색 실행 → 키보드를 내려 dock 을 키보드 위 모핑(stage 2)에서 접지(grounded)
+    // 상태로 복귀. 검색 세션은 유지(결과 화면). 키보드가 내려가므로 닫기(X)는 접힌다
+    // (X 는 키보드 표시 중에만 노출 — 결과 화면에선 홈 버튼으로 종료).
     $searchInput.blur();
   }
 });
@@ -195,10 +196,13 @@ $searchClear?.addEventListener("click", () => {
   $searchInput.focus();
 });
 
-// 검색 닫기(X) — 검색 세션 전체 롤백 → 기본 탭 바. navigate 가 route →
-// syncTabBarActive → exitTabSearch 를 태운다.
+// 닫기(X) — 키보드가 떠 있을 때만 보이며(setKeyboardState), 키보드만 내린다.
+// 검색 세션·입력값·결과는 유지(grounded dock) → 결과를 스크롤해 둘러볼 수 있다.
+// blur 로 키보드가 내려가면 visualViewport resize → setKeyboardState(false) 가
+// X 를 접고 body.tabbar-keyboard 를 푼다. 다시 입력을 탭하면 키보드·X 가 복귀.
+// 검색 종료(→홈)는 홈 버튼 담당(X 와 역할 분리).
 $searchClose?.addEventListener("click", () => {
-  closeSearchToHome();
+  $searchInput?.blur();
 });
 
 // views-routing 의 syncTabBarActive 가 라우트 변경 시 호출(검색 외 라우트면 복구).

--- a/js/app/tabbar.js
+++ b/js/app/tabbar.js
@@ -202,7 +202,12 @@ $searchClear?.addEventListener("click", () => {
 // X 를 접고 body.tabbar-keyboard 를 푼다. 다시 입력을 탭하면 키보드·X 가 복귀.
 // 검색 종료(→홈)는 홈 버튼 담당(X 와 역할 분리).
 $searchClose?.addEventListener("click", () => {
+  // 키보드·스크린리더 사용자는 X 자체에 포커스가 있다. 키보드가 내려가면 X 가
+  // 곧 a11y 트리에서 제외(aria-hidden·tabindex -1)되므로, 포커스가 숨은 컨트롤에
+  // 갇히지 않게 검색 버튼으로 옮긴다(closeSearchToHome 과 동일한 복귀 타깃 —
+  // grounded dock 에서도 보이는 컨트롤). 입력에 주면 키보드가 다시 떠 제외.
   $searchInput?.blur();
+  $searchBtn?.focus();
 });
 
 // views-routing 의 syncTabBarActive 가 라우트 변경 시 호출(검색 외 라우트면 복구).


### PR DESCRIPTION
## 배경

#186 후속. 키보드가 떠 있을 때의 X 버튼이 홈 버튼과 동작이 완전히 겹쳤습니다 — 둘 다 검색 세션을 롤백하고 홈으로 이동. (X 클릭 → `closeSearchToHome()` → `navigate("/")`)

## 변경

X 를 **"키보드만 내리기"** 버튼으로 재정의합니다(입력값·검색 결과 유지, grounded dock → 결과를 스크롤해 둘러보기 좋게).

- **동작**: X 클릭 → `closeSearchToHome()` 대신 `$searchInput.blur()`. blur 로 키보드가 내려가면 `visualViewport` resize → `setKeyboardState(false)` 가 X 를 접고 `body.tabbar-keyboard` 를 해제. 다시 입력을 탭하면 키보드·X 가 복귀.
- **역할 분리**: 검색 종료(→홈)는 **홈 버튼** 전담. Esc(`closeTabSearch`)는 기존대로 전체 종료.
- **시각/a11y**: 아이콘을 `X` → **아래 chevron** 으로, `aria-label` 을 `검색 닫기` → **`키보드 내리기`** 로 변경해 새 의미를 정확히 표상.

## 테스트

- `node --test tests/unit/*.test.js` → **574 통과**.
- `npx tsc -p tsconfig.json --noEmit` 0 error.

> X 클릭 핸들러는 한 줄짜리 DOM 핸들러(blur)라 유닛 신규 추가 없이 기존 키보드 게이팅 테스트가 후속 상태(키보드 내려감 → X 접힘)를 커버합니다. 실기기 거동은 e2e/수동 확인 영역(ADR-013).

https://claude.ai/code/session_01FoQkXBY4tFz5Ftskaighd2

---
_Generated by [Claude Code](https://claude.ai/code/session_01FoQkXBY4tFz5Ftskaighd2)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized mobile tab-bar search UX and focus handling; no routing, auth, or data-layer changes.
> 
> **Overview**
> **Mobile tab search:** the control beside the search pill (`#tab-search-close`) no longer ends the search session and navigates home. It **dismisses the keyboard only**—`blur` on the input and focus moved to the search button—while keeping the grounded dock, query, and results.
> 
> **UX/a11y:** icon changes from **X** to a **down chevron**; `aria-label` becomes **키보드 내리기**. Comments in `tabbar.js`, `index.html`, and `style.css` document that **ending search stays on the home tab** (and Esc via `closeTabSearch` unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12f8797bd27d8a40a94e04ce0c574411288df734. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->