### PR TITLE
feat: 모바일 읽기 헤더 북마크 = 이 장 저장 모달 + 우측 끝 정렬

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3692,7 +3692,9 @@ body.tabbar-searching #search-inpage-bar { display: none; }
 
 .title-bookmark-btn {
   position: absolute;
-  right: 2.4rem;
+  /* 우측 끝 정렬 — 모바일 설정 기어가 탭 바로 이전(ADR-029)돼 title 행 우측이 비었고,
+     데스크탑 기어는 상단 행에 있어, 양쪽 모두 북마크가 far-right slot 을 차지(ADR-030 후속). */
+  right: 0;
   top: 50%;
   transform: translateY(-50%);
   /* HIG 최소 탭 영역 44px (2.45rem ≈ 44px @ 18px root) — .title-back-btn 와 동일 */
@@ -3711,15 +3713,6 @@ body.tabbar-searching #search-inpage-bar { display: none; }
 
 .title-bookmark-btn:hover {
   opacity: 0.7;
-}
-
-/* Desktop: the settings gear lives in the top row (#settings-anchor), not the
-   title row, so the bookmark takes the far-right slot instead of sitting inset
-   by the (hidden) per-view gear's width. Mobile keeps right: 2.4rem. */
-@media (min-width: 769px) {
-  .title-bookmark-btn {
-    right: 0;
-  }
 }
 
 /* ── Settings button placement (responsive) ──

--- a/index.html
+++ b/index.html
@@ -161,7 +161,7 @@
     <button id="tab-search" type="button" aria-label="검색" aria-expanded="false">
       <svg class="tab-search-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="6.4"/><path d="m20 20-3.7-3.7"/></svg>
     </button>
-    <input id="tab-search-input" type="search" inputmode="search" enterkeyhint="search" autocorrect="off" autocapitalize="off" spellcheck="false" autocomplete="off" placeholder="검색 (예: 사랑, 사랑 in:요한, 창세 1:3)" aria-label="검색" hidden>
+    <input id="tab-search-input" type="search" inputmode="search" enterkeyhint="search" autocorrect="off" autocapitalize="off" spellcheck="false" autocomplete="off" placeholder="예: 사랑, 사랑 in:요한, 창세 1:3" aria-label="검색" hidden>
     <!-- ADR-030 P3: 입력 pill 안의 검색어 지우기(⊗) — 텍스트 있을 때만 표시. -->
     <button id="tab-search-clear" type="button" aria-label="검색어 지우기" hidden>
       <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20zm3.5 12.1-1.4 1.4L12 13.4l-2.1 2.1-1.4-1.4L10.6 12 8.5 9.9l1.4-1.4L12 10.6l2.1-2.1 1.4 1.4L13.4 12l2.1 2.1z"/></svg>

--- a/js/app/bookmark.js
+++ b/js/app/bookmark.js
@@ -826,7 +826,12 @@ function buildBookmarkHeaderBtn(bookId, chapter) {
   path.setAttribute("d", hasBookmark ? BOOKMARK_ICON_FILLED : BOOKMARK_ICON_OUTLINE);
   svg.appendChild(path);
   btn.appendChild(svg);
-  btn.addEventListener("click", () => openBookmarkDrawer(bookId, chapter));
+  // 모바일 읽기 화면(장 맥락 있음)에선 헤더 북마크 = '이 장 저장' 모달로 바로 진입.
+  // 그 외(데스크탑 전체, 또는 책 목록·장 선택처럼 장 맥락 없음)는 기존 드로어.
+  btn.addEventListener("click", () => {
+    if (_isMobileViewport() && bookId && chapter != null) openSaveModal("chapter");
+    else openBookmarkDrawer(bookId, chapter);
+  });
   return btn;
 }
 

--- a/js/app/search.js
+++ b/js/app/search.js
@@ -303,7 +303,7 @@ function buildInPageSearchInput(query, autofocus = false) {
     autocorrect: "off",
     autocapitalize: "off",
     spellcheck: "false",
-    placeholder: "검색 (예: 사랑, 사랑 in:요한, 창세 1:3)",
+    placeholder: "예: 사랑, 사랑 in:요한, 창세 1:3",
     "aria-label": "검색",
     autocomplete: "off",
   }));

--- a/tests/e2e/test_features.py
+++ b/tests/e2e/test_features.py
@@ -68,3 +68,19 @@ def test_long_press_save_updates_header_bookmark_icon(browser):
     assert raw, "bookmark should be saved to localStorage after long-press save"
 
     ctx.close()
+
+
+def test_mobile_reading_header_bookmark_opens_save_modal(browser):
+    """모바일 읽기 헤더 북마크 버튼 = '이 장 저장' 모달(드로어 아님) — ADR-030 후속."""
+    ctx = browser.new_context(viewport={"width": 390, "height": 844}, has_touch=True)
+    ctx.add_init_script("localStorage.removeItem('bible-bookmarks');")
+    page = ctx.new_page()
+    try:
+        page.goto(f"{BASE}/gen/1")
+        page.wait_for_selector("article.chapter-text .verse")
+        page.locator(".title-bookmark-btn").click()
+        page.wait_for_selector("#bm-save-modal:not([hidden])")
+        assert page.locator("#bookmark-drawer").get_attribute("hidden") is not None, \
+            "drawer must stay closed on mobile reading header (modal instead)"
+    finally:
+        ctx.close()


### PR DESCRIPTION
모바일 읽기 화면의 헤더 북마크 버튼을, 드로어 대신 **'이 장 저장' 모달**로 바로 진입하게 바꾸고 헤더 **우측 끝에 정렬**한다. (드로어 자체 제거는 데스크탑 사이드바 단계에서 — 본 PR은 모바일 읽기 헤더 한정.)

## 변경
- **클릭 동작(읽기 화면 모바일 한정)**: `buildBookmarkHeaderBtn` 클릭이 `_isMobileViewport() && 장 맥락`이면 `openSaveModal("chapter")`(이미 존재하는 모달, readingContext 사용 + 머지 체크 포함). 데스크탑·비읽기(책목록·장선택, 장 맥락 없음)는 기존 `openBookmarkDrawer` 유지.
- **우측 끝 정렬**: `.title-bookmark-btn { right: 0 }`. 모바일 설정 기어가 탭 바로 이전(ADR-029)돼 비어 있던 `2.4rem` 인셋 제거. 데스크탑 redundant override 정리.
- **절 선택**은 본문 절 롱프레스로 유지(드로어 없이도 진입 가능), 북마크 조회/관리는 북마크 탭.

## 범위 밖(후속)
- 드로어 완전 제거 + 데스크탑 /bookmarks 전체 뷰 전환 → 데스크탑 사이드바 단계.

## 테스트
- 유닛 578·tsc 0(app+worker). e2e: 모바일 읽기 헤더 → 저장 모달(드로어 미표시) 케이스 추가. 기존 폴더 CRUD e2e는 데스크탑 컨텍스트라 드로어 경로 유지(영향 없음).
- dev 검증: 읽기(/matt/2) → 모달·우측정렬, 장선택(/matt) → 드로어(장 맥락 없음).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Bookmark UX and CSS alignment only; desktop and non-reading flows unchanged; save modal reuses existing logic with new e2e coverage.
> 
> **Overview**
> **모바일 읽기 화면**에서 헤더 북마크 탭 동작과 위치를 ADR-030 후속에 맞춘다.
> 
> `buildBookmarkHeaderBtn` 클릭 시 **모바일 뷰포트이고 장 맥락(`bookId`·`chapter`)이 있으면** `openSaveModal("chapter")`로 바로 **「이 장 저장」** 모달을 연다. 데스크탑·장 맥락 없는 화면(책/장 선택 등)은 기존처럼 `openBookmarkDrawer`를 유지한다.
> 
> `.title-bookmark-btn`을 **`right: 0`** 으로 통일해 타이틀 행 **우측 끝**에 붙이고, 데스크탑 전용 `@media` 오버라이드는 제거한다.
> 
> 검색 입력 **placeholder**에서 `검색` 접두어를 빼 **`예: 사랑, …`** 형태로 맞춘다(`#tab-search-input`, in-page 검색 바).
> 
> **e2e**: 모바일 `/gen/1`에서 헤더 북마크 → 저장 모달 표시, 드로어는 닫힌 상태를 검증한다.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed7bae30a59b753113157c8c202390c9d855afd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->