### PR TITLE
fix: 폴더 안 북마크 스와이프 시 액션 컬러가 화면 끝까지 닿도록

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -5461,8 +5461,18 @@ body.verse-select-active .verse[data-vref]:not(.verse-selected):hover {
     padding: 0;
   }
 
+  /* Nested rows go full-bleed (no UL indent) so a swipe action's color reaches
+     the screen edge even inside a folder; the visual indent moves onto the
+     content's padding-left (per depth via --bm-indent) below. */
+  .bm-folder-children {
+    padding-left: 0;
+  }
+
   .bm-row-content {
     padding: var(--space-3) var(--space-4);
+    /* Depth indent lives here (not on the folder-children UL) so the row stays
+       full-bleed; --bm-indent is set per nesting level by the item builders. */
+    padding-left: calc(var(--space-4) + var(--bm-indent, 0px));
     background: var(--bg);
     position: relative;
     z-index: 1; /* slider sits above the full-bleed actions, hiding them when closed */

--- a/docs/decisions/010-bookmark-feature.md
+++ b/docs/decisions/010-bookmark-feature.md
@@ -372,3 +372,11 @@ li.bm-bookmark
 > 글자가 중앙으로 밀리지 않는다**. 행 높이: 본문 1.8 leading 상속으로 2줄 북마크가 1줄 폴더보다 커서 짧은
 > 폴더 뒤 액션이 비치던 문제 → `.bm-row-content` 에 `line-height: --leading-snug` + 공유 `min-height` +
 > `align-self: stretch` 로 폴더·북마크 **동일 높이** + 콘텐츠가 행을 꽉 채워 피킹 제거.
+>
+> **중첩 행 full-bleed (2026-06-06 후속²):** 폴더 안 북마크는 `.bm-folder-children`
+> `padding-left`(들여쓰기) 때문에 행이 안쪽으로 밀려 스와이프 액션 컬러가 화면 끝에
+> 닿지 못하고 여백이 생겼다. 모바일에서 **들여쓰기를 UL 패딩 → 콘텐츠 패딩으로 이전** —
+> `.bm-folder-children { padding-left: 0 }`(행 full-bleed) + `.bm-row-content`
+> `padding-left: calc(var(--space-4) + var(--bm-indent))`, 깊이별 `--bm-indent`(= `--space-8 × depth`)
+> 를 아이템 빌더가 콘텐츠에 인라인 설정. 본문 위치는 동일(루트 16px, depth1 48px…)하되 행은
+> 가장자리까지 차 액션 컬러가 화면 끝에 닿는다. 데스크탑은 스와이프가 없어 기존 UL 패딩 유지.

--- a/js/app/bookmark.js
+++ b/js/app/bookmark.js
@@ -1146,6 +1146,9 @@ function _buildBookmarkItem(bm, depth) {
   // the active sort inside the handler.
   _setupDragHandle(li, row);
   const content = el("div", { className: "bm-row-content" });
+  // Nested-row indent lives on the content (mobile keeps the row full-bleed so
+  // the swipe action reaches the screen edge) — one folder level = --space-8.
+  if (depth > 0) content.style.setProperty("--bm-indent", `calc(var(--space-8) * ${depth})`);
   const typeIcon = el("span", { className: "bm-bookmark-type-icon" });
   typeIcon.appendChild(_buildBookmarkTypeIcon(isActive));
   const link = el("a", { className: "bm-bookmark-link", href: _bookmarkHref(bm), draggable: "false" });
@@ -1455,6 +1458,8 @@ function _buildFolderItem(folder, depth) {
   // See bookmark row: handler owns swipe-to-reveal; reorder self-gates on sort.
   _setupDragHandle(li, row);
   const content = el("div", { className: "bm-row-content" });
+  // Same depth indent as bookmark rows (one folder level = --space-8).
+  if (depth > 0) content.style.setProperty("--bm-indent", `calc(var(--space-8) * ${depth})`);
   const toggle = el("span", { className: "bm-folder-toggle", "aria-hidden": "true" });
   toggle.appendChild(_buildFolderToggleIcon(expanded));
   const name = el("span", { className: "bm-folder-name" }, folder.name);


### PR DESCRIPTION
## 문제

폴더 안에 중첩된 북마크를 스와이프하면 삭제/수정 액션 컬러가 화면 가장자리에 닿지 못하고 **왼쪽에 여백**이 생깁니다 (스크린샷의 빨강 삭제가 들여쓴 만큼 떠 있음).

## 원인

중첩 북마크 행은 `.bm-folder-children { padding-left: var(--space-8) }`(폴더 들여쓰기)로 안쪽으로 밀립니다. 스와이프 액션은 `position: absolute; left: 0`로 **행 기준**이라, 행이 들여쓴 만큼 액션도 안쪽에서 시작 → 화면 끝에 닿지 못합니다.

## 해결

들여쓰기를 **UL 패딩 → 콘텐츠 패딩**으로 이전(모바일):
- `.bm-folder-children { padding-left: 0 }` — 행을 full-bleed로(액션이 화면 끝까지).
- `.bm-row-content { padding-left: calc(var(--space-4) + var(--bm-indent, 0px)) }` — 들여쓰기를 콘텐츠로.
- 깊이별 `--bm-indent`(= `--space-8 × depth`)를 `_buildBookmarkItem`/`_buildFolderItem`이 콘텐츠에 인라인 설정.

본문(아이콘/텍스트) 위치는 **그대로**(루트 16px, depth1 48px…)이고, 행만 가장자리까지 채워져 액션 컬러가 화면 끝에 닿습니다. 데스크탑은 스와이프가 없어 기존 UL 패딩 유지.

## 검증
- `npx tsc -p tsconfig.json --noEmit` 0 error.
- `node --test tests/unit/bookmark.test.js` — **123 pass**.
- 중첩+루트 북마크 인터랙티브 미리보기로 액션이 양쪽 모두 화면 끝에 닿음을 확인.

> PR #202(merged) 후속. 동일 변경 재오픈 아님 — 머지 후 발견된 중첩 행 회귀 수정.

https://claude.ai/code/session_01PHnHyjQKRX5U29Nf79Kimw

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHnHyjQKRX5U29Nf79Kimw)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to mobile bookmark list layout/CSS and inline depth tokens; desktop unchanged and existing unit tests pass.
> 
> **Overview**
> Fixes a **regression after full-bleed swipe actions**: bookmarks inside folders still sat inset because `.bm-folder-children` used `padding-left`, so delete/edit color stopped short of the screen edge.
> 
> On **mobile (≤768px)** only, nesting indent moves from the folder list to row content: `.bm-folder-children { padding-left: 0 }` keeps rows edge-to-edge, while `.bm-row-content` uses `padding-left: calc(var(--space-4) + var(--bm-indent))`. `_buildBookmarkItem` and `_buildFolderItem` set `--bm-indent` to `calc(var(--space-8) * depth)` on the content node so **text alignment stays the same** but swipe backgrounds can bleed to the viewport. Desktop keeps the original UL indent (no swipe). ADR-010 documents the nested full-bleed follow-up.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc21981ca9e985a364adfc9305fa935b9cac78c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->