### PR TITLE
fix: 검색 버튼 탭 시 키보드 즉시 표시

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1685,6 +1685,66 @@ body {
   color: var(--text-secondary);
 }
 
+/* 검색 방법 guide on the empty /search view (extends the ADR-030 P3 empty
+   state): tappable example queries under the prompt. Centered column to match
+   .empty-state, but each row is a left-aligned card so the example queries scan
+   as a list — tapping one runs that search. Uses neutral --accent for chrome
+   (ADR-028: theme color stays limited to verse nums / nav signature). */
+.search-examples {
+  width: 100%;
+  max-width: 22rem;
+  margin: var(--space-5) auto 0;
+}
+.search-examples-heading {
+  margin: 0 0 var(--space-3);
+  text-align: center;
+  font-size: var(--font-sm);
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+.search-examples-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+.search-example-btn {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  width: 100%;
+  min-height: var(--touch-target);
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-card);
+  color: var(--text);
+  text-align: left;
+  cursor: pointer;
+  transition: background var(--duration-fast) var(--ease-standard);
+}
+.search-example-btn:hover,
+.search-example-btn:focus-visible {
+  background: color-mix(in srgb, var(--accent) 8%, var(--bg-card));
+}
+.search-example-btn:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 2px color-mix(in srgb, var(--accent) 50%, transparent);
+}
+.search-example-btn:active {
+  background: color-mix(in srgb, var(--accent) 12%, var(--bg-card));
+}
+.search-example-q {
+  flex: none;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: var(--font-sm);
+  color: var(--accent);
+}
+.search-example-desc {
+  font-size: var(--font-sm);
+  color: var(--text-secondary);
+}
+
 .search-results {
   list-style: none;
 }

--- a/docs/decisions/030-morphing-tab-bar.md
+++ b/docs/decisions/030-morphing-tab-bar.md
@@ -108,6 +108,8 @@ ADR-029 는 Safari 26 home-indicator 틴팅 회피를 위해 glass 를 `::before
 - **축소 상태 복구 = 최상단 자동 복구 + 홈 탭(펼치기)**. (초안 "홈 탭으로만"에서 dev 검증 후 개정 — 최상단 도달 시 자동 복구가 자연스럽고, 홈 탭은 홈 이동이 아니라 펼치기로 일원화.) iOS Safari 식 "위로 스크롤 즉시 복구"는 끝에서 깜빡일 수 있어, **최상단에서만** 자동 복구 + 중간 위로 스크롤은 유지로 절충.
 - **검색 입력 = 하단 입력창 직접 검색 + visualViewport 키보드 위 띄움**(대안: 모핑은 연출만 하고 입력은 `/search` 상단으로 핸드오프 — 미채택). iOS 가 포커스 입력을 키보드 위로 올리려 페이지를 미는 문제는 **focus 시 `scrollTo(0,0)` + `preventScroll`**로 상쇄, **X(키보드 내리기) 노출·홈 숨김은 입력 focus/blur**에 묶어(visualViewport 높이 감지 불안정 회피) 안정화.
 
+> **개정 (2026-06-07): 검색 버튼 탭 → 키보드 즉시 표시.** 검색 원형 버튼을 눌러 모핑 진입할 때 dock 입력 `focus()` 를 `requestAnimationFrame` 안에서 호출하고 있었는데, iOS Safari 는 프로그래밍 `focus()` 가 **사용자 제스처(탭 핸들러)와 같은 동기 실행 턴** 안에서 불릴 때만 소프트 키보드를 띄운다 — rAF 로 미루면 제스처 체인이 끊겨 입력엔 포커스가 가도 키보드가 안 떴다(검색 화면만 열리고 키보드는 한 번 더 입력을 탭해야 등장). `openSearch()` 는 `#tab-search` 클릭 핸들러에서 동기로 불리고(그 안 `navigate` 도 동기), 입력은 `hidden=false` 후 같은 함수 안에서 다루므로, rAF 를 제거하고 **`$searchInput.focus({ preventScroll: true })` 를 동기 호출**해 같은 제스처 턴에 머물게 했다. `renderSearchView` 는 `body.tabbar-searching`(navigate 전 설정) 일 때 in-page 입력 autofocus 를 끄므로 dock 포커스를 가로채지 않고, 이미 검색 중 재진입 분기(127–132)도 동일하게 동기 focus 라 일관. 키보드 위치 보정(`liftForKeyboard`/`--kb-overlap`)·X 게이팅은 그대로.
+
 ## 검토한 대안
 
 - **검색을 4탭 중 하나로 유지(ADR-029 원안)** — Apple Music idiom(분리 원형 + 모핑)과 어긋나고, 입력 확장 모션을 줄 자리가 없음. → 분리 원형 채택.

--- a/docs/decisions/030-morphing-tab-bar.md
+++ b/docs/decisions/030-morphing-tab-bar.md
@@ -87,6 +87,8 @@ ADR-029 는 Safari 26 home-indicator 틴팅 회피를 위해 glass 를 `::before
   - 홈 탭 등 검색 외 라우트로 가면 `views-routing` 의 `syncTabBarActive`가 `window.exitTabSearch`를 호출해 복구.
 - **빈 상태** — 결과 0건 / 빈 검색어 뷰에 중앙 빈 상태(돋보기 + 제목 + 부제).
 
+> **개정 (2026-06-07): 빈 검색 뷰 안내를 "검색 방법" 예시 가이드로.** 빈 검색어 뷰의 부제는 본래 예시 문자열(`예: 사랑, 사랑 in:요한, 창세 1:3`) 한 줄뿐이라 무엇을 입력할 수 있는지 불친절했다. 북마크 빈 목록(BOOKMARK_ADD_HELP)의 설명형 빈 상태를 참고하되, 세 검색 형식을 한 문장에 몰아넣는 대신 **예시별 안내 카드 목록**으로 풀었다 — 제목 "찾고 싶은 말씀을 검색해 보세요" + 한 줄 부제 + `이렇게 검색해 보세요` 가이드(`사랑`=낱말 / `사랑 in:요한`=책 범위 / `창세 1:3`=장·절 펼치기). 각 카드는 탭하면 그 예시로 바로 검색(`commitTopSearch`). `js/app/search.js` `SEARCH_EXAMPLES`/`buildSearchExamples`, `.search-examples*` CSS(중립 `--accent` 사용 — ADR-028 테마색 범위 유지). 결과 0건 부제도 다시 시도 제안으로 보완.
+
 ### 4. 옛 모바일 검색 시트 제거
 
 검색이 탭바 모핑 단일 경로가 되면서 **모바일 검색 바텀 시트(`openSearchSheet`/`closeSearchSheet`/`#search-sheet`·드래그)를 전면 제거**(search.js 대폭 감소). 데스크탑 인라인 검색 바 + `/search` 결과 경로는 유지. 검색 FAB 는 ADR-029 에서 이미 제거.

--- a/js/app/search.js
+++ b/js/app/search.js
@@ -331,11 +331,38 @@ function buildInPageSearchInput(query, autofocus = false) {
 }
 
 // Friendly guidance for the empty-query /search view — mirrors the bookmark
-// list's explanatory empty state (BOOKMARK_ADD_HELP) so first-time users learn
-// what they can type (낱말 검색 · in: 범위 좁히기 · 장:절 바로 펼치기) instead of
-// just seeing a bare example string.
-const SEARCH_INTRO_HELP =
-  "낱말을 입력하면 성경 전체에서 찾아 드립니다. ‘사랑 in:요한’처럼 특정 책으로 범위를 좁히거나, ‘창세 1:3’처럼 장과 절을 입력해 그 구절을 바로 펼칠 수도 있습니다.";
+// list's explanatory empty state (BOOKMARK_ADD_HELP), but instead of cramming
+// every search form into one run-on sentence it lays them out as a small
+// "검색 방법" guide (example query + what it does) that's easier to scan.
+const SEARCH_INTRO_HELP = "낱말, 책 이름, 장·절로 찾을 수 있습니다.";
+
+// Each row of the 검색 방법 guide: the example query the user can type + a short
+// plain-language description of what that form does. Mirrors the in-field
+// placeholder examples (예: 사랑, 사랑 in:요한, 창세 1:3).
+const SEARCH_EXAMPLES = [
+  { q: "사랑", desc: "성경 전체에서 낱말 찾기" },
+  { q: "사랑 in:요한", desc: "특정 책 안에서만 찾기" },
+  { q: "창세 1:3", desc: "장·절로 그 구절 바로 펼치기" },
+];
+
+// Build the 검색 방법 guide as a definition-style list (example → description).
+// Tapping a row fills + commits that example so users can try it without typing.
+function buildSearchExamples() {
+  const wrap = el("div", { className: "search-examples" });
+  wrap.appendChild(el("p", { className: "search-examples-heading" }, "이렇게 검색해 보세요"));
+  const list = el("ul", { className: "search-examples-list", role: "list" });
+  for (const { q, desc } of SEARCH_EXAMPLES) {
+    const item = el("li", { className: "search-example" });
+    const btn = el("button", { type: "button", className: "search-example-btn" });
+    btn.appendChild(el("code", { className: "search-example-q" }, q));
+    btn.appendChild(el("span", { className: "search-example-desc" }, desc));
+    btn.addEventListener("click", () => commitTopSearch(q));
+    item.appendChild(btn);
+    list.appendChild(item);
+  }
+  wrap.appendChild(list);
+  return wrap;
+}
 
 // Apple-Music-style centered empty state (ADR-030 P3): large magnifier glyph +
 // title + subtitle. Used for the empty-query /search view and zero-result lists.
@@ -384,6 +411,7 @@ function renderSearchView() {
   view.appendChild(
     buildSearchEmptyState("찾고 싶은 말씀을 검색해 보세요", SEARCH_INTRO_HELP)
   );
+  view.appendChild(buildSearchExamples());
   $app.appendChild(view);
 }
 

--- a/js/app/search.js
+++ b/js/app/search.js
@@ -225,7 +225,7 @@ function renderSearchResultList(container, result, query, page, pageSize, pagina
   if (!hasRef && result.total === 0) {
     if (!result.unmatchedScopes || result.unmatchedScopes.length === 0) {
       container.appendChild(
-        buildSearchEmptyState("검색 결과 없음", `"${query}"에 대한 결과가 없습니다.`)
+        buildSearchEmptyState("검색 결과가 없습니다", `‘${query}’에 해당하는 구절을 찾지 못했어요. 다른 낱말로 검색하거나 띄어쓰기를 바꿔 보세요.`)
       );
     }
     return;
@@ -330,6 +330,13 @@ function buildInPageSearchInput(query, autofocus = false) {
   return wrap;
 }
 
+// Friendly guidance for the empty-query /search view — mirrors the bookmark
+// list's explanatory empty state (BOOKMARK_ADD_HELP) so first-time users learn
+// what they can type (낱말 검색 · in: 범위 좁히기 · 장:절 바로 펼치기) instead of
+// just seeing a bare example string.
+const SEARCH_INTRO_HELP =
+  "낱말을 입력하면 성경 전체에서 찾아 드립니다. ‘사랑 in:요한’처럼 특정 책으로 범위를 좁히거나, ‘창세 1:3’처럼 장과 절을 입력해 그 구절을 바로 펼칠 수도 있습니다.";
+
 // Apple-Music-style centered empty state (ADR-030 P3): large magnifier glyph +
 // title + subtitle. Used for the empty-query /search view and zero-result lists.
 /**
@@ -375,7 +382,7 @@ function renderSearchView() {
   const morphing = document.body.classList.contains("tabbar-searching");
   view.appendChild(buildInPageSearchInput("", !morphing));
   view.appendChild(
-    buildSearchEmptyState("검색", "예: 사랑, 사랑 in:요한, 창세 1:3")
+    buildSearchEmptyState("찾고 싶은 말씀을 검색해 보세요", SEARCH_INTRO_HELP)
   );
   $app.appendChild(view);
 }

--- a/js/app/tabbar.js
+++ b/js/app/tabbar.js
@@ -156,7 +156,13 @@ function openSearch() {
     ? $inpage.value
     : (new URLSearchParams(location.search).get("q") || "");
   syncClearBtn();
-  requestAnimationFrame(() => $searchInput?.focus({ preventScroll: true }));
+  // 키보드는 검색 버튼 탭으로 떠야 한다. iOS Safari 는 프로그래밍 focus() 가 사용자
+  // 제스처(탭 핸들러)와 같은 동기 실행 안에서 호출될 때만 소프트 키보드를 띄운다 —
+  // rAF 로 미루면 제스처 체인이 끊겨 입력엔 포커스가 가도 키보드가 안 뜬다. openSearch
+  // 는 $searchBtn 클릭 핸들러에서 동기로 불리므로(그 위 navigate 도 동기), 여기서 바로
+  // focus 하면 같은 제스처 턴에 머문다. preventScroll: iOS 가 포커스 입력을 키보드 위로
+  // 보이려 페이지를 pan 하는 걸 막는다(dock 은 --kb-overlap 으로 별도로 올라간다).
+  $searchInput.focus({ preventScroll: true });
   attachKeyboardTracking();
 }
 


### PR DESCRIPTION
## 문제

검색 원형 버튼(`#tab-search`)을 누르면 검색 화면(모핑)은 열리지만 모바일(특히 iOS Safari)에서 **키보드가 바로 뜨지 않는다**. 입력을 한 번 더 탭해야 키보드가 등장했다.

## 원인

`openSearch()` 에서 dock 입력 `focus()` 를 `requestAnimationFrame` 안에서 호출하고 있었다. iOS Safari 는 프로그래밍 `focus()` 가 **사용자 제스처(탭 핸들러)와 같은 동기 실행 턴** 안에서 불릴 때만 소프트 키보드를 띄운다. rAF 로 미루면 제스처 체인이 끊겨 입력엔 포커스가 가도 키보드가 안 떴다.

## 수정

`js/app/tabbar.js` `openSearch()` 의 rAF 를 제거하고 `$searchInput.focus({ preventScroll: true })` 를 **동기 호출**.

- `openSearch()` 는 `#tab-search` 클릭 핸들러에서 동기로 호출되고, 그 안 `navigate` 도 동기 → focus 가 같은 제스처 턴에 머문다.
- `renderSearchView` 는 `body.tabbar-searching`(navigate 전 설정) 일 때 in-page 입력 autofocus 를 끄므로 dock 포커스를 가로채지 않는다.
- 이미 검색 중 재진입 분기(127–132)도 동일한 동기 focus 라 일관.
- 키보드 위치 보정(`liftForKeyboard`/`--kb-overlap`)·X 게이팅은 그대로.

## 테스트

- 유닛 650 케이스 전부 통과 (`node --test tests/unit/*.test.js`)
- 실제 모바일 키보드 등장은 e2e/수동 검증 영역(ADR-013)

## 문서

ADR-030 §6 에 개정 노트(2026-06-07) 추가.

https://claude.ai/code/session_01MSGKSgUcCYazwKYwGtpYAp

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSGKSgUcCYazwKYwGtpYAp)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> 모바일 검색 UX·빈 상태 UI 변경이며 인증·데이터·결제 경로는 없다. iOS 키보드는 수동/e2e 검증 권장(ADR-013).
> 
> **Overview**
> **검색 원형 탭 → 키보드 즉시 표시 (iOS Safari).** `openSearch()`에서 dock 입력 `focus()`를 `requestAnimationFrame` 밖으로 옮겨, 탭 제스처와 **같은 동기 턴**에 `$searchInput.focus({ preventScroll: true })`가 실행되게 한다. rAF로 미루면 iOS가 소프트 키보드를 띄우지 않던 문제를 해결한다. in-page 입력 autofocus(`tabbar-searching`)와의 역할 분담은 그대로다.
> 
> **빈 `/search` UX.** 한 줄 예시 부제 대신 제목·부제(`SEARCH_INTRO_HELP`)와 **「이렇게 검색해 보세요」** 카드 목록(`SEARCH_EXAMPLES` / `buildSearchExamples`)을 붙인다. 카드 탭 시 `commitTopSearch`로 해당 예시 검색. **0건** empty state 문구도 재시도 안내로 다듬는다. `.search-examples*` 스타일은 중립 `--accent`(ADR-028). ADR-030에 두 변경(2026-06-07) 개정 노트 반영.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 444c3c0db5972b42501e10ca072be8e0f15af0fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->