### PR TITLE
feat: 검색 옵션 + 최근 검색 목록

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1745,6 +1745,98 @@ body {
   color: var(--text-secondary);
 }
 
+/* 최근 검색 list on the mobile /search empty view — surfaces the ADR-014 history
+   store (shared with the desktop header dropdown) as an in-body list. Rows are
+   full-width tap targets (re-run the query) with a trailing × (delete one); the
+   header carries 모두 지우기. Neutral --accent for chrome (ADR-028). */
+.search-recent {
+  width: 100%;
+  max-width: 32rem;
+  margin: var(--space-2) auto 0;
+}
+.search-recent-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: 0 var(--space-1) var(--space-1);
+}
+.search-recent-title {
+  margin: 0;
+  font-size: var(--font-sm);
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+.search-recent-clear {
+  flex: none;
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--font-sm);
+  color: var(--accent);
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+.search-recent-clear:hover { text-decoration: underline; }
+.search-recent-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+}
+.search-recent-item {
+  display: flex;
+  align-items: center;
+  border-bottom: 1px solid var(--border);
+}
+.search-recent-item:last-child { border-bottom: none; }
+.search-recent-select {
+  flex: 1 1 auto;
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  min-width: 0;
+  min-height: var(--touch-target);
+  padding: var(--space-2) var(--space-2);
+  background: none;
+  border: none;
+  text-align: left;
+  color: var(--text);
+  font-size: var(--font-base);
+  cursor: pointer;
+}
+.search-recent-select:hover,
+.search-recent-select:focus-visible {
+  background: color-mix(in srgb, var(--accent) 8%, transparent);
+  outline: none;
+}
+.search-recent-icon {
+  flex: none;
+  width: 1.15rem;
+  height: 1.15rem;
+  color: var(--text-secondary);
+  opacity: 0.7;
+}
+.search-recent-q {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.search-recent-remove {
+  flex: none;
+  width: var(--touch-target);
+  height: var(--touch-target);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: var(--font-lg);
+  line-height: 1;
+  color: var(--text-secondary);
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+.search-recent-remove:hover { color: var(--text); }
+
 .search-results {
   list-style: none;
 }

--- a/js/app/search.js
+++ b/js/app/search.js
@@ -364,6 +364,90 @@ function buildSearchExamples() {
   return wrap;
 }
 
+// Recent-searches list for the mobile full-screen /search empty view. The
+// history CRUD (loadSearchHistory / removeSearchHistory / clearSearchHistory)
+// already backs the desktop header dropdown (ADR-014); here we surface the same
+// store as an in-body list so mobile users entering search see (and can re-run /
+// delete) their past queries. Returns a host element that repaints itself in
+// place on delete/clear so input focus is preserved. When the history is empty
+// (first run, or after 모두 지우기) it falls back to the empty-state prompt so the
+// view never goes blank.
+function buildRecentSearches() {
+  const host = el("div", { className: "search-recent-host" });
+  function paint() {
+    clearNode(host);
+    const list = loadSearchHistory();
+    if (!list.length) {
+      host.appendChild(
+        buildSearchEmptyState("찾고 싶은 말씀을 검색해 보세요", SEARCH_INTRO_HELP)
+      );
+      return;
+    }
+    const section = el("section", { className: "search-recent", "aria-label": "최근 검색" });
+    const head = el("div", { className: "search-recent-head" });
+    head.appendChild(el("h2", { className: "search-recent-title" }, "최근 검색"));
+    const clearAll = el("button", { type: "button", className: "search-recent-clear" }, "모두 지우기");
+    clearAll.addEventListener("click", () => {
+      clearSearchHistory();
+      topSearchHistory?.refresh();
+      paint();
+    });
+    head.appendChild(clearAll);
+    section.appendChild(head);
+
+    const ul = el("ul", { className: "search-recent-list", role: "list" });
+    for (const q of list) {
+      const li = el("li", { className: "search-recent-item" });
+      const select = el("button", { type: "button", className: "search-recent-select" });
+      select.appendChild(buildRecentIcon());
+      select.appendChild(el("span", { className: "search-recent-q" }, q));
+      select.addEventListener("click", () => commitTopSearch(q));
+      const remove = el("button", {
+        type: "button",
+        className: "search-recent-remove",
+        "aria-label": `최근 검색어 "${q}" 삭제`,
+      });
+      remove.appendChild(el("span", { "aria-hidden": "true" }, "×"));
+      remove.addEventListener("click", () => {
+        removeSearchHistory(q);
+        topSearchHistory?.refresh();
+        paint();
+      });
+      li.appendChild(select);
+      li.appendChild(remove);
+      ul.appendChild(li);
+    }
+    section.appendChild(ul);
+    host.appendChild(section);
+  }
+  paint();
+  return host;
+}
+
+// Small clock/history glyph for each recent-search row (built as an SVG node so
+// the markup stays string-free / XSS-safe, matching buildSearchEmptyState).
+function buildRecentIcon() {
+  const NS = "http://www.w3.org/2000/svg";
+  const icon = document.createElementNS(NS, "svg");
+  icon.setAttribute("viewBox", "0 0 24 24");
+  icon.setAttribute("fill", "none");
+  icon.setAttribute("stroke", "currentColor");
+  icon.setAttribute("stroke-width", "1.8");
+  icon.setAttribute("stroke-linecap", "round");
+  icon.setAttribute("stroke-linejoin", "round");
+  icon.setAttribute("aria-hidden", "true");
+  icon.classList.add("search-recent-icon");
+  const circle = document.createElementNS(NS, "circle");
+  circle.setAttribute("cx", "12");
+  circle.setAttribute("cy", "12");
+  circle.setAttribute("r", "9");
+  const hands = document.createElementNS(NS, "path");
+  hands.setAttribute("d", "M12 7v5l3 2");
+  icon.appendChild(circle);
+  icon.appendChild(hands);
+  return icon;
+}
+
 // Apple-Music-style centered empty state (ADR-030 P3): large magnifier glyph +
 // title + subtitle. Used for the empty-query /search view and zero-result lists.
 /**
@@ -408,9 +492,9 @@ function renderSearchView() {
   // (hidden) in-page input grab it back via autofocus.
   const morphing = document.body.classList.contains("tabbar-searching");
   view.appendChild(buildInPageSearchInput("", !morphing));
-  view.appendChild(
-    buildSearchEmptyState("찾고 싶은 말씀을 검색해 보세요", SEARCH_INTRO_HELP)
-  );
+  // Recent searches when present (else the empty-state prompt, handled inside);
+  // the 검색 방법 guide follows so first-timers always have an example to tap.
+  view.appendChild(buildRecentSearches());
   view.appendChild(buildSearchExamples());
   $app.appendChild(view);
 }


### PR DESCRIPTION
검색 옵션·히스토리 개선 작업입니다. 단계별 커밋으로 진행합니다.

## 1단계 — 모바일 검색 화면에 최근 검색 목록 노출 ✅ (이 커밋)

검색 히스토리 CRUD(`loadSearchHistory`/`removeSearchHistory`/`clearSearchHistory`)는 ADR-014로 이미 구현돼 **데스크탑 헤더 드롭다운**에만 노출돼 있었습니다. 모바일 `/search` 빈 화면에 같은 store를 인-바디 목록으로 surface 합니다.

- 검색 진입 시 **최근 검색** 목록 표시 (탭 → 재검색)
- 행 끝 **×** 로 개별 삭제
- 헤더 **모두 지우기** 로 전체 삭제
- 히스토리 없으면 기존 빈 상태 안내(검색 방법 예시)로 폴백
- 삭제/지우기 시 해당 섹션만 부분 리페인트(입력 포커스 보존), 데스크탑 컨트롤러 `refresh()`로 상태 동기화

## 다음 단계 (예정)

- **2단계 — Book picker 필터**: `in:` 연산자를 책 선택 UI로 (여러 책 + 구약/신약/외경 그룹). 입력창 아래 필터 칩.
- **3단계 — 결과 내 재검색**: 검색 엔진 AND 다중 키워드 지원.
- (미래) 검색 범위 성서/노트 — 노트 기능 도입 시.

## 테스트
- 유닛 650 케이스 통과, tsc 0 (config deprecation 제외)
- 실제 모바일 렌더는 e2e/수동 영역(원격 환경에 Playwright 없음)

https://claude.ai/code/session_01MSGKSgUcCYazwKYwGtpYAp

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSGKSgUcCYazwKYwGtpYAp)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> 검색 UI·로컬 히스토리 표시만 확장하며 기존 CRUD와 라우팅을 재사용해 보안·데이터 처리 영향은 없습니다.
> 
> **Overview**
> **모바일 `/search` 빈 화면**에 데스크탑 헤더와 같은 ADR-014 검색 히스토리 저장소를 **최근 검색** 인-바디 목록으로 노출합니다. 행 탭은 `commitTopSearch`로 재검색, **×**는 개별 삭제, **모두 지우기**는 전체 삭제이며, 삭제·지우기 시 `buildRecentSearches`가 호스트만 다시 그려 입력 포커스를 유지하고 `topSearchHistory?.refresh()`로 데스크탑 드롭다운과 동기화합니다. 히스토리가 없으면 기존 빈 상태 안내로 폴백하고, 그 아래 **검색 방법** 예시는 그대로 둡니다.
> 
> `css/style.css`에 `.search-recent*` 스타일(터치 타깃, ellipsis, 중립 `--accent`)을 추가했고, `renderSearchView`는 고정 빈 상태 대신 `buildRecentSearches()`를 붙입니다.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcb40cc8969158d9f8b27a0fce173573efa6fd27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->