### PR TITLE
refactor: 북마크 href/공유·정렬 헬퍼를 bookmark-core.js로 분리 (ADR-034 후속 PR2)

### DIFF
--- a/index.html
+++ b/index.html
@@ -414,6 +414,7 @@
   <script type="module" src="/js/app/search.js"></script>
   <script type="module" src="/js/app/reading-context.js"></script>
   <script type="module" src="/js/app/verse-spec.js"></script>
+  <script type="module" src="/js/app/bookmark-core.js"></script>
   <script type="module" src="/js/app/bookmark.js"></script>
   <!-- ADR-022: cite sheet (bottom sheet on mobile, right side panel on desktop) -->
   <aside id="cite-sheet" role="dialog" aria-modal="true" aria-labelledby="cite-sheet-title" hidden>

--- a/js/app/bookmark-core.js
+++ b/js/app/bookmark-core.js
@@ -1,0 +1,147 @@
+"use strict";
+// @ts-check
+
+// Bookmark core — extracted from bookmark.js (ADR-034 후속 PR2). Pure bookmark
+// display/link logic with no DOM or UI state: href/share builders (HREF block)
+// and the sort/last-viewed helpers (SORT block, localStorage-backed per-device
+// view settings). bookmark.js (UI) imports these; no external callers, no
+// window facade. Leaf module (localStorage only).
+
+/** @typedef {import("../types").BookmarkTreeNode} BookmarkTreeNode */
+/** @typedef {import("../types").BookmarkTreeBookmark} BookmarkTreeBookmark */
+
+// ── BEGIN BOOKMARK_HREF ──
+// Exercised by tests/unit/bookmark.test.js. Pure URL builder — verseSpec="all"
+// drops the verse segment so the link points at the whole chapter.
+function _bookmarkHref(bm) {
+  if (bm.verseSpec === "all") return `/${bm.bookId}/${bm.chapter}`;
+  return `/${bm.bookId}/${bm.chapter}/${bm.verseSpec}`;
+}
+
+// Public site origin used to build absolute shareable links. Deliberately a
+// single named constant (not the live `location.origin`) for two reasons: a link
+// copied from localhost / dev must still open the real app, and the domain may
+// change later (e.g. a unified bok.anglican.kr — "book of prayer"). Change it
+// HERE to repoint every shared link. NOTE: the canonical URL also appears in
+// index.html (<link rel="canonical">, og:*) and sitemap.xml — update those too if
+// the domain moves.
+const SITE_BASE = "https://bible.anglican.kr";
+
+// Build a Web Share API payload for one or more bookmarks. A single bookmark
+// shares as {title, url} (the native sheet shows a rich link); multiple share as
+// a {title, text} list (label + absolute URL per line). Pure — testable without
+// navigator.share.
+/**
+ * @param {BookmarkTreeBookmark[]} bookmarks
+ * @returns {{ title: string, url?: string, text?: string }}
+ */
+function _buildSharePayload(bookmarks) {
+  if (bookmarks.length === 1) {
+    const bm = bookmarks[0];
+    return { title: bm.label ?? "공동번역성서", url: SITE_BASE + _bookmarkHref(bm) };
+  }
+  const text = bookmarks
+    .map((bm) => `${bm.label ?? ""}\n${SITE_BASE}${_bookmarkHref(bm)}`.trim())
+    .join("\n\n");
+  return { title: "공동번역성서 북마크", text };
+}
+// ── END BOOKMARK_HREF ──
+
+// ── BEGIN BOOKMARK_SORT ──
+// Bookmark list ordering. The chosen sort is a per-device preference kept in
+// localStorage and deliberately NOT synced to Drive — ADR-011 sync covers the
+// bookmark objects, not this view setting. "manual" preserves the stored
+// (drag-reordered) order; the other modes cluster folders first, then
+// bookmarks, each group sorted by the chosen key. Sorting is display-only — it
+// returns a shallow copy and never rewrites the store.
+const _BM_SORT_KEY = "bible-bookmark-sort";
+/** @type {readonly string[]} */
+const _BM_SORT_MODES = ["manual", "title", "created", "modified", "viewed"];
+
+/** @returns {string} */
+function getBookmarkSort() {
+  try {
+    const v = localStorage.getItem(_BM_SORT_KEY);
+    return v && _BM_SORT_MODES.includes(v) ? v : "manual";
+  } catch { return "manual"; }
+}
+/** @param {string} mode */
+function setBookmarkSort(mode) {
+  if (!_BM_SORT_MODES.includes(mode)) return;
+  try { localStorage.setItem(_BM_SORT_KEY, mode); } catch { /* private mode */ }
+}
+
+// Per-device "last viewed" timestamps, keyed by bookmark id. Kept in
+// localStorage only: tracking this on the synced object would rewrite (and
+// re-sync) a bookmark every time it is merely opened, and would drag the
+// "수정한 날짜" key along with it.
+const _BM_VIEWED_KEY = "bible-bookmark-viewed";
+/** @returns {Record<string, number>} */
+function _loadViewedMap() {
+  try {
+    const raw = localStorage.getItem(_BM_VIEWED_KEY);
+    const m = raw ? JSON.parse(raw) : null;
+    return (m && typeof m === "object") ? m : {};
+  } catch { return {}; }
+}
+/** @param {string} id */
+function markBookmarkViewed(id) {
+  if (!id) return;
+  try {
+    const m = _loadViewedMap();
+    m[id] = Date.now();
+    localStorage.setItem(_BM_VIEWED_KEY, JSON.stringify(m));
+  } catch { /* private mode */ }
+}
+/** @param {string} id */
+function _forgetViewed(id) {
+  try {
+    const m = _loadViewedMap();
+    if (m[id] != null) { delete m[id]; localStorage.setItem(_BM_VIEWED_KEY, JSON.stringify(m)); }
+  } catch { /* private mode */ }
+}
+
+/** @param {BookmarkTreeNode} n @returns {string} */
+function _nodeTitle(n) {
+  return (n.type === "folder" ? n.name : n.label) || "";
+}
+
+// Build a comparator for a sort mode. Date modes sort newest-first; "title"
+// uses Korean locale collation. The viewed map is read once per sort rather
+// than once per comparison.
+/** @param {string} mode @returns {(a: BookmarkTreeNode, b: BookmarkTreeNode) => number} */
+function _bookmarkComparator(mode) {
+  if (mode === "title") {
+    return (a, b) => _nodeTitle(a).localeCompare(_nodeTitle(b), "ko");
+  }
+  const viewed = mode === "viewed" ? _loadViewedMap() : null;
+  /** @param {BookmarkTreeNode} n @returns {number} */
+  const keyOf = (n) => {
+    if (mode === "created")  return n.createdAt || 0;
+    if (mode === "modified") return n.updatedAt || n.createdAt || 0;
+    if (mode === "viewed")   return (viewed && viewed[n.id]) || n.createdAt || 0;
+    return 0;
+  };
+  return (a, b) => keyOf(b) - keyOf(a);
+}
+
+// Display-ordered shallow copy of `nodes` for the active sort mode. "manual"
+// keeps the exact stored order (including any folder/bookmark interleaving from
+// drag); other modes put folders before bookmarks, each sorted by the key.
+/** @param {BookmarkTreeNode[]} nodes @returns {BookmarkTreeNode[]} */
+function sortBookmarkNodes(nodes) {
+  const list = Array.isArray(nodes) ? nodes : [];
+  const mode = getBookmarkSort();
+  if (mode === "manual") return list.slice();
+  const cmp = _bookmarkComparator(mode);
+  const folders = list.filter(n => n.type === "folder").sort(cmp);
+  const marks   = list.filter(n => n.type !== "folder").sort(cmp);
+  return [...folders, ...marks];
+}
+// ── END BOOKMARK_SORT ──
+
+export {
+  _bookmarkHref, _buildSharePayload,
+  getBookmarkSort, setBookmarkSort, markBookmarkViewed, _forgetViewed,
+  sortBookmarkNodes,
+};

--- a/js/app/bookmark.js
+++ b/js/app/bookmark.js
@@ -30,6 +30,14 @@ import {
   selectedVersesToSpec, mergeVerseSpecs, serializeVerseRange,
 } from "./verse-spec.js";
 
+// Bookmark href/share builders + sort/last-viewed helpers split out to
+// bookmark-core.js (ADR-034 후속). Internal-only (no facade); imported here.
+import {
+  _bookmarkHref, _buildSharePayload,
+  getBookmarkSort, setBookmarkSort, markBookmarkViewed, _forgetViewed,
+  sortBookmarkNodes,
+} from "./bookmark-core.js";
+
 // ── BEGIN BOOKMARK_QUERY ──
 // Exercised by tests/unit/bookmark.test.js. Pure tree operations on the
 // in-memory bookmark store; only `findExistingChapterBookmarks` calls out
@@ -922,135 +930,6 @@ function closeBookmarkDrawer() { drawerOverlay.close(); }
 
 // ── Bookmark tree rendering ──
 
-// ── BEGIN BOOKMARK_HREF ──
-// Exercised by tests/unit/bookmark.test.js. Pure URL builder — verseSpec="all"
-// drops the verse segment so the link points at the whole chapter.
-function _bookmarkHref(bm) {
-  if (bm.verseSpec === "all") return `/${bm.bookId}/${bm.chapter}`;
-  return `/${bm.bookId}/${bm.chapter}/${bm.verseSpec}`;
-}
-
-// Public site origin used to build absolute shareable links. Deliberately a
-// single named constant (not the live `location.origin`) for two reasons: a link
-// copied from localhost / dev must still open the real app, and the domain may
-// change later (e.g. a unified bok.anglican.kr — "book of prayer"). Change it
-// HERE to repoint every shared link. NOTE: the canonical URL also appears in
-// index.html (<link rel="canonical">, og:*) and sitemap.xml — update those too if
-// the domain moves.
-const SITE_BASE = "https://bible.anglican.kr";
-
-// Build a Web Share API payload for one or more bookmarks. A single bookmark
-// shares as {title, url} (the native sheet shows a rich link); multiple share as
-// a {title, text} list (label + absolute URL per line). Pure — testable without
-// navigator.share.
-/**
- * @param {BookmarkTreeBookmark[]} bookmarks
- * @returns {{ title: string, url?: string, text?: string }}
- */
-function _buildSharePayload(bookmarks) {
-  if (bookmarks.length === 1) {
-    const bm = bookmarks[0];
-    return { title: bm.label ?? "공동번역성서", url: SITE_BASE + _bookmarkHref(bm) };
-  }
-  const text = bookmarks
-    .map((bm) => `${bm.label ?? ""}\n${SITE_BASE}${_bookmarkHref(bm)}`.trim())
-    .join("\n\n");
-  return { title: "공동번역성서 북마크", text };
-}
-// ── END BOOKMARK_HREF ──
-
-// ── BEGIN BOOKMARK_SORT ──
-// Bookmark list ordering. The chosen sort is a per-device preference kept in
-// localStorage and deliberately NOT synced to Drive — ADR-011 sync covers the
-// bookmark objects, not this view setting. "manual" preserves the stored
-// (drag-reordered) order; the other modes cluster folders first, then
-// bookmarks, each group sorted by the chosen key. Sorting is display-only — it
-// returns a shallow copy and never rewrites the store.
-const _BM_SORT_KEY = "bible-bookmark-sort";
-/** @type {readonly string[]} */
-const _BM_SORT_MODES = ["manual", "title", "created", "modified", "viewed"];
-
-/** @returns {string} */
-function getBookmarkSort() {
-  try {
-    const v = localStorage.getItem(_BM_SORT_KEY);
-    return v && _BM_SORT_MODES.includes(v) ? v : "manual";
-  } catch { return "manual"; }
-}
-/** @param {string} mode */
-function setBookmarkSort(mode) {
-  if (!_BM_SORT_MODES.includes(mode)) return;
-  try { localStorage.setItem(_BM_SORT_KEY, mode); } catch { /* private mode */ }
-}
-
-// Per-device "last viewed" timestamps, keyed by bookmark id. Kept in
-// localStorage only: tracking this on the synced object would rewrite (and
-// re-sync) a bookmark every time it is merely opened, and would drag the
-// "수정한 날짜" key along with it.
-const _BM_VIEWED_KEY = "bible-bookmark-viewed";
-/** @returns {Record<string, number>} */
-function _loadViewedMap() {
-  try {
-    const raw = localStorage.getItem(_BM_VIEWED_KEY);
-    const m = raw ? JSON.parse(raw) : null;
-    return (m && typeof m === "object") ? m : {};
-  } catch { return {}; }
-}
-/** @param {string} id */
-function markBookmarkViewed(id) {
-  if (!id) return;
-  try {
-    const m = _loadViewedMap();
-    m[id] = Date.now();
-    localStorage.setItem(_BM_VIEWED_KEY, JSON.stringify(m));
-  } catch { /* private mode */ }
-}
-/** @param {string} id */
-function _forgetViewed(id) {
-  try {
-    const m = _loadViewedMap();
-    if (m[id] != null) { delete m[id]; localStorage.setItem(_BM_VIEWED_KEY, JSON.stringify(m)); }
-  } catch { /* private mode */ }
-}
-
-/** @param {BookmarkTreeNode} n @returns {string} */
-function _nodeTitle(n) {
-  return (n.type === "folder" ? n.name : n.label) || "";
-}
-
-// Build a comparator for a sort mode. Date modes sort newest-first; "title"
-// uses Korean locale collation. The viewed map is read once per sort rather
-// than once per comparison.
-/** @param {string} mode @returns {(a: BookmarkTreeNode, b: BookmarkTreeNode) => number} */
-function _bookmarkComparator(mode) {
-  if (mode === "title") {
-    return (a, b) => _nodeTitle(a).localeCompare(_nodeTitle(b), "ko");
-  }
-  const viewed = mode === "viewed" ? _loadViewedMap() : null;
-  /** @param {BookmarkTreeNode} n @returns {number} */
-  const keyOf = (n) => {
-    if (mode === "created")  return n.createdAt || 0;
-    if (mode === "modified") return n.updatedAt || n.createdAt || 0;
-    if (mode === "viewed")   return (viewed && viewed[n.id]) || n.createdAt || 0;
-    return 0;
-  };
-  return (a, b) => keyOf(b) - keyOf(a);
-}
-
-// Display-ordered shallow copy of `nodes` for the active sort mode. "manual"
-// keeps the exact stored order (including any folder/bookmark interleaving from
-// drag); other modes put folders before bookmarks, each sorted by the key.
-/** @param {BookmarkTreeNode[]} nodes @returns {BookmarkTreeNode[]} */
-function sortBookmarkNodes(nodes) {
-  const list = Array.isArray(nodes) ? nodes : [];
-  const mode = getBookmarkSort();
-  if (mode === "manual") return list.slice();
-  const cmp = _bookmarkComparator(mode);
-  const folders = list.filter(n => n.type === "folder").sort(cmp);
-  const marks   = list.filter(n => n.type !== "folder").sort(cmp);
-  return [...folders, ...marks];
-}
-// ── END BOOKMARK_SORT ──
 
 // Build the two edge-anchored mobile swipe actions: 삭제 (left edge, revealed by
 // swiping the row right) and 수정 (right edge, revealed by swiping left). They sit

--- a/sw.js
+++ b/sw.js
@@ -41,6 +41,7 @@ const SHELL_FILES = [
   "/js/app/search.js",
   "/js/app/reading-context.js",
   "/js/app/verse-spec.js",
+  "/js/app/bookmark-core.js",
   "/js/app/bookmark.js",
   "/js/app/citations.js",
   "/js/app/parallels.js",

--- a/tests/unit/bookmark.test.js
+++ b/tests/unit/bookmark.test.js
@@ -39,6 +39,10 @@ const BOOKMARK_SOURCE = fs.readFileSync(BOOKMARK_PATH, "utf8");
 // marker block now lives there, so its loader slices from this source.
 const VERSE_SPEC_PATH = path.resolve(__dirname, "../../js/app/verse-spec.js");
 const VERSE_SPEC_SOURCE = fs.readFileSync(VERSE_SPEC_PATH, "utf8");
+// Href/share + sort helpers moved to bookmark-core.js (ADR-034 후속 PR2); their
+// marker blocks (BOOKMARK_HREF / BOOKMARK_SORT) now live there.
+const BOOKMARK_CORE_PATH = path.resolve(__dirname, "../../js/app/bookmark-core.js");
+const BOOKMARK_CORE_SOURCE = fs.readFileSync(BOOKMARK_CORE_PATH, "utf8");
 
 function extractBlock(name, source = BOOKMARK_SOURCE) {
   const begin = `// ── BEGIN ${name} ──`;
@@ -1117,7 +1121,7 @@ test('closeSwipedRowIfOutside: non-Node target → guard rejects, close fires', 
 function loadBookmarkHref() {
   const ctx = { Object, Array, String, console, Error };
   vm.createContext(ctx);
-  vm.runInContext(extractBlock("BOOKMARK_HREF"), ctx, { filename: "bookmark-href.js" });
+  vm.runInContext(extractBlock("BOOKMARK_HREF", BOOKMARK_CORE_SOURCE), ctx, { filename: "bookmark-core.js" });
   return { _bookmarkHref: ctx._bookmarkHref, _buildSharePayload: ctx._buildSharePayload };
 }
 
@@ -1128,7 +1132,7 @@ function loadBookmarkHref() {
 function loadBookmarkActive() {
   const ctx = { Object, Array, String, console, Error };
   vm.createContext(ctx);
-  vm.runInContext(extractBlock("BOOKMARK_HREF") + "\n" + extractBlock("BOOKMARK_ACTIVE"), ctx, {
+  vm.runInContext(extractBlock("BOOKMARK_HREF", BOOKMARK_CORE_SOURCE) + "\n" + extractBlock("BOOKMARK_ACTIVE"), ctx, {
     filename: "bookmark-active.js",
   });
   return {
@@ -1564,7 +1568,7 @@ function loadBookmarkSort(seed = {}) {
     localStorage,
   };
   vm.createContext(ctx);
-  vm.runInContext(extractBlock("BOOKMARK_SORT"), ctx, { filename: "bookmark-sort.js" });
+  vm.runInContext(extractBlock("BOOKMARK_SORT", BOOKMARK_CORE_SOURCE), ctx, { filename: "bookmark-core.js" });
   return {
     getBookmarkSort: ctx.getBookmarkSort,
     setBookmarkSort: ctx.setBookmarkSort,


### PR DESCRIPTION
## 무엇을

`bookmark.js`의 **`BOOKMARK_HREF` + `BOOKMARK_SORT` 블록**(href/share 빌더 + per-device 정렬·최근열람 헬퍼, localStorage 기반)을 `js/app/bookmark-core.js`(leaf)로 분리.

- `bookmark.js` **3,364 → 3,235줄**

## 왜 깔끔한가
이 함수들은 **전부 bookmark 내부 전용** — 외부 모듈 호출 0, `window` facade·`appBookmark` aggregate·`export {}` 등장 0. 그래서 단순 import-only 이동이고, 지난 PR1에서 겪은 "export {정의안된이름}" 버그 위험이 없음.
- export: bookmark이 쓰는 7개(`_bookmarkHref`·`_buildSharePayload`·`getBookmarkSort`·`setBookmarkSort`·`markBookmarkViewed`·`_forgetViewed`·`sortBookmarkNodes`)
- core 내부 유지: `_loadViewedMap`·`_nodeTitle`·`_bookmarkComparator`·`SITE_BASE`

## 테스트
`bookmark.test.js`의 `BOOKMARK_HREF`/`SORT` 슬라이스를 bookmark-core.js로(ACTIVE 로더는 core의 HREF + bookmark의 ACTIVE 연결 — ACTIVE는 다음 단계).

## 검증
- ✅ tsc 0 · 유닛 678 · e2e bookmark 17
- ✅ **playwright 로드 검사 pageerror 0** (PR1의 export 버그 재발 방지 표준 검사)

## 다음
PR3: `BOOKMARK_QUERY`, PR4: `BOOKMARK_ACTIVE`(`_renderPathname` setter 배선) → bookmark-core.js로.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical move with imports and test loader updates only; bookmark behavior and external APIs are unchanged.
> 
> **Overview**
> **ADR-034 follow-up (PR2):** Pure bookmark **href/share** and **sort / last-viewed** logic moves out of `bookmark.js` into a new leaf module `js/app/bookmark-core.js` (`BOOKMARK_HREF` + `BOOKMARK_SORT` marker blocks unchanged in behavior).
> 
> `bookmark.js` **imports** those seven symbols and drops ~130 lines of inlined code; there is **no** new `window` facade or public API surface—still bookmark-internal only.
> 
> **Load order / offline:** `index.html` loads `bookmark-core.js` **before** `bookmark.js`; `sw.js` precaches the new file so the PWA shell stays consistent.
> 
> **Tests:** `tests/unit/bookmark.test.js` slices `BOOKMARK_HREF` / `BOOKMARK_SORT` from `bookmark-core.js` (ACTIVE loader still concatenates core HREF + bookmark ACTIVE).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d9f128e6a73bb0908e93a5cfb610d335839a86e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->