### PR TITLE
refactor: 북마크 query/tree 헬퍼를 bookmark-core.js로 분리 (ADR-034 후속 PR3)

### DIFF
--- a/js/app/bookmark-core.js
+++ b/js/app/bookmark-core.js
@@ -1,14 +1,191 @@
 "use strict";
 // @ts-check
 
-// Bookmark core — extracted from bookmark.js (ADR-034 후속 PR2). Pure bookmark
-// display/link logic with no DOM or UI state: href/share builders (HREF block)
-// and the sort/last-viewed helpers (SORT block, localStorage-backed per-device
-// view settings). bookmark.js (UI) imports these; no external callers, no
-// window facade. Leaf module (localStorage only).
+// Bookmark core — extracted from bookmark.js (ADR-034 후속 PR2~3). DOM-free
+// bookmark logic: query/tree ops (QUERY block, loadBookmarks-backed), href/share
+// builders (HREF), sort/last-viewed helpers (SORT, localStorage). bookmark.js (UI)
+// imports these; a few QUERY fns keep a window facade for the legacy bare-global
+// contract (types.d.ts). Deps: appStorage, localStorage.
 
 /** @typedef {import("../types").BookmarkTreeNode} BookmarkTreeNode */
 /** @typedef {import("../types").BookmarkTreeBookmark} BookmarkTreeBookmark */
+/** @typedef {import("../types").BookmarkTreeFolder} BookmarkTreeFolder */
+
+const { loadBookmarks } = window.appStorage;
+
+// ── BEGIN BOOKMARK_QUERY ──
+// Exercised by tests/unit/bookmark.test.js. Pure tree operations on the
+// in-memory bookmark store; only `findExistingChapterBookmarks` calls out
+// to `loadBookmarks` (provided as a stub by the test loader prelude).
+// ── Bookmark query helpers ──
+
+/**
+ * @param {BookmarkTreeNode[]} store
+ * @param {(item: BookmarkTreeNode, parent: BookmarkTreeNode[]) => unknown} fn
+ * @returns {boolean}
+ */
+function _walkBookmarks(store, fn) {
+  // Guard against folders with missing/null `children` (and a null root) so the
+  // walk — and any caller mid-mutation (e.g. cascade delete) — can't throw.
+  for (const item of store || []) {
+    if (fn(item, store) === false) return false;
+    if (item.type === "folder") {
+      if (_walkBookmarks(item.children, fn) === false) return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * @param {string} bookId
+ * @param {number} chapter
+ * @returns {BookmarkTreeBookmark[]}
+ */
+function findExistingChapterBookmarks(bookId, chapter) {
+  /** @type {BookmarkTreeBookmark[]} */
+  const results = [];
+  _walkBookmarks(loadBookmarks(), (item) => {
+    if (item.type === "bookmark" && item.bookId === bookId && item.chapter === chapter) {
+      results.push(item);
+    }
+  });
+  return results;
+}
+
+// Header bookmark toggle-off (mobile) presents the chapter's bookmarks with
+// checkboxes so the reader removes only the ones they mean to. These two pure
+// helpers drive that picker's chrome.
+
+// Tri-state for the "전체 선택" checkbox given how many of the chapter's
+// bookmarks are currently ticked: none → unchecked, all → checked, otherwise
+// indeterminate.
+/**
+ * @param {number} selectedCount
+ * @param {number} totalCount
+ * @returns {"none" | "some" | "all"}
+ */
+function _selectAllState(selectedCount, totalCount) {
+  if (totalCount <= 0 || selectedCount <= 0) return "none";
+  if (selectedCount >= totalCount) return "all";
+  return "some";
+}
+
+// Confirm-button label: bare "삭제" with nothing selected (button is disabled),
+// else the count appended so the destructive action states its scope.
+/**
+ * @param {number} selectedCount
+ * @returns {string}
+ */
+function _deleteBtnLabel(selectedCount) {
+  return selectedCount > 0 ? `삭제 (${selectedCount})` : "삭제";
+}
+
+// Floating count-chip text for the bookmark select dock (#bm-select-count).
+// 0 → the guidance prompt; otherwise the marked-node count (a ticked folder
+// counts every node under it, mirroring _bmCountMarked).
+/**
+ * @param {number} markedCount
+ * @returns {string}
+ */
+function _bmSelectCountLabel(markedCount) {
+  return markedCount > 0 ? `${markedCount}개 선택됨` : "항목을 선택하세요";
+}
+
+/**
+ * @param {BookmarkTreeNode[]} store
+ * @param {string} id
+ * @returns {{ item: BookmarkTreeNode, parent: BookmarkTreeNode[], index: number } | null}
+ */
+function _findItemInStore(store, id) {
+  for (let i = 0; i < store.length; i++) {
+    const it = store[i];
+    if (it.id === id) return { item: it, parent: store, index: i };
+    if (it.type === "folder") {
+      const found = _findItemInStore(it.children, id);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+
+// Returns the parent folder's id (null = root), or undefined if not found.
+/**
+ * @param {BookmarkTreeNode[]} store
+ * @param {string} id
+ * @param {string | null} [parentId]
+ * @returns {string | null | undefined}
+ */
+function _findParentFolderId(store, id, parentId = null) {
+  for (const item of store) {
+    if (item.id === id) return parentId;
+    if (item.type === "folder") {
+      const r = _findParentFolderId(item.children, id, item.id);
+      if (r !== undefined) return r;
+    }
+  }
+  return undefined;
+}
+
+/** @param {BookmarkTreeNode[]} store @param {string} id */
+function removeItemById(store, id) {
+  const found = _findItemInStore(store, id);
+  if (found) found.parent.splice(found.index, 1);
+}
+
+/**
+ * @param {BookmarkTreeNode[]} store
+ * @param {string | null | undefined} folderId
+ * @param {BookmarkTreeNode} item
+ */
+function insertItem(store, folderId, item) {
+  if (!folderId) {
+    store.push(item);
+    return;
+  }
+  const found = _findItemInStore(store, folderId);
+  if (found && found.item.type === "folder") {
+    found.item.children.push(item);
+  } else {
+    store.push(item);
+  }
+}
+
+/**
+ * @param {BookmarkTreeNode[]} store
+ * @param {number} [depth]
+ * @param {Array<{ id: string, name: string, depth: number }>} [options]
+ * @returns {Array<{ id: string, name: string, depth: number }>}
+ */
+function collectFolderOptions(store, depth = 0, options = []) {
+  for (const item of store) {
+    if (item.type === "folder") {
+      options.push({ id: item.id, name: item.name, depth });
+      collectFolderOptions(item.children, depth + 1, options);
+    }
+  }
+  return options;
+}
+
+/**
+ * Ids of every descendant under a node (folders + bookmarks), excluding the
+ * node itself; empty for a bookmark. Lets folder delete + the select-delete mode
+ * forget the per-device viewed timestamps of a folder's nested bookmarks before
+ * the folder is spliced out, and lets a folder tick subsume already-ticked
+ * descendants in select mode.
+ * @param {BookmarkTreeNode} node
+ * @param {string[]} [out]
+ * @returns {string[]}
+ */
+function _descendantIds(node, out = []) {
+  if (node && node.type === "folder") {
+    for (const child of node.children || []) {
+      out.push(child.id);
+      _descendantIds(child, out);
+    }
+  }
+  return out;
+}
+// ── END BOOKMARK_QUERY ──
 
 // ── BEGIN BOOKMARK_HREF ──
 // Exercised by tests/unit/bookmark.test.js. Pure URL builder — verseSpec="all"
@@ -140,8 +317,23 @@ function sortBookmarkNodes(nodes) {
 }
 // ── END BOOKMARK_SORT ──
 
+// ── Window facade ──
+// QUERY tree helpers keep the legacy bare-global contract (types.d.ts declares
+// them on Window). No current module reads them, but preserved to avoid a hidden
+// runtime break.
+window._walkBookmarks = _walkBookmarks;
+window.findExistingChapterBookmarks = findExistingChapterBookmarks;
+window._findItemInStore = _findItemInStore;
+window._findParentFolderId = _findParentFolderId;
+window.removeItemById = removeItemById;
+window.insertItem = insertItem;
+window.collectFolderOptions = collectFolderOptions;
+
 export {
   _bookmarkHref, _buildSharePayload,
   getBookmarkSort, setBookmarkSort, markBookmarkViewed, _forgetViewed,
   sortBookmarkNodes,
+  _walkBookmarks, findExistingChapterBookmarks, _findItemInStore,
+  _findParentFolderId, removeItemById, insertItem, collectFolderOptions,
+  _selectAllState, _deleteBtnLabel, _bmSelectCountLabel, _descendantIds,
 };

--- a/js/app/bookmark.js
+++ b/js/app/bookmark.js
@@ -30,187 +30,18 @@ import {
   selectedVersesToSpec, mergeVerseSpecs, serializeVerseRange,
 } from "./verse-spec.js";
 
-// Bookmark href/share builders + sort/last-viewed helpers split out to
-// bookmark-core.js (ADR-034 후속). Internal-only (no facade); imported here.
+// Bookmark logic (query/tree ops, href/share, sort) split out to bookmark-core.js
+// (ADR-034 후속 PR2~3). The QUERY tree helpers keep a window facade owned by
+// bookmark-core; bookmark.js imports everything it calls.
 import {
   _bookmarkHref, _buildSharePayload,
   getBookmarkSort, setBookmarkSort, markBookmarkViewed, _forgetViewed,
   sortBookmarkNodes,
+  _walkBookmarks, findExistingChapterBookmarks, _findItemInStore,
+  _findParentFolderId, removeItemById, insertItem, collectFolderOptions,
+  _selectAllState, _deleteBtnLabel, _bmSelectCountLabel, _descendantIds,
 } from "./bookmark-core.js";
 
-// ── BEGIN BOOKMARK_QUERY ──
-// Exercised by tests/unit/bookmark.test.js. Pure tree operations on the
-// in-memory bookmark store; only `findExistingChapterBookmarks` calls out
-// to `loadBookmarks` (provided as a stub by the test loader prelude).
-// ── Bookmark query helpers ──
-
-/**
- * @param {BookmarkTreeNode[]} store
- * @param {(item: BookmarkTreeNode, parent: BookmarkTreeNode[]) => unknown} fn
- * @returns {boolean}
- */
-function _walkBookmarks(store, fn) {
-  // Guard against folders with missing/null `children` (and a null root) so the
-  // walk — and any caller mid-mutation (e.g. cascade delete) — can't throw.
-  for (const item of store || []) {
-    if (fn(item, store) === false) return false;
-    if (item.type === "folder") {
-      if (_walkBookmarks(item.children, fn) === false) return false;
-    }
-  }
-  return true;
-}
-
-/**
- * @param {string} bookId
- * @param {number} chapter
- * @returns {BookmarkTreeBookmark[]}
- */
-function findExistingChapterBookmarks(bookId, chapter) {
-  /** @type {BookmarkTreeBookmark[]} */
-  const results = [];
-  _walkBookmarks(loadBookmarks(), (item) => {
-    if (item.type === "bookmark" && item.bookId === bookId && item.chapter === chapter) {
-      results.push(item);
-    }
-  });
-  return results;
-}
-
-// Header bookmark toggle-off (mobile) presents the chapter's bookmarks with
-// checkboxes so the reader removes only the ones they mean to. These two pure
-// helpers drive that picker's chrome.
-
-// Tri-state for the "전체 선택" checkbox given how many of the chapter's
-// bookmarks are currently ticked: none → unchecked, all → checked, otherwise
-// indeterminate.
-/**
- * @param {number} selectedCount
- * @param {number} totalCount
- * @returns {"none" | "some" | "all"}
- */
-function _selectAllState(selectedCount, totalCount) {
-  if (totalCount <= 0 || selectedCount <= 0) return "none";
-  if (selectedCount >= totalCount) return "all";
-  return "some";
-}
-
-// Confirm-button label: bare "삭제" with nothing selected (button is disabled),
-// else the count appended so the destructive action states its scope.
-/**
- * @param {number} selectedCount
- * @returns {string}
- */
-function _deleteBtnLabel(selectedCount) {
-  return selectedCount > 0 ? `삭제 (${selectedCount})` : "삭제";
-}
-
-// Floating count-chip text for the bookmark select dock (#bm-select-count).
-// 0 → the guidance prompt; otherwise the marked-node count (a ticked folder
-// counts every node under it, mirroring _bmCountMarked).
-/**
- * @param {number} markedCount
- * @returns {string}
- */
-function _bmSelectCountLabel(markedCount) {
-  return markedCount > 0 ? `${markedCount}개 선택됨` : "항목을 선택하세요";
-}
-
-/**
- * @param {BookmarkTreeNode[]} store
- * @param {string} id
- * @returns {{ item: BookmarkTreeNode, parent: BookmarkTreeNode[], index: number } | null}
- */
-function _findItemInStore(store, id) {
-  for (let i = 0; i < store.length; i++) {
-    const it = store[i];
-    if (it.id === id) return { item: it, parent: store, index: i };
-    if (it.type === "folder") {
-      const found = _findItemInStore(it.children, id);
-      if (found) return found;
-    }
-  }
-  return null;
-}
-
-// Returns the parent folder's id (null = root), or undefined if not found.
-/**
- * @param {BookmarkTreeNode[]} store
- * @param {string} id
- * @param {string | null} [parentId]
- * @returns {string | null | undefined}
- */
-function _findParentFolderId(store, id, parentId = null) {
-  for (const item of store) {
-    if (item.id === id) return parentId;
-    if (item.type === "folder") {
-      const r = _findParentFolderId(item.children, id, item.id);
-      if (r !== undefined) return r;
-    }
-  }
-  return undefined;
-}
-
-/** @param {BookmarkTreeNode[]} store @param {string} id */
-function removeItemById(store, id) {
-  const found = _findItemInStore(store, id);
-  if (found) found.parent.splice(found.index, 1);
-}
-
-/**
- * @param {BookmarkTreeNode[]} store
- * @param {string | null | undefined} folderId
- * @param {BookmarkTreeNode} item
- */
-function insertItem(store, folderId, item) {
-  if (!folderId) {
-    store.push(item);
-    return;
-  }
-  const found = _findItemInStore(store, folderId);
-  if (found && found.item.type === "folder") {
-    found.item.children.push(item);
-  } else {
-    store.push(item);
-  }
-}
-
-/**
- * @param {BookmarkTreeNode[]} store
- * @param {number} [depth]
- * @param {Array<{ id: string, name: string, depth: number }>} [options]
- * @returns {Array<{ id: string, name: string, depth: number }>}
- */
-function collectFolderOptions(store, depth = 0, options = []) {
-  for (const item of store) {
-    if (item.type === "folder") {
-      options.push({ id: item.id, name: item.name, depth });
-      collectFolderOptions(item.children, depth + 1, options);
-    }
-  }
-  return options;
-}
-
-/**
- * Ids of every descendant under a node (folders + bookmarks), excluding the
- * node itself; empty for a bookmark. Lets folder delete + the select-delete mode
- * forget the per-device viewed timestamps of a folder's nested bookmarks before
- * the folder is spliced out, and lets a folder tick subsume already-ticked
- * descendants in select mode.
- * @param {BookmarkTreeNode} node
- * @param {string[]} [out]
- * @returns {string[]}
- */
-function _descendantIds(node, out = []) {
-  if (node && node.type === "folder") {
-    for (const child of node.children || []) {
-      out.push(child.id);
-      _descendantIds(child, out);
-    }
-  }
-  return out;
-}
-// ── END BOOKMARK_QUERY ──
 
 // ── BEGIN DRAG_CORE ──
 // Exercised by tests/unit/bookmark.test.js. The test loader concatenates
@@ -3155,10 +2986,7 @@ function initBookmarkDrawerResize() {
 // `renderBookmarkTree` for sync/state-machine.js's post-sync re-render.
 
 const appBookmark = {
-  // Phase 6a helpers (verse-spec utilities moved to verse-spec.js, ADR-034 후속)
-  findExistingChapterBookmarks,
-  _walkBookmarks, _findItemInStore, _findParentFolderId,
-  removeItemById, insertItem, collectFolderOptions,
+  // Phase 6a helpers (verse-spec → verse-spec.js, query/href/sort → bookmark-core.js, ADR-034 후속)
   moveBookmarkItem, closeSwipedRow, _setupDragHandle,
   resetSwipedRow, closeSwipedRowIfOutside,
   // Phase 6b UI
@@ -3177,13 +3005,9 @@ window.appBookmark = appBookmark;
 // Phase 6a per-name globals (existing). Verse-spec facade (parseVerseSpec /
 // collapseFullVerseRefs / selectedVersesToSpec / mergeVerseSpecs /
 // serializeVerseRange) moved to verse-spec.js (ADR-034 후속).
-window.findExistingChapterBookmarks = findExistingChapterBookmarks;
-window._walkBookmarks = _walkBookmarks;
-window._findItemInStore = _findItemInStore;
-window._findParentFolderId = _findParentFolderId;
-window.removeItemById = removeItemById;
-window.insertItem = insertItem;
-window.collectFolderOptions = collectFolderOptions;
+// QUERY tree helpers' facade (findExistingChapterBookmarks / _walkBookmarks /
+// _findItemInStore / _findParentFolderId / removeItemById / insertItem /
+// collectFolderOptions) moved to bookmark-core.js (ADR-034 후속 PR3).
 window.moveBookmarkItem = moveBookmarkItem;
 window.closeSwipedRow = closeSwipedRow;
 window._setupDragHandle = _setupDragHandle;
@@ -3228,9 +3052,6 @@ window.initBookmarkSheetDrag = initBookmarkSheetDrag;
 window.initBookmarkDrawerResize = initBookmarkDrawerResize;
 
 export {
-  findExistingChapterBookmarks,
-  _walkBookmarks, _findItemInStore, _findParentFolderId,
-  removeItemById, insertItem, collectFolderOptions,
   moveBookmarkItem, closeSwipedRow, _setupDragHandle,
   resetSwipedRow, closeSwipedRowIfOutside,
   buildBackBtn, buildBookmarkHeaderBtn,

--- a/tests/unit/bookmark.test.js
+++ b/tests/unit/bookmark.test.js
@@ -135,7 +135,7 @@ function loadBookmarkQuery(initialStore = []) {
     function loadBookmarks() { return _loadBookmarksImpl(); }
   `;
   ctx._loadBookmarksImpl = () => storeForLoad;
-  vm.runInContext(prelude + extractBlock("BOOKMARK_QUERY"), ctx, { filename: "bookmark-query.js" });
+  vm.runInContext(prelude + extractBlock("BOOKMARK_QUERY", BOOKMARK_CORE_SOURCE), ctx, { filename: "bookmark-core.js" });
   return {
     ctx,
     setStore: (s) => { storeForLoad = s; },
@@ -208,7 +208,7 @@ function loadDragCore() {
   ctx._store = currentStore;
   ctx._saveCalls = saveCalls;
   vm.runInContext(
-    prelude + extractBlock("BOOKMARK_QUERY") + "\n" + extractBlock("DRAG_CORE"),
+    prelude + extractBlock("BOOKMARK_QUERY", BOOKMARK_CORE_SOURCE) + "\n" + extractBlock("DRAG_CORE"),
     ctx,
     { filename: "bookmark-drag-core.js" },
   );


### PR DESCRIPTION
## 무엇을

`bookmark.js`의 **`BOOKMARK_QUERY` 블록**(트리 walk/find/insert/remove/folder-options + `findExistingChapterBookmarks` + select-mode 라벨 헬퍼)을 `bookmark-core.js`로 이동.

- `bookmark.js` **3,243 → 3,064줄** · `bookmark-core.js` 147 → 339줄
- 누적 `bookmark.js` 3,578 → **3,064줄 (−14%)**

## 결합 처리
- bookmark이 쓰는 11개 함수 import. `loadBookmarks`(appStorage) 의존은 core가 직접 import.
- QUERY 트리 헬퍼 7개의 **`window` facade 계약**(types.d.ts 전역 선언)을 bookmark-core가 그대로 소유(실호출 모듈 없으나 은닉 런타임 깨짐 방지).
- **3곳(window facade·appBookmark aggregate·`export {}`) 모두 정리** — PR1에서 겪은 `export{정의안된이름}` ESM 인스턴스화 실패 재발 방지.

## 검증
- ✅ tsc main·worker 0 · 유닛 678 · e2e bookmark 21
- ✅ **playwright 로드 검사 pageerror 0** (표준 검사)

## 다음
PR4: `BOOKMARK_ACTIVE`(`_renderPathname` setter 배선) → bookmark-core.js. 이후 모달 묶음 → `bookmark-modals.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> 동작 동일한 모듈 분리와 facade 소유권 이동이며, 기존 유닛/e2e 검증으로 회귀 위험이 낮습니다.
> 
> **Overview**
> ADR-034 후속으로 **`bookmark.js`의 `BOOKMARK_QUERY` 블록**을 DOM 없는 **`bookmark-core.js`**로 옮깁니다. 트리 walk/find/insert/remove, `findExistingChapterBookmarks`, 선택 모드용 라벨 헬퍼(`_selectAllState`, `_deleteBtnLabel`, `_bmSelectCountLabel`, `_descendantIds`)가 core로 합쳐지고, **`loadBookmarks`는 core가 `window.appStorage`에서 직접** 가져옵니다.
> 
> **`bookmark.js`**는 위 11개 심볼을 core에서 import만 하고, **`window` / `appBookmark` / `export`에서 QUERY 관련 항목을 제거**해 ESM export 불일치를 막습니다. **레거시 전역 계약**(`types.d.ts`)을 위해 QUERY 트리 헬퍼 7개의 **`window` facade는 `bookmark-core.js`가 소유**합니다.
> 
> **`tests/unit/bookmark.test.js`**는 `BOOKMARK_QUERY`·DRAG 연동 슬라이스를 **`bookmark-core.js` 소스**에서 추출하도록 바꿉니다.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4cc1b632ee475cecb6a3f0424128e5b77066402. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->