### PR TITLE
refactor: 북마크 active-route 강조 헬퍼를 bookmark-core.js로 분리 (ADR-034 후속 PR4)

### DIFF
--- a/js/app/bookmark-core.js
+++ b/js/app/bookmark-core.js
@@ -1,11 +1,12 @@
 "use strict";
 // @ts-check
 
-// Bookmark core — extracted from bookmark.js (ADR-034 후속 PR2~3). DOM-free
+// Bookmark core — extracted from bookmark.js (ADR-034 후속 PR2~4). DOM-free
 // bookmark logic: query/tree ops (QUERY block, loadBookmarks-backed), href/share
-// builders (HREF), sort/last-viewed helpers (SORT, localStorage). bookmark.js (UI)
-// imports these; a few QUERY fns keep a window facade for the legacy bare-global
-// contract (types.d.ts). Deps: appStorage, localStorage.
+// builders (HREF), sort/last-viewed helpers (SORT, localStorage), active-route
+// highlight predicates (ACTIVE, _renderPathname set by UI via setRenderPathname).
+// bookmark.js (UI) imports these; a few QUERY fns keep a window facade for the
+// legacy bare-global contract (types.d.ts). Deps: appStorage, localStorage.
 
 /** @typedef {import("../types").BookmarkTreeNode} BookmarkTreeNode */
 /** @typedef {import("../types").BookmarkTreeBookmark} BookmarkTreeBookmark */
@@ -317,6 +318,35 @@ function sortBookmarkNodes(nodes) {
 }
 // ── END BOOKMARK_SORT ──
 
+// ── BEGIN BOOKMARK_ACTIVE ──
+// Exercised by tests/unit/bookmark.test.js. Tracks the pathname rendered by
+// the bookmark tree so each bookmark/folder can self-highlight when the URL
+// matches it. The `pathname` parameter defaults to the module-scoped tracker,
+// which the bookmark.js (UI) renderer sets via setRenderPathname() from
+// window.location.pathname; the explicit parameter lets tests call without
+// driving the full renderer. Depends on `_bookmarkHref` (HREF block above).
+let _renderPathname = "";
+
+/** @param {string} pathname */
+function setRenderPathname(pathname) {
+  _renderPathname = pathname;
+}
+
+/** @param {BookmarkTreeBookmark} bm @param {string} [pathname] @returns {boolean} */
+function _isActiveBookmark(bm, pathname = _renderPathname) {
+  return pathname === _bookmarkHref(bm);
+}
+
+/** @param {BookmarkTreeFolder} folder @param {string} [pathname] @returns {boolean} */
+function _hasActiveDescendant(folder, pathname = _renderPathname) {
+  for (const child of (folder.children || [])) {
+    if (child.type === "bookmark" && _isActiveBookmark(child, pathname)) return true;
+    if (child.type === "folder" && _hasActiveDescendant(child, pathname)) return true;
+  }
+  return false;
+}
+// ── END BOOKMARK_ACTIVE ──
+
 // ── Window facade ──
 // QUERY tree helpers keep the legacy bare-global contract (types.d.ts declares
 // them on Window). No current module reads them, but preserved to avoid a hidden
@@ -336,4 +366,5 @@ export {
   _walkBookmarks, findExistingChapterBookmarks, _findItemInStore,
   _findParentFolderId, removeItemById, insertItem, collectFolderOptions,
   _selectAllState, _deleteBtnLabel, _bmSelectCountLabel, _descendantIds,
+  _isActiveBookmark, _hasActiveDescendant, setRenderPathname,
 };

--- a/js/app/bookmark.js
+++ b/js/app/bookmark.js
@@ -30,9 +30,10 @@ import {
   selectedVersesToSpec, mergeVerseSpecs, serializeVerseRange,
 } from "./verse-spec.js";
 
-// Bookmark logic (query/tree ops, href/share, sort) split out to bookmark-core.js
-// (ADR-034 후속 PR2~3). The QUERY tree helpers keep a window facade owned by
-// bookmark-core; bookmark.js imports everything it calls.
+// Bookmark logic (query/tree ops, href/share, sort, active-route highlight)
+// split out to bookmark-core.js (ADR-034 후속 PR2~4). The QUERY tree helpers
+// keep a window facade owned by bookmark-core; bookmark.js imports everything it
+// calls. _renderPathname now lives in core; the UI sets it via setRenderPathname.
 import {
   _bookmarkHref, _buildSharePayload,
   getBookmarkSort, setBookmarkSort, markBookmarkViewed, _forgetViewed,
@@ -40,6 +41,7 @@ import {
   _walkBookmarks, findExistingChapterBookmarks, _findItemInStore,
   _findParentFolderId, removeItemById, insertItem, collectFolderOptions,
   _selectAllState, _deleteBtnLabel, _bmSelectCountLabel, _descendantIds,
+  _isActiveBookmark, _hasActiveDescendant, setRenderPathname,
 } from "./bookmark-core.js";
 
 
@@ -939,28 +941,6 @@ function _buildBookmarkTypeIcon(active = false, size = 20) {
   return svg;
 }
 
-// ── BEGIN BOOKMARK_ACTIVE ──
-// Exercised by tests/unit/bookmark.test.js. Tracks the pathname rendered by
-// the bookmark tree so each bookmark/folder can self-highlight when the URL
-// matches it. The `pathname` parameter defaults to the module-scoped tracker
-// (set by renderBookmarkTree() from window.location.pathname) and exists as
-// an explicit parameter so tests can call without needing to drive the full
-// renderer.
-let _renderPathname = "";
-
-function _isActiveBookmark(bm, pathname = _renderPathname) {
-  return pathname === _bookmarkHref(bm);
-}
-
-function _hasActiveDescendant(folder, pathname = _renderPathname) {
-  for (const child of (folder.children || [])) {
-    if (child.type === "bookmark" && _isActiveBookmark(child, pathname)) return true;
-    if (child.type === "folder" && _hasActiveDescendant(child, pathname)) return true;
-  }
-  return false;
-}
-// ── END BOOKMARK_ACTIVE ──
-
 function _buildMaterialFolderIcon({ size = 18 } = {}) {
   const ns = "http://www.w3.org/2000/svg";
   const svg = document.createElementNS(ns, "svg");
@@ -1307,7 +1287,7 @@ function _buildEmptyState() {
 }
 
 function renderBookmarkTree(target = $bookmarkDrawerBody) {
-  _renderPathname = window.location.pathname;
+  setRenderPathname(window.location.pathname);
   // The previously swiped row may be replaced when we re-render; drop the
   // stale reference held by js/app/bookmark.js.
   resetSwipedRow();

--- a/tests/unit/bookmark.test.js
+++ b/tests/unit/bookmark.test.js
@@ -39,8 +39,9 @@ const BOOKMARK_SOURCE = fs.readFileSync(BOOKMARK_PATH, "utf8");
 // marker block now lives there, so its loader slices from this source.
 const VERSE_SPEC_PATH = path.resolve(__dirname, "../../js/app/verse-spec.js");
 const VERSE_SPEC_SOURCE = fs.readFileSync(VERSE_SPEC_PATH, "utf8");
-// Href/share + sort helpers moved to bookmark-core.js (ADR-034 후속 PR2); their
-// marker blocks (BOOKMARK_HREF / BOOKMARK_SORT) now live there.
+// Href/share, sort, query/tree, and active-route helpers moved to bookmark-core.js
+// (ADR-034 후속 PR2~4); their marker blocks (BOOKMARK_HREF / BOOKMARK_SORT /
+// BOOKMARK_QUERY / BOOKMARK_ACTIVE) now live there.
 const BOOKMARK_CORE_PATH = path.resolve(__dirname, "../../js/app/bookmark-core.js");
 const BOOKMARK_CORE_SOURCE = fs.readFileSync(BOOKMARK_CORE_PATH, "utf8");
 
@@ -1132,9 +1133,11 @@ function loadBookmarkHref() {
 function loadBookmarkActive() {
   const ctx = { Object, Array, String, console, Error };
   vm.createContext(ctx);
-  vm.runInContext(extractBlock("BOOKMARK_HREF", BOOKMARK_CORE_SOURCE) + "\n" + extractBlock("BOOKMARK_ACTIVE"), ctx, {
-    filename: "bookmark-active.js",
-  });
+  vm.runInContext(
+    extractBlock("BOOKMARK_HREF", BOOKMARK_CORE_SOURCE) + "\n" + extractBlock("BOOKMARK_ACTIVE", BOOKMARK_CORE_SOURCE),
+    ctx,
+    { filename: "bookmark-core.js" },
+  );
   return {
     _isActiveBookmark: ctx._isActiveBookmark,
     _hasActiveDescendant: ctx._hasActiveDescendant,


### PR DESCRIPTION
## 무엇을

`bookmark.js`의 **`BOOKMARK_ACTIVE` 블록**(현재 URL과 일치하는 북마크/폴더 자기 강조 술어)을 `bookmark-core.js`로 이동.

- `_renderPathname` 모듈 상태 + `_isActiveBookmark` + `_hasActiveDescendant`
- `bookmark.js` 3,064 → **3,044줄** · `bookmark-core.js` 339 → 370줄
- 누적 `bookmark.js` 3,578 → **3,044줄 (−15%)**

## setter 배선 (이번 단계의 핵심)
`_renderPathname` 은 UI(`renderBookmarkTree`)가 `window.location.pathname` 으로 set 하던 모듈 상태다. ESM import 는 읽기 전용 바인딩이라 UI에서 core 상태를 직접 대입할 수 없으므로:

- core 가 `_renderPathname` 을 소유 + **`setRenderPathname()` setter export**
- `renderBookmarkTree()` 가 `_renderPathname = …` → `setRenderPathname(…)` 로 호출
- 두 술어의 기본 인자(`= _renderPathname`)는 core 모듈 스코프에서 평가되므로 setter 가 갱신한 값을 그대로 읽음

## facade 정책
두 술어는 **기존부터 window facade 없는 순수 내부 함수**(types.d.ts 전역 선언 없음, 외부 호출 모듈 없음)였으므로 core 에서도 ESM export 만 두고 facade 는 두지 않음 — PR3 의 QUERY(전역 계약 보유)와 의도적으로 다름.

## 검증
- ✅ tsc main·worker 0 · 유닛 678 · e2e bookmark+folders 17
- ✅ **playwright 로드 검사 pageerror 0** (앱 렌더 #app 2102, 두 모듈 로드)

## 다음
이후 모달 묶음(save·merge·confirm·move·import/export, ~900줄) → `bookmark-modals.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Structural refactor with behavior preserved; highlight still depends on renderBookmarkTree calling setRenderPathname on each render.
> 
> **Overview**
> Continues **ADR-034** by moving the **`BOOKMARK_ACTIVE`** block out of `bookmark.js` into DOM-free **`bookmark-core.js`**: `_renderPathname`, `_isActiveBookmark`, `_hasActiveDescendant`, plus a new **`setRenderPathname()`** export so the UI can update core state (ESM imports are read-only).
> 
> `renderBookmarkTree()` now calls **`setRenderPathname(window.location.pathname)`** instead of assigning `_renderPathname` locally. Active helpers stay **ESM-only** (no new `window` facade). Unit tests load **`BOOKMARK_ACTIVE`** from `bookmark-core.js` (still after **`BOOKMARK_HREF`** in the vm slice).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e1359eda3c9de005568d6a81fd5c6dd492bdc4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->