### PR TITLE
refactor: 북마크 confirm·chapter-delete 모달을 bookmark-modals.js로 분리 (ADR-034 후속 PR5a)

### DIFF
--- a/index.html
+++ b/index.html
@@ -415,6 +415,7 @@
   <script type="module" src="/js/app/reading-context.js"></script>
   <script type="module" src="/js/app/verse-spec.js"></script>
   <script type="module" src="/js/app/bookmark-core.js"></script>
+  <script type="module" src="/js/app/bookmark-modals.js"></script>
   <script type="module" src="/js/app/bookmark.js"></script>
   <!-- ADR-022: cite sheet (bottom sheet on mobile, right side panel on desktop) -->
   <aside id="cite-sheet" role="dialog" aria-modal="true" aria-labelledby="cite-sheet-title" hidden>

--- a/js/app/bookmark-modals.js
+++ b/js/app/bookmark-modals.js
@@ -1,0 +1,209 @@
+"use strict";
+// @ts-check
+
+// Bookmark modals — extracted from bookmark.js (ADR-034 후속 PR5). DOM-bound
+// dialog UI: confirm + chapter-delete picker for PR5a (save/folder/merge/move/
+// import to follow). bookmark.js (drawer/tree UI) opens these and injects its
+// render callbacks once via initBookmarkModals(), so the modal→render cycle
+// needs no circular import (의존성 주입). The modal Escape stack lives here as
+// closeTopmostModal(), which bookmark.js's document keydown handler delegates to
+// before its own drawer/select handling. Deps: appHelpers, appOverlay,
+// appStorage, bookmark-core, window.{announce, getBooksCache}.
+
+/** @typedef {import("../types").BookmarkTreeBookmark} BookmarkTreeBookmark */
+
+import {
+  _selectAllState, _deleteBtnLabel, _forgetViewed, removeItemById,
+} from "./bookmark-core.js";
+
+const { _$, el, clearNode, chUnit } = window.appHelpers;
+const { createOverlay } = window.appOverlay;
+const { loadBookmarks, saveBookmarks } = window.appStorage;
+
+// ── Dependency injection ──
+// bookmark.js injects its render callbacks at startup so a modal can refresh the
+// tree/header after a mutation without importing bookmark.js back (which would be
+// a circular import — the very class of break that hid behind tsc in PR1).
+/**
+ * @typedef {{
+ *   rerenderActiveBookmarkTree: () => void,
+ *   refreshBookmarkHeaderBtn: () => void,
+ * }} BookmarkModalDeps
+ */
+/** @type {BookmarkModalDeps} */
+let _deps;
+/** @param {BookmarkModalDeps} deps */
+function initBookmarkModals(deps) { _deps = deps; }
+
+// ── DOM refs (moved from bookmark.js) ──
+const $bmConfirmScrim = _$("bm-confirm-scrim");
+const $bmConfirmModal = _$("bm-confirm-modal");
+const $bmConfirmTitle = _$("bm-confirm-title");
+const $bmConfirmBody = _$("bm-confirm-body");
+const $bmConfirmOk = _$("bm-confirm-ok");
+const $bmConfirmCancel = _$("bm-confirm-cancel");
+const $bmChapterDeleteScrim = _$("bm-chapter-delete-scrim");
+const $bmChapterDeleteModal = _$("bm-chapter-delete-modal");
+const $bmChapterDeleteAll = /** @type {HTMLInputElement} */ (_$("bm-chapter-delete-all"));
+const $bmChapterDeleteList = _$("bm-chapter-delete-list");
+const $bmChapterDeleteConfirm = /** @type {HTMLButtonElement} */ (_$("bm-chapter-delete-confirm"));
+const $bmChapterDeleteCancel = _$("bm-chapter-delete-cancel");
+
+// ── BEGIN BOOKMARK_CONFIRM ──
+// Generic destructive-confirm dialog. The caller passes the onConfirm action, so
+// this stays a pure primitive with no render dependency.
+// Overlay lifecycle (scrim/hidden/focus-trap/focus-restore) is owned by the
+// shared controller (ADR-032). closeOnEsc stays off: this modal participates in
+// bookmark.js's stacked Escape router (confirm > chapter-delete > … > drawer),
+// which calls closeConfirmModal() for the topmost overlay. A controller-level
+// Escape listener here would double-handle and also close whatever sits beneath.
+// Default initial focus = cancel (safe action); destructive button is opt-in.
+const confirmOverlay = createOverlay({
+  panel: $bmConfirmModal,
+  scrim: $bmConfirmScrim,
+  initialFocus: () => $bmConfirmCancel,
+  onClose: () => { $bmConfirmOk.onclick = null; },
+});
+
+function openConfirmModal({ title, message, confirmLabel = "삭제", onConfirm }) {
+  $bmConfirmTitle.textContent = title;
+  $bmConfirmBody.textContent = message;
+  $bmConfirmOk.textContent = confirmLabel;
+  $bmConfirmOk.onclick = () => {
+    closeConfirmModal();
+    onConfirm();
+  };
+  confirmOverlay.open();
+}
+
+function closeConfirmModal() {
+  confirmOverlay.close();
+}
+// ── END BOOKMARK_CONFIRM ──
+
+// ── BEGIN BOOKMARK_CHAPTER_DELETE ──
+// Header bookmark toggle-off (mobile): instead of a blunt "delete all", present
+// the chapter's bookmarks (whole-chapter + verse ranges) as a checkbox list so
+// the reader removes only what they mean to. "전체 선택" ticks them all at once.
+// Nothing is pre-selected (the select-all is the bulk affordance) and the
+// delete button stays disabled until at least one row is ticked.
+// closeOnEsc off: in the stacked Escape router. onClose clears per-open
+// handlers; returnFocus restores the pre-open focus (ADR-032).
+const chapterDeleteOverlay = createOverlay({
+  panel: $bmChapterDeleteModal,
+  scrim: $bmChapterDeleteScrim,
+  initialFocus: () => $bmChapterDeleteCancel,
+  onClose: () => {
+    $bmChapterDeleteConfirm.onclick = null;
+    $bmChapterDeleteCancel.onclick = null;
+    $bmChapterDeleteAll.onchange = null;
+  },
+});
+
+/**
+ * @param {BookmarkTreeBookmark[]} candidates
+ */
+function openChapterDeleteModal(candidates) {
+  if (!candidates.length) return;
+  /** @type {Set<string>} */
+  const selected = new Set();
+
+  const syncChrome = () => {
+    const state = _selectAllState(selected.size, candidates.length);
+    $bmChapterDeleteAll.checked = state === "all";
+    $bmChapterDeleteAll.indeterminate = state === "some";
+    $bmChapterDeleteConfirm.textContent = _deleteBtnLabel(selected.size);
+    $bmChapterDeleteConfirm.disabled = selected.size === 0;
+  };
+
+  clearNode($bmChapterDeleteList);
+  /** @type {HTMLInputElement[]} */
+  const rowChecks = [];
+  candidates.forEach((bm, i) => {
+    const id = `bm-chapter-del-${i}`;
+    const li = el("li", { className: "bm-chapter-delete-item" });
+    const labelEl = el("label", { className: "bm-chapter-delete-label", for: id });
+    const input = /** @type {HTMLInputElement} */ (el("input", { type: "checkbox", id }));
+    rowChecks.push(input);
+    input.addEventListener("change", () => {
+      if (input.checked) selected.add(bm.id);
+      else selected.delete(bm.id);
+      syncChrome();
+    });
+    const book = (window.getBooksCache() ?? []).find((b) => b.id === bm.bookId);
+    const bookName = book ? (book.short_name_ko || book.name_ko) : bm.bookId;
+    const refText = bm.verseSpec === "all"
+      ? `${bookName} ${bm.chapter}${chUnit(bm.bookId)}`
+      : `${bookName} ${bm.chapter}:${bm.verseSpec}`;
+    const text = el("span", { className: "bm-chapter-delete-text" });
+    text.appendChild(el("span", { className: "bm-chapter-delete-item-label" }, bm.label));
+    text.appendChild(el("span", { className: "bm-chapter-delete-item-ref" }, refText));
+    labelEl.appendChild(input);
+    labelEl.appendChild(text);
+    li.appendChild(labelEl);
+    $bmChapterDeleteList.appendChild(li);
+  });
+
+  $bmChapterDeleteAll.onchange = () => {
+    const checkAll = $bmChapterDeleteAll.checked;
+    selected.clear();
+    if (checkAll) candidates.forEach((bm) => selected.add(bm.id));
+    rowChecks.forEach((c) => { c.checked = checkAll; });
+    syncChrome();
+  };
+
+  syncChrome();
+  chapterDeleteOverlay.open();
+
+  $bmChapterDeleteConfirm.onclick = () => {
+    if (!selected.size) return;
+    const store = loadBookmarks();
+    for (const bmId of selected) {
+      // Mirror swipe-row/folder delete: clear the per-device viewed timestamp
+      // so removed ids don't accrue as stale entries in the viewed map.
+      _forgetViewed(bmId);
+      removeItemById(store, bmId);
+    }
+    const removed = selected.size;
+    saveBookmarks(store);
+    _deps.rerenderActiveBookmarkTree();
+    _deps.refreshBookmarkHeaderBtn();
+    announce(removed === 1 ? "북마크를 삭제했습니다." : `북마크 ${removed}개를 삭제했습니다.`);
+    closeChapterDeleteModal();
+  };
+  $bmChapterDeleteCancel.onclick = closeChapterDeleteModal;
+}
+
+function closeChapterDeleteModal() { chapterDeleteOverlay.close(); }
+// ── END BOOKMARK_CHAPTER_DELETE ──
+
+// ── Static listeners (moved from bookmark.js) ──
+$bmConfirmCancel.addEventListener("click", closeConfirmModal);
+$bmConfirmScrim.addEventListener("click", closeConfirmModal);
+$bmChapterDeleteScrim.addEventListener("click", closeChapterDeleteModal);
+
+// ── Modal Escape stack ──
+// Topmost-first dismissal for the modal overlays, priority order matching the
+// pre-split bookmark.js router. Returns true when it closed one so bookmark.js's
+// document keydown handler can stop before its drawer/select handling. As more
+// modals move here (PR5b~), the chain grows and bookmark.js's local checks shrink.
+/** @returns {boolean} */
+function closeTopmostModal() {
+  if (!$bmConfirmModal.hidden) { closeConfirmModal(); return true; }
+  if (!$bmChapterDeleteModal.hidden) { closeChapterDeleteModal(); return true; }
+  return false;
+}
+
+// ── Window facade ──
+// Vestigial: route() now dismisses every open overlay via
+// appOverlay.closeAllOverlays() (ADR-034), which superseded these per-modal
+// close facades. Kept behavior-neutral until a dedicated facade-cleanup pass
+// confirms no remaining caller, then removable.
+window.closeConfirmModal = closeConfirmModal;
+window.closeChapterDeleteModal = closeChapterDeleteModal;
+
+export {
+  initBookmarkModals, closeTopmostModal,
+  openConfirmModal, closeConfirmModal,
+  openChapterDeleteModal, closeChapterDeleteModal,
+};

--- a/js/app/bookmark.js
+++ b/js/app/bookmark.js
@@ -44,6 +44,16 @@ import {
   _isActiveBookmark, _hasActiveDescendant, setRenderPathname,
 } from "./bookmark-core.js";
 
+// Modal dialogs split out to bookmark-modals.js (ADR-034 후속 PR5). They own
+// their overlays + DOM refs + Escape stack (closeTopmostModal); bookmark.js
+// injects its render callbacks once via initBookmarkModals() so the modal→render
+// path needs no circular import back here.
+import {
+  initBookmarkModals, closeTopmostModal,
+  openConfirmModal, closeConfirmModal,
+  openChapterDeleteModal, closeChapterDeleteModal,
+} from "./bookmark-modals.js";
+
 
 // ── BEGIN DRAG_CORE ──
 // Exercised by tests/unit/bookmark.test.js. The test loader concatenates
@@ -540,18 +550,7 @@ const $bmMergeBody = _$("bm-merge-body");
 const $bmMergeYes = _$("bm-merge-yes");
 const $bmMergeNo = _$("bm-merge-no");
 const $bmMergeCancel = _$("bm-merge-cancel");
-const $bmConfirmScrim = _$("bm-confirm-scrim");
-const $bmConfirmModal = _$("bm-confirm-modal");
-const $bmConfirmTitle = _$("bm-confirm-title");
-const $bmConfirmBody = _$("bm-confirm-body");
-const $bmConfirmOk = _$("bm-confirm-ok");
-const $bmConfirmCancel = _$("bm-confirm-cancel");
-const $bmChapterDeleteScrim = _$("bm-chapter-delete-scrim");
-const $bmChapterDeleteModal = _$("bm-chapter-delete-modal");
-const $bmChapterDeleteAll = /** @type {HTMLInputElement} */ (_$("bm-chapter-delete-all"));
-const $bmChapterDeleteList = _$("bm-chapter-delete-list");
-const $bmChapterDeleteConfirm = /** @type {HTMLButtonElement} */ (_$("bm-chapter-delete-confirm"));
-const $bmChapterDeleteCancel = _$("bm-chapter-delete-cancel");
+// $bmConfirm* / $bmChapterDelete* refs moved to bookmark-modals.js (PR5a).
 const $verseSelectBar = _$("verse-select-bar");
 const $verseSelectCount = _$("verse-select-count");
 const $verseSelectBookmarkBtn = /** @type {HTMLButtonElement} */ (_$("verse-select-bookmark-btn"));
@@ -2086,133 +2085,7 @@ function openMergeDialog(candidates, incomingSpec, mode, fallbackContext = null)
 }
 
 // ── Destructive confirm modal ──
-// Reusable confirmation for destructive actions (bookmark/folder delete,
-// header bookmark toggle-off). Replaces the old native window.confirm() so the
-// prompt is themed, focus-trapped, and stacks above the drawer/save modals.
-/**
- * @param {{ title: string, message: string, confirmLabel?: string, onConfirm: () => void }} opts
- */
-// Overlay lifecycle (scrim/hidden/focus-trap/focus-restore) is owned by the
-// shared controller (ADR-032). closeOnEsc stays off: this modal participates in
-// bookmark.js's stacked Escape router (confirm > chapter-delete > … > drawer),
-// which calls closeConfirmModal() for the topmost overlay. A controller-level
-// Escape listener here would double-handle and also close whatever sits beneath.
-// Default initial focus = cancel (safe action); destructive button is opt-in.
-const confirmOverlay = createOverlay({
-  panel: $bmConfirmModal,
-  scrim: $bmConfirmScrim,
-  initialFocus: () => $bmConfirmCancel,
-  onClose: () => { $bmConfirmOk.onclick = null; },
-});
-
-function openConfirmModal({ title, message, confirmLabel = "삭제", onConfirm }) {
-  $bmConfirmTitle.textContent = title;
-  $bmConfirmBody.textContent = message;
-  $bmConfirmOk.textContent = confirmLabel;
-  $bmConfirmOk.onclick = () => {
-    closeConfirmModal();
-    onConfirm();
-  };
-  confirmOverlay.open();
-}
-
-function closeConfirmModal() {
-  confirmOverlay.close();
-}
-
-// Header bookmark toggle-off (mobile): instead of a blunt "delete all", present
-// the chapter's bookmarks (whole-chapter + verse ranges) as a checkbox list so
-// the reader removes only what they mean to. "전체 선택" ticks them all at once.
-// Nothing is pre-selected (the select-all is the bulk affordance) and the
-// delete button stays disabled until at least one row is ticked.
-/**
- * @param {BookmarkTreeBookmark[]} candidates
- */
-// closeOnEsc off: in the stacked Escape router. onClose clears per-open
-// handlers; returnFocus restores the pre-open focus (ADR-032).
-const chapterDeleteOverlay = createOverlay({
-  panel: $bmChapterDeleteModal,
-  scrim: $bmChapterDeleteScrim,
-  initialFocus: () => $bmChapterDeleteCancel,
-  onClose: () => {
-    $bmChapterDeleteConfirm.onclick = null;
-    $bmChapterDeleteCancel.onclick = null;
-    $bmChapterDeleteAll.onchange = null;
-  },
-});
-
-function openChapterDeleteModal(candidates) {
-  if (!candidates.length) return;
-  /** @type {Set<string>} */
-  const selected = new Set();
-
-  const syncChrome = () => {
-    const state = _selectAllState(selected.size, candidates.length);
-    $bmChapterDeleteAll.checked = state === "all";
-    $bmChapterDeleteAll.indeterminate = state === "some";
-    $bmChapterDeleteConfirm.textContent = _deleteBtnLabel(selected.size);
-    $bmChapterDeleteConfirm.disabled = selected.size === 0;
-  };
-
-  clearNode($bmChapterDeleteList);
-  /** @type {HTMLInputElement[]} */
-  const rowChecks = [];
-  candidates.forEach((bm, i) => {
-    const id = `bm-chapter-del-${i}`;
-    const li = el("li", { className: "bm-chapter-delete-item" });
-    const labelEl = el("label", { className: "bm-chapter-delete-label", for: id });
-    const input = /** @type {HTMLInputElement} */ (el("input", { type: "checkbox", id }));
-    rowChecks.push(input);
-    input.addEventListener("change", () => {
-      if (input.checked) selected.add(bm.id);
-      else selected.delete(bm.id);
-      syncChrome();
-    });
-    const book = (window.getBooksCache() ?? []).find((b) => b.id === bm.bookId);
-    const bookName = book ? (book.short_name_ko || book.name_ko) : bm.bookId;
-    const refText = bm.verseSpec === "all"
-      ? `${bookName} ${bm.chapter}${chUnit(bm.bookId)}`
-      : `${bookName} ${bm.chapter}:${bm.verseSpec}`;
-    const text = el("span", { className: "bm-chapter-delete-text" });
-    text.appendChild(el("span", { className: "bm-chapter-delete-item-label" }, bm.label));
-    text.appendChild(el("span", { className: "bm-chapter-delete-item-ref" }, refText));
-    labelEl.appendChild(input);
-    labelEl.appendChild(text);
-    li.appendChild(labelEl);
-    $bmChapterDeleteList.appendChild(li);
-  });
-
-  $bmChapterDeleteAll.onchange = () => {
-    const checkAll = $bmChapterDeleteAll.checked;
-    selected.clear();
-    if (checkAll) candidates.forEach((bm) => selected.add(bm.id));
-    rowChecks.forEach((c) => { c.checked = checkAll; });
-    syncChrome();
-  };
-
-  syncChrome();
-  chapterDeleteOverlay.open();
-
-  $bmChapterDeleteConfirm.onclick = () => {
-    if (!selected.size) return;
-    const store = loadBookmarks();
-    for (const bmId of selected) {
-      // Mirror swipe-row/folder delete: clear the per-device viewed timestamp
-      // so removed ids don't accrue as stale entries in the viewed map.
-      _forgetViewed(bmId);
-      removeItemById(store, bmId);
-    }
-    const removed = selected.size;
-    saveBookmarks(store);
-    _rerenderActiveBookmarkTree();
-    refreshBookmarkHeaderBtn();
-    announce(removed === 1 ? "북마크를 삭제했습니다." : `북마크 ${removed}개를 삭제했습니다.`);
-    closeChapterDeleteModal();
-  };
-  $bmChapterDeleteCancel.onclick = closeChapterDeleteModal;
-}
-
-function closeChapterDeleteModal() { chapterDeleteOverlay.close(); }
+// openConfirmModal / openChapterDeleteModal moved to bookmark-modals.js (PR5a).
 
 // ── Bookmark select mode (ADR-029 개정 / ADR-010) ──
 // In-place multi-select over the mobile /bookmarks full view, replacing the old
@@ -2803,10 +2676,13 @@ $bookmarkScrim.addEventListener("click", closeBookmarkDrawer);
 $bmSaveClose.addEventListener("click", closeSaveModal);
 $bmSaveScrim.addEventListener("click", closeSaveModal);
 
-$bmConfirmCancel.addEventListener("click", closeConfirmModal);
-$bmConfirmScrim.addEventListener("click", closeConfirmModal);
-
-$bmChapterDeleteScrim.addEventListener("click", closeChapterDeleteModal);
+// bookmark-modals.js owns its own scrim/cancel listeners; bookmark.js only
+// injects the render callbacks a modal needs to refresh the tree/header after a
+// mutation (의존성 주입 — breaks the modal→render cycle without a circular import).
+initBookmarkModals({
+  rerenderActiveBookmarkTree: _rerenderActiveBookmarkTree,
+  refreshBookmarkHeaderBtn,
+});
 
 $bmNewFolderClose.addEventListener("click", closeNewFolderModal);
 $bmNewFolderScrim.addEventListener("click", closeNewFolderModal);
@@ -2919,8 +2795,7 @@ $bmImportScrim.addEventListener("click", closeImportModal);
 document.addEventListener("keydown", (e) => {
   if (e.key === "Escape") {
     if (!$bmNewFolderModal.hidden) { e.preventDefault(); e.stopPropagation(); closeNewFolderModal(); return; }
-    if (!$bmConfirmModal.hidden) { closeConfirmModal(); return; }
-    if (!$bmChapterDeleteModal.hidden) { closeChapterDeleteModal(); return; }
+    if (closeTopmostModal()) return;  // confirm > chapter-delete (bookmark-modals.js)
     if (!$bmMoveModal.hidden) { closeMoveModal(); return; }
     if (!$bmImportModal.hidden) { closeImportModal(); return; }
     if (!$bmMergeModal.hidden) { closeMergeModal(); return; }
@@ -3004,13 +2879,10 @@ window.closeSaveModal = closeSaveModal;
 window.closeNewFolderModal = closeNewFolderModal;
 window.closeMergeModal = closeMergeModal;
 window.closeImportModal = closeImportModal;
-// Exposed so route() can dismiss the destructive-confirm overlay on any nav
-// (e.g. OS back gesture mid-confirm) — its scrim would otherwise persist over
-// the rebuilt view. Safe to call when already hidden (self-guards).
-window.closeConfirmModal = closeConfirmModal;
-// Same rationale for the chapter-delete picker (header bookmark toggle-off).
-window.closeChapterDeleteModal = closeChapterDeleteModal;
-// Same rationale for the move-to-folder modal (선택 모드 → 이동).
+// Exposed so route() can dismiss the move-to-folder overlay on any nav (e.g. OS
+// back gesture mid-move) — its scrim would otherwise persist over the rebuilt
+// view. Safe to call when already hidden (self-guards). The confirm /
+// chapter-delete equivalents moved with their modals to bookmark-modals.js.
 window.closeMoveModal = closeMoveModal;
 window.renderBookmarkTree = renderBookmarkTree;
 // Re-render whichever bookmark surface is mounted (drawer OR /bookmarks full

--- a/sw.js
+++ b/sw.js
@@ -42,6 +42,7 @@ const SHELL_FILES = [
   "/js/app/reading-context.js",
   "/js/app/verse-spec.js",
   "/js/app/bookmark-core.js",
+  "/js/app/bookmark-modals.js",
   "/js/app/bookmark.js",
   "/js/app/citations.js",
   "/js/app/parallels.js",


### PR DESCRIPTION
## 무엇을

모달 다이얼로그를 `bookmark-modals.js`로 빼는 **1단계(PR5a)**. `confirm`(범용 삭제 확인) + `chapter-delete`(장 북마크 토글-오프 피커)를 신규 모듈로 이동.

- `bookmark.js` **3,044 → 2,916줄** · `bookmark-modals.js` 신규 209줄
- 각 모달의 overlay·DOM ref·정적 리스너·Escape 우선순위를 모듈이 소유

## 의존성 주입 (이 시리즈의 핵심)
모달→렌더 양방향 고리를 **주입으로 차단**:
- bookmark.js 가 시작 시 `initBookmarkModals({ rerenderActiveBookmarkTree, refreshBookmarkHeaderBtn })` 로 콜백 주입
- 모달은 bookmark.js 를 import 하지 않음 → **순환 import 없음** → tsc 가 못 잡는 평가시점 깨짐(PR1 부류) **구조적 차단**

## Escape 스택
7개 모달이 우선순위 최상단 연속 블록이라, 모듈의 `closeTopmostModal()` 하나로 묶고 bookmark.js 라우터가 위임(`if (closeTopmostModal()) return;`). 단계마다 이 함수가 커지고 bookmark.js 로컬 체크가 줄어듦.

## 죽은 facade 발견
`route()` 가 쓰던 `window.close{Confirm,ChapterDelete}Modal` 은 `appOverlay.closeAllOverlays()`(ADR-034)로 **이미 대체된 잔재**(외부 호출 0건). 이번 PR은 행동 변화 0을 위해 보존하되 주석으로 명시 → **PR5 시리즈 후 dead-code 정리 PR**에서 일괄 제거 예정.

## 검증
- ✅ tsc main·worker 0 · 유닛 678 · e2e bookmark+folders+edit 21
- ✅ **playwright 로드 검사 pageerror 0** (모달 facade·rerender·bookmark 모두 로드)

## 다음
PR5b: save + newFolder + `_buildFolderCombobox`(폴더 피커 클러스터). PR5c: merge + move + import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Structural refactor with dependency injection; bookmark delete paths unchanged and covered by existing tests. Load order and SW precache updated for the new module.
> 
> **Overview**
> **ADR-034 PR5a** pulls the generic **confirm** dialog and **chapter-delete** picker out of `bookmark.js` into new **`bookmark-modals.js`**, shrinking the main bookmark UI module while keeping behavior the same.
> 
> The new module owns overlay wiring (`createOverlay`), DOM refs, scrim/cancel listeners, and **`closeTopmostModal()`** for Escape (confirm before chapter-delete). **`bookmark.js`** still opens those flows but calls **`initBookmarkModals({ rerenderActiveBookmarkTree, refreshBookmarkHeaderBtn })`** once so post-delete UI refresh does not require importing `bookmark.js` back (avoids circular imports). The document Escape handler now delegates the top of the stack via **`closeTopmostModal()`** instead of inline checks.
> 
> **`index.html`** loads `bookmark-modals.js` before `bookmark.js`; **`sw.js`** precaches the new file. **`window.closeConfirmModal` / `closeChapterDeleteModal`** remain on the new module for compatibility (noted as likely dead after `closeAllOverlays`); further modals are planned in PR5b/c.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c333867c7df322afc76af25cfc390f5a920b6464. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->