### PR TITLE
refactor: 북마크 import 흐름을 bookmark-modals.js로 분리 (ADR-034 후속 PR5d)

### DIFF
--- a/js/app/bookmark-modals.js
+++ b/js/app/bookmark-modals.js
@@ -3,8 +3,9 @@
 
 // Bookmark modals — extracted from bookmark.js (ADR-034 후속 PR5). DOM-bound
 // dialog UI: confirm + chapter-delete picker (PR5a), folder combobox + new-folder
-// modal (PR5b), save/edit + merge dialog (PR5c); move/import to follow.
-// bookmark.js (drawer/tree UI) opens these and injects its
+// modal (PR5b), save/edit + merge dialog (PR5c), import flow (PR5d). The move
+// modal stays in bookmark.js (it reads select-mode state); export is a plain
+// download, also in bookmark.js. bookmark.js (drawer/tree UI) opens these and injects its
 // render callbacks once via initBookmarkModals(), so the modal→render cycle
 // needs no circular import (의존성 주입). The modal Escape stack lives here as
 // closeTopmostModal(), which bookmark.js's document keydown handler delegates to
@@ -72,6 +73,14 @@ const $bmMergeBody = _$("bm-merge-body");
 const $bmMergeYes = _$("bm-merge-yes");
 const $bmMergeNo = _$("bm-merge-no");
 const $bmMergeCancel = _$("bm-merge-cancel");
+const $bmImportBtn = _$("bm-import-btn");
+const $bmImportInput = /** @type {HTMLInputElement} */ (_$("bm-import-input"));
+const $bmImportScrim = _$("bm-import-scrim");
+const $bmImportModal = _$("bm-import-modal");
+const $bmImportBody = _$("bm-import-body");
+const $bmImportMerge = _$("bm-import-merge");
+const $bmImportOverwrite = _$("bm-import-overwrite");
+const $bmImportCancel = _$("bm-import-cancel");
 
 // ── BEGIN BOOKMARK_CONFIRM ──
 // Generic destructive-confirm dialog. The caller passes the onConfirm action, so
@@ -725,6 +734,146 @@ function openMergeDialog(candidates, incomingSpec, mode, fallbackContext = null)
 }
 // ── END BOOKMARK_MERGE ──
 
+// ── BEGIN IMPORT_EXPORT ──
+// Exercised by tests/unit/bookmark.test.js. Pure helpers for the import
+// pipeline: validation (structural), merge (id-deduped union with existing
+// taking precedence), and recursive count.
+function _validateImportData(data) {
+  if (!data || typeof data !== "object") return false;
+  if (!Array.isArray(data.bookmarks)) return false;
+  return true;
+}
+
+function _mergeBookmarkStores(existing, incoming) {
+  const existingIds = new Set();
+  function collectIds(items) {
+    for (const item of items) {
+      existingIds.add(item.id);
+      if (item.type === "folder" && Array.isArray(item.children)) {
+        collectIds(item.children);
+      }
+    }
+  }
+  collectIds(existing);
+
+  function filterNew(items) {
+    const result = [];
+    for (const item of items) {
+      if (item.type === "folder") {
+        if (!existingIds.has(item.id)) {
+          const mergedChildren = filterNew(item.children || []);
+          result.push({ ...item, children: mergedChildren });
+        }
+      } else {
+        if (!existingIds.has(item.id)) {
+          result.push(item);
+        }
+      }
+    }
+    return result;
+  }
+
+  return [...existing, ...filterNew(incoming)];
+}
+
+function _countBookmarks(items) {
+  let count = 0;
+  for (const item of items) {
+    if (item.type === "bookmark") {
+      count += 1;
+    } else if (item.type === "folder" && Array.isArray(item.children)) {
+      count += _countBookmarks(item.children);
+    }
+  }
+  return count;
+}
+// ── END IMPORT_EXPORT ──
+
+// ── BEGIN BOOKMARK_IMPORT ──
+// Full import flow: a hidden file input + its trigger (openImportFilePicker, used
+// by the ⋯ menu's 가져오기), the read/parse/validate step, then the
+// merge-vs-overwrite confirmation modal. Export is a plain download and stays in
+// bookmark.js (no dialog).
+// closeOnEsc off: in the stacked Escape router. onClose clears per-open
+// handlers and resets the file input (so re-picking the same file re-fires
+// change) (ADR-032).
+const importOverlay = createOverlay({
+  panel: $bmImportModal,
+  scrim: $bmImportScrim,
+  initialFocus: () => $bmImportMerge,
+  onClose: () => {
+    $bmImportMerge.onclick = null;
+    $bmImportOverwrite.onclick = null;
+    $bmImportCancel.onclick = null;
+    $bmImportInput.value = "";
+  },
+});
+
+function closeImportModal() { importOverlay.close(); }
+
+// Open the OS file picker (called from bookmark.js's ⋯ menu). Resetting value
+// first lets the same file be picked twice in a row and still fire change.
+function openImportFilePicker() {
+  $bmImportInput.value = "";
+  $bmImportInput.click();
+}
+
+function openImportModal(incoming) {
+  const bmCount = _countBookmarks(incoming.bookmarks);
+  clearNode($bmImportBody);
+  $bmImportBody.appendChild(
+    el("p", {}, `북마크 ${bmCount}개를 현재 목록에 병합하거나 덮어쓸 수 있습니다.`)
+  );
+
+  importOverlay.open();
+  const cleanup = closeImportModal;
+
+  $bmImportMerge.onclick = () => {
+    const existing = loadBookmarks();
+    const merged = _mergeBookmarkStores(existing, incoming.bookmarks);
+    saveBookmarks(merged);
+    _deps.rerenderActiveBookmarkTree();
+    announce("북마크를 병합했습니다.");
+    cleanup();
+  };
+
+  $bmImportOverwrite.onclick = () => {
+    saveBookmarks(incoming.bookmarks);
+    _deps.rerenderActiveBookmarkTree();
+    announce("북마크를 덮어썼습니다.");
+    cleanup();
+  };
+
+  $bmImportCancel.onclick = cleanup;
+}
+
+$bmImportBtn.addEventListener("click", openImportFilePicker);
+$bmImportInput.addEventListener("change", () => {
+  const file = $bmImportInput.files?.[0];
+  if (!file) return;
+  const reader = new FileReader();
+  reader.onload = (e) => {
+    let data;
+    try {
+      const result = /** @type {FileReader} */ (e.target).result;
+      data = JSON.parse(typeof result === "string" ? result : "");
+    } catch (_) {
+      announce("파일을 읽을 수 없습니다. 올바른 JSON 파일인지 확인해 주세요.");
+      $bmImportInput.value = "";
+      return;
+    }
+    if (!_validateImportData(data)) {
+      announce("북마크 파일 형식이 올바르지 않습니다.");
+      $bmImportInput.value = "";
+      return;
+    }
+    openImportModal(data);
+  };
+  reader.readAsText(file);
+});
+$bmImportScrim.addEventListener("click", closeImportModal);
+// ── END BOOKMARK_IMPORT ──
+
 // ── Static listeners (moved from bookmark.js) ──
 $bmConfirmCancel.addEventListener("click", closeConfirmModal);
 $bmConfirmScrim.addEventListener("click", closeConfirmModal);
@@ -754,6 +903,7 @@ function closeTopmostModal(e) {
   if (!$bmChapterDeleteModal.hidden) { closeChapterDeleteModal(); return true; }
   if (!$bmMergeModal.hidden) { closeMergeModal(); return true; }
   if (!$bmSaveModal.hidden) { closeSaveModal(); return true; }
+  if (!$bmImportModal.hidden) { closeImportModal(); return true; }
   return false;
 }
 
@@ -767,6 +917,7 @@ window.closeChapterDeleteModal = closeChapterDeleteModal;
 window.closeNewFolderModal = closeNewFolderModal;
 window.closeSaveModal = closeSaveModal;
 window.closeMergeModal = closeMergeModal;
+window.closeImportModal = closeImportModal;
 
 // Only the entry points bookmark.js calls are exported; each modal's close fn
 // stays module-internal (reached via closeTopmostModal + scrim/cancel listeners
@@ -775,4 +926,5 @@ export {
   initBookmarkModals, closeTopmostModal,
   openConfirmModal, openChapterDeleteModal,
   openNewFolderModal, openSaveModal,
+  openImportFilePicker,
 };

--- a/js/app/bookmark.js
+++ b/js/app/bookmark.js
@@ -2146,8 +2146,10 @@ $bmExportBtn.addEventListener("click", exportBookmarks);
 
 document.addEventListener("keydown", (e) => {
   if (e.key === "Escape") {
-    if (closeTopmostModal(e)) return;  // all modals except move (bookmark-modals.js)
+    // move sits above the bookmark-modals.js modals (z 78-79 vs ≤77), so it must
+    // be checked first when both are open; the rest are owned by closeTopmostModal.
     if (!$bmMoveModal.hidden) { closeMoveModal(); return; }
+    if (closeTopmostModal(e)) return;
     if (!$bookmarkDrawer.hidden) { closeBookmarkDrawer(); return; }
     if (readingContext.verseSelectMode) { exitVerseSelectMode(); return; }
     if (_bmSelectMode) { exitBookmarkSelectMode(); return; }

--- a/js/app/bookmark.js
+++ b/js/app/bookmark.js
@@ -52,6 +52,7 @@ import {
   initBookmarkModals, closeTopmostModal,
   openConfirmModal, openChapterDeleteModal,
   openNewFolderModal, openSaveModal,
+  openImportFilePicker,
 } from "./bookmark-modals.js";
 
 
@@ -490,8 +491,7 @@ const $bmAddFolderBtn = /** @type {HTMLButtonElement} */ (_$("bm-add-folder-btn"
 const $bmOverflowBtn = _$("bm-overflow-btn");
 const $bmOverflowPanel = _$("bm-overflow-panel");
 const $bmExportBtn = _$("bm-export-btn");
-const $bmImportBtn = _$("bm-import-btn");
-const $bmImportInput = /** @type {HTMLInputElement} */ (_$("bm-import-input"));
+// $bmImportBtn / $bmImportInput + the import modal refs moved to bookmark-modals.js (PR5d).
 const $driveDisconnectScrim = _$("drive-disconnect-scrim");
 const $driveDisconnectModal = _$("drive-disconnect-modal");
 const $driveDisconnectDelete = _$("drive-disconnect-delete");
@@ -523,12 +523,7 @@ $driveDisconnectDelete.addEventListener("click", async () => {
   await window.driveSync?.deleteRemoteFile();
   window.driveSync?.signOut();
 });
-const $bmImportScrim = _$("bm-import-scrim");
-const $bmImportModal = _$("bm-import-modal");
-const $bmImportBody = _$("bm-import-body");
-const $bmImportMerge = _$("bm-import-merge");
-const $bmImportOverwrite = _$("bm-import-overwrite");
-const $bmImportCancel = _$("bm-import-cancel");
+// $bmImport* modal refs moved to bookmark-modals.js (PR5d).
 // $bmSave* / $bmNewFolder* / $bmMerge* refs moved to bookmark-modals.js (PR5b~5c).
 // $bmConfirm* / $bmChapterDelete* refs moved to bookmark-modals.js (PR5a).
 const $verseSelectBar = _$("verse-select-bar");
@@ -1354,8 +1349,7 @@ function buildBmViewActions() {
     "M8.5 8.5 12 12l3.5-3.5",
     "M5 13v5a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-5",
   ], () => {
-    $bmImportInput.value = "";
-    $bmImportInput.click();
+    openImportFilePicker();
   });
   // 선택 — checkmark.circle. Enters the in-place select mode (ADR-029 개정): rows
   // reveal a leading selection circle and the tab dock yields to #bm-select-bar
@@ -1954,105 +1948,10 @@ function exportBookmarks() {
   announce("북마크를 내보냈습니다.");
 }
 
-// ── BEGIN IMPORT_EXPORT ──
-// Exercised by tests/unit/bookmark.test.js. Pure helpers for the import
-// pipeline: validation (structural), merge (id-deduped union with existing
-// taking precedence), and recursive count.
-function _validateImportData(data) {
-  if (!data || typeof data !== "object") return false;
-  if (!Array.isArray(data.bookmarks)) return false;
-  return true;
-}
-
-function _mergeBookmarkStores(existing, incoming) {
-  const existingIds = new Set();
-  function collectIds(items) {
-    for (const item of items) {
-      existingIds.add(item.id);
-      if (item.type === "folder" && Array.isArray(item.children)) {
-        collectIds(item.children);
-      }
-    }
-  }
-  collectIds(existing);
-
-  function filterNew(items) {
-    const result = [];
-    for (const item of items) {
-      if (item.type === "folder") {
-        if (!existingIds.has(item.id)) {
-          const mergedChildren = filterNew(item.children || []);
-          result.push({ ...item, children: mergedChildren });
-        }
-      } else {
-        if (!existingIds.has(item.id)) {
-          result.push(item);
-        }
-      }
-    }
-    return result;
-  }
-
-  return [...existing, ...filterNew(incoming)];
-}
-
-function _countBookmarks(items) {
-  let count = 0;
-  for (const item of items) {
-    if (item.type === "bookmark") {
-      count += 1;
-    } else if (item.type === "folder" && Array.isArray(item.children)) {
-      count += _countBookmarks(item.children);
-    }
-  }
-  return count;
-}
-// ── END IMPORT_EXPORT ──
-
-// closeOnEsc off: in the stacked Escape router. onClose clears per-open
-// handlers and resets the file input (ADR-032).
-const importOverlay = createOverlay({
-  panel: $bmImportModal,
-  scrim: $bmImportScrim,
-  initialFocus: () => $bmImportMerge,
-  onClose: () => {
-    $bmImportMerge.onclick = null;
-    $bmImportOverwrite.onclick = null;
-    $bmImportCancel.onclick = null;
-    $bmImportInput.value = "";
-  },
-});
-
-function closeImportModal() { importOverlay.close(); }
-
-function openImportModal(incoming) {
-  const bmCount = _countBookmarks(incoming.bookmarks);
-  clearNode($bmImportBody);
-  $bmImportBody.appendChild(
-    el("p", {}, `북마크 ${bmCount}개를 현재 목록에 병합하거나 덮어쓸 수 있습니다.`)
-  );
-
-  importOverlay.open();
-  const cleanup = closeImportModal;
-
-  $bmImportMerge.onclick = () => {
-    const existing = loadBookmarks();
-    const merged = _mergeBookmarkStores(existing, incoming.bookmarks);
-    saveBookmarks(merged);
-    _rerenderActiveBookmarkTree();
-    announce("북마크를 병합했습니다.");
-    cleanup();
-  };
-
-  $bmImportOverwrite.onclick = () => {
-    saveBookmarks(incoming.bookmarks);
-    _rerenderActiveBookmarkTree();
-    announce("북마크를 덮어썼습니다.");
-    cleanup();
-  };
-
-  $bmImportCancel.onclick = cleanup;
-}
+// Import flow (file input + read/validate + merge/overwrite modal) and the
+// IMPORT_EXPORT pure helpers moved to bookmark-modals.js (PR5d); the ⋯ menu's
+// 가져오기 calls openImportFilePicker (imported above). exportBookmarks stays
+// below (plain download, no dialog).
 
 // ── Verse selection mode ──
 
@@ -2243,43 +2142,12 @@ $bmOverflowBtn.addEventListener("click", () => {
 });
 
 $bmExportBtn.addEventListener("click", exportBookmarks);
-
-$bmImportBtn.addEventListener("click", () => {
-  $bmImportInput.value = "";
-  $bmImportInput.click();
-});
-
-$bmImportInput.addEventListener("change", () => {
-  const file = $bmImportInput.files?.[0];
-  if (!file) return;
-  const reader = new FileReader();
-  reader.onload = (e) => {
-    let data;
-    try {
-      const result = /** @type {FileReader} */ (e.target).result;
-      data = JSON.parse(typeof result === "string" ? result : "");
-    } catch (_) {
-      announce("파일을 읽을 수 없습니다. 올바른 JSON 파일인지 확인해 주세요.");
-      $bmImportInput.value = "";
-      return;
-    }
-    if (!_validateImportData(data)) {
-      announce("북마크 파일 형식이 올바르지 않습니다.");
-      $bmImportInput.value = "";
-      return;
-    }
-    openImportModal(data);
-  };
-  reader.readAsText(file);
-});
-
-$bmImportScrim.addEventListener("click", closeImportModal);
+// import file-input + change listener moved to bookmark-modals.js (PR5d).
 
 document.addEventListener("keydown", (e) => {
   if (e.key === "Escape") {
-    if (closeTopmostModal(e)) return;  // new-folder/confirm/chapter-delete/merge/save (bookmark-modals.js)
+    if (closeTopmostModal(e)) return;  // all modals except move (bookmark-modals.js)
     if (!$bmMoveModal.hidden) { closeMoveModal(); return; }
-    if (!$bmImportModal.hidden) { closeImportModal(); return; }
     if (!$bookmarkDrawer.hidden) { closeBookmarkDrawer(); return; }
     if (readingContext.verseSelectMode) { exitVerseSelectMode(); return; }
     if (_bmSelectMode) { exitBookmarkSelectMode(); return; }
@@ -2355,7 +2223,6 @@ window.buildHomeBtn = buildHomeBtn;
 window.buildBookmarkHeaderBtn = buildBookmarkHeaderBtn;
 window.openBookmarkDrawer = openBookmarkDrawer;
 window.closeBookmarkDrawer = closeBookmarkDrawer;
-window.closeImportModal = closeImportModal;
 // Exposed so route() can dismiss the move-to-folder overlay on any nav (e.g. OS
 // back gesture mid-move) — its scrim would otherwise persist over the rebuilt
 // view. Safe to call when already hidden (self-guards). The confirm /

--- a/tests/unit/bookmark.test.js
+++ b/tests/unit/bookmark.test.js
@@ -44,6 +44,10 @@ const VERSE_SPEC_SOURCE = fs.readFileSync(VERSE_SPEC_PATH, "utf8");
 // BOOKMARK_QUERY / BOOKMARK_ACTIVE) now live there.
 const BOOKMARK_CORE_PATH = path.resolve(__dirname, "../../js/app/bookmark-core.js");
 const BOOKMARK_CORE_SOURCE = fs.readFileSync(BOOKMARK_CORE_PATH, "utf8");
+// Modal dialogs (incl. the IMPORT_EXPORT pure helpers) moved to bookmark-modals.js
+// (ADR-034 후속 PR5); the IMPORT_EXPORT marker block now lives there.
+const BOOKMARK_MODALS_PATH = path.resolve(__dirname, "../../js/app/bookmark-modals.js");
+const BOOKMARK_MODALS_SOURCE = fs.readFileSync(BOOKMARK_MODALS_PATH, "utf8");
 
 function extractBlock(name, source = BOOKMARK_SOURCE) {
   const begin = `// ── BEGIN ${name} ──`;
@@ -1149,7 +1153,7 @@ function loadBookmarkActive() {
 function loadImportExport() {
   const ctx = { Object, Array, Set, String, JSON, console, Error };
   vm.createContext(ctx);
-  vm.runInContext(extractBlock("IMPORT_EXPORT"), ctx, { filename: "bookmark-import-export.js" });
+  vm.runInContext(extractBlock("IMPORT_EXPORT", BOOKMARK_MODALS_SOURCE), ctx, { filename: "bookmark-modals.js" });
   return {
     _validateImportData: ctx._validateImportData,
     _mergeBookmarkStores: ctx._mergeBookmarkStores,


### PR DESCRIPTION
## 무엇을

모달 분리 **마지막 단계(PR5d)**. import 전체 흐름 + IMPORT_EXPORT 순수 헬퍼를 `bookmark-modals.js`로 이동.

- 숨은 파일 입력 + 읽기/검증 + 병합/덮어쓰기 확인 모달 + `_validateImportData`/`_mergeBookmarkStores`/`_countBookmarks`
- ⋯ 메뉴 가져오기는 노출된 `openImportFilePicker()` 호출
- `bookmark.js` **2,393 → 2,260줄** · `bookmark-modals.js` 778 → 930줄
- 누적 `bookmark.js` 3,578 → **2,260줄 (−37%)**

## Escape 스택 완성
import 가 `closeTopmostModal` 에 합류 → 모듈이 모달 6종(new-folder·confirm·chapter-delete·merge·save·import)의 Escape 스택을 소유. bookmark.js 라우터는 `closeTopmostModal` 위임 + move(잔류) + drawer/select 만.

## 의도적으로 남긴 것 (branch 명과 달리 move 는 잔류)
- **move 모달** — `_bmSelected`·`_bmAncestorSelected` 등 select-mode 상태를 직접 읽는 select UI. 범용 modals 에 넣으면 select 내부를 DI 로 줄줄이 넘겨야 함 → bookmark.js 잔류. 후속 `bookmark-select.js` 분리 후보.
- **exportBookmarks** — 다이얼로그 없는 다운로드 액션이라 잔류.

## 검증
- ✅ tsc main·worker 0 · 유닛 678(IMPORT_EXPORT 테스트는 modals.js 소스에서 추출하도록 갱신) · **e2e 북마크 75건**(export/import 포함)
- ✅ **playwright 로드 검사 pageerror 0**

## 다음
모달 분리 시리즈 완료. 다음은 약속한 **죽은 facade 정리 PR**(잔재 window.close*Modal 등).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly a file move with the same merge/overwrite and storage behavior; risk is limited to wiring (Escape stack, DI rerender) rather than new import semantics.
> 
> **Overview**
> Completes **ADR-034 PR5d** by moving the bookmark **import** path out of `bookmark.js` into `bookmark-modals.js`, alongside the other modal flows.
> 
> The **IMPORT_EXPORT** helpers (`_validateImportData`, `_mergeBookmarkStores`, `_countBookmarks`), hidden file input, JSON read/validate, merge/overwrite confirmation overlay, and related listeners now live in modals. **`bookmark.js`** only calls exported **`openImportFilePicker()`** from the ⋯ **가져오기** menu; **`exportBookmarks`** stays in `bookmark.js` (download only). Import joins **`closeTopmostModal`**; document Escape handling checks **move** first, then delegates to modals (import no longer closed separately in `bookmark.js`). **`window.closeImportModal`** is registered from modals.
> 
> Unit tests load the **IMPORT_EXPORT** block from **`bookmark-modals.js`** instead of **`bookmark.js`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75d800dcc6a2680b9d04f81e983292ef3f285706. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->