### PR TITLE
refactor: 북마크 move 모달을 파라미터화해 bookmark-modals.js로 분리 (ADR-034 후속 PR5e)

### DIFF
--- a/js/app/bookmark-modals.js
+++ b/js/app/bookmark-modals.js
@@ -3,9 +3,10 @@
 
 // Bookmark modals — extracted from bookmark.js (ADR-034 후속 PR5). DOM-bound
 // dialog UI: confirm + chapter-delete picker (PR5a), folder combobox + new-folder
-// modal (PR5b), save/edit + merge dialog (PR5c), import flow (PR5d). The move
-// modal stays in bookmark.js (it reads select-mode state); export is a plain
-// download, also in bookmark.js. bookmark.js (drawer/tree UI) opens these and injects its
+// modal (PR5b), save/edit + merge dialog (PR5c), import flow (PR5d), move
+// destination picker (PR5e — a parameterized folder picker; select-mode keeps the
+// selection logic and passes excludeFolder/onPick). export stays in bookmark.js
+// (plain download, no dialog). bookmark.js (drawer/tree UI) opens these and injects its
 // render callbacks once via initBookmarkModals(), so the modal→render cycle
 // needs no circular import (의존성 주입). The modal Escape stack lives here as
 // closeTopmostModal(), which bookmark.js's document keydown handler delegates to
@@ -81,6 +82,11 @@ const $bmImportBody = _$("bm-import-body");
 const $bmImportMerge = _$("bm-import-merge");
 const $bmImportOverwrite = _$("bm-import-overwrite");
 const $bmImportCancel = _$("bm-import-cancel");
+const $bmMoveScrim = _$("bm-move-scrim");
+const $bmMoveModal = _$("bm-move-modal");
+const $bmMoveList = _$("bm-move-list");
+const $bmMoveNewFolder = _$("bm-move-new-folder");
+const $bmMoveCancel = _$("bm-move-cancel");
 
 // ── BEGIN BOOKMARK_CONFIRM ──
 // Generic destructive-confirm dialog. The caller passes the onConfirm action, so
@@ -874,6 +880,94 @@ $bmImportInput.addEventListener("change", () => {
 $bmImportScrim.addEventListener("click", closeImportModal);
 // ── END BOOKMARK_IMPORT ──
 
+// ── BEGIN BOOKMARK_MOVE ──
+// Generic "pick a destination folder" dialog. Caller (bookmark.js select mode)
+// passes excludeFolder(id)→boolean to drop ineligible destinations and
+// onPick(targetFolderId|null) to perform the move; the modal self-closes before
+// invoking onPick. New-folder runs the create flow (filtered by the same
+// predicate) and forwards the new id to onPick. No select-mode state lives here.
+const moveOverlay = createOverlay({
+  panel: $bmMoveModal,
+  scrim: $bmMoveScrim,
+  initialFocus: () => $bmMoveCancel,
+  onClose: () => { $bmMoveCancel.onclick = null; $bmMoveNewFolder.onclick = null; },
+});
+
+// Stroke-style SVG from path data (same recipe as bookmark.js's menu icons),
+// kept local so the move rows don't pull a cross-module icon helper.
+function _moveRowIcon(paths) {
+  const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  svg.setAttribute("viewBox", "0 0 24 24");
+  svg.setAttribute("fill", "none");
+  svg.setAttribute("aria-hidden", "true");
+  for (const d of paths) {
+    const p = document.createElementNS("http://www.w3.org/2000/svg", "path");
+    p.setAttribute("d", d);
+    p.setAttribute("stroke", "currentColor");
+    p.setAttribute("stroke-width", "1.7");
+    p.setAttribute("stroke-linecap", "round");
+    p.setAttribute("stroke-linejoin", "round");
+    svg.appendChild(p);
+  }
+  return svg;
+}
+
+// One destination row: leading glyph + label, indented by depth. 최상위(root)
+// gets a home glyph; folders get a folder glyph. (새 폴더 is a dedicated button
+// below the list, not a row.)
+/** @param {string} label @param {"root" | "folder"} kind @param {number} [depth] */
+function _buildMoveRow(label, kind, depth = 0) {
+  const btn = el("button", { className: "bm-move-item", type: "button" });
+  if (depth > 0) btn.style.setProperty("--bm-move-indent", `calc(var(--space-5) * ${depth})`);
+  const icon = el("span", { className: "bm-move-icon", "aria-hidden": "true" });
+  const paths = kind === "root"
+    ? ["M4 10.5 12 4l8 6.5", "M6 9.5V19a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1V9.5"]
+    : ["M3 7.5a2 2 0 0 1 2-2h3.6l1.8 2H19a2 2 0 0 1 2 2V18a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7.5Z"];
+  icon.appendChild(_moveRowIcon(paths));
+  btn.appendChild(icon);
+  btn.appendChild(el("span", { className: "bm-move-label" }, label));
+  return btn;
+}
+
+function closeMoveModal() { moveOverlay.close(); }
+
+/**
+ * @param {{ excludeFolder: (folderId: string) => boolean, onPick: (targetFolderId: string | null) => void }} opts
+ */
+function openMoveModal({ excludeFolder, onPick }) {
+  clearNode($bmMoveList);
+
+  // 최상위 (root) first, then the eligible folders (indented by depth).
+  const rootRow = _buildMoveRow("최상위", "root");
+  rootRow.addEventListener("click", () => { closeMoveModal(); onPick(null); });
+  $bmMoveList.appendChild(rootRow);
+
+  for (const f of collectFolderOptions(loadBookmarks())) {
+    if (excludeFolder(f.id)) continue;
+    const row = _buildMoveRow(f.name, "folder", f.depth);
+    row.addEventListener("click", () => { closeMoveModal(); onPick(f.id); });
+    $bmMoveList.appendChild(row);
+  }
+
+  // 새 폴더 (below the list) — opens the new-folder modal (parent picker filtered
+  // by the same predicate so the new folder can't land inside the selection),
+  // then forwards the created id to onPick.
+  $bmMoveNewFolder.onclick = () => {
+    closeMoveModal();
+    openNewFolderModal(
+      (newId) => { if (newId) onPick(newId); },
+      null,
+      { folderFilter: (f) => !excludeFolder(f.id) },
+    );
+  };
+
+  moveOverlay.open();
+  $bmMoveCancel.onclick = closeMoveModal;
+}
+
+$bmMoveScrim.addEventListener("click", closeMoveModal);
+// ── END BOOKMARK_MOVE ──
+
 // ── Static listeners (moved from bookmark.js) ──
 $bmConfirmCancel.addEventListener("click", closeConfirmModal);
 $bmConfirmScrim.addEventListener("click", closeConfirmModal);
@@ -889,21 +983,20 @@ $bmSaveClose.addEventListener("click", closeSaveModal);
 $bmSaveScrim.addEventListener("click", closeSaveModal);
 
 // ── Modal Escape stack ──
-// Topmost-first dismissal for the modal overlays. Returns true when it closed one
-// so bookmark.js's document keydown handler can stop before its drawer/select
-// handling. new-folder sits at the top and consumes the event
-// (preventDefault/stopPropagation) to match the pre-split behavior. move/import
-// stay in bookmark.js until PR5d; since every modal except new-folder is mutually
-// exclusive (only new-folder ever stacks, and it's checked first), the relative
-// order of the others across the module boundary doesn't affect behavior.
+// Topmost-first dismissal for every bookmark modal. Returns true when it closed
+// one so bookmark.js's document keydown handler can stop before its drawer/select
+// handling. Order follows z-index so the visually topmost layer is dismissed
+// first: new-folder (stacks above save/move, and consumes the event), then move
+// (z 78-79), then import (z 76-77), then the mutually-exclusive rest.
 /** @param {KeyboardEvent} e @returns {boolean} */
 function closeTopmostModal(e) {
   if (!$bmNewFolderModal.hidden) { e.preventDefault(); e.stopPropagation(); closeNewFolderModal(); return true; }
+  if (!$bmMoveModal.hidden) { closeMoveModal(); return true; }
+  if (!$bmImportModal.hidden) { closeImportModal(); return true; }
   if (!$bmConfirmModal.hidden) { closeConfirmModal(); return true; }
   if (!$bmChapterDeleteModal.hidden) { closeChapterDeleteModal(); return true; }
   if (!$bmMergeModal.hidden) { closeMergeModal(); return true; }
   if (!$bmSaveModal.hidden) { closeSaveModal(); return true; }
-  if (!$bmImportModal.hidden) { closeImportModal(); return true; }
   return false;
 }
 
@@ -918,6 +1011,7 @@ window.closeNewFolderModal = closeNewFolderModal;
 window.closeSaveModal = closeSaveModal;
 window.closeMergeModal = closeMergeModal;
 window.closeImportModal = closeImportModal;
+window.closeMoveModal = closeMoveModal;
 
 // Only the entry points bookmark.js calls are exported; each modal's close fn
 // stays module-internal (reached via closeTopmostModal + scrim/cancel listeners
@@ -926,5 +1020,5 @@ export {
   initBookmarkModals, closeTopmostModal,
   openConfirmModal, openChapterDeleteModal,
   openNewFolderModal, openSaveModal,
-  openImportFilePicker,
+  openImportFilePicker, openMoveModal,
 };

--- a/js/app/bookmark.js
+++ b/js/app/bookmark.js
@@ -39,7 +39,7 @@ import {
   getBookmarkSort, setBookmarkSort, markBookmarkViewed, _forgetViewed,
   sortBookmarkNodes,
   _walkBookmarks, findExistingChapterBookmarks, _findItemInStore,
-  _findParentFolderId, removeItemById, insertItem, collectFolderOptions,
+  _findParentFolderId, removeItemById, insertItem,
   _selectAllState, _deleteBtnLabel, _bmSelectCountLabel, _descendantIds,
   _isActiveBookmark, _hasActiveDescendant, setRenderPathname,
 } from "./bookmark-core.js";
@@ -52,7 +52,7 @@ import {
   initBookmarkModals, closeTopmostModal,
   openConfirmModal, openChapterDeleteModal,
   openNewFolderModal, openSaveModal,
-  openImportFilePicker,
+  openImportFilePicker, openMoveModal,
 } from "./bookmark-modals.js";
 
 
@@ -542,11 +542,7 @@ const $bmSelectMoveBtn = /** @type {HTMLButtonElement} */ (_$("bm-select-move-bt
 const $bmSelectDeleteBtn = /** @type {HTMLButtonElement} */ (_$("bm-select-delete-btn"));
 const $bmSelectCancelBtn = _$("bm-select-cancel-btn");
 // Move-to-folder modal (선택 모드 → 이동).
-const $bmMoveScrim = _$("bm-move-scrim");
-const $bmMoveModal = _$("bm-move-modal");
-const $bmMoveList = _$("bm-move-list");
-const $bmMoveNewFolder = _$("bm-move-new-folder");
-const $bmMoveCancel = _$("bm-move-cancel");
+// $bmMove* refs moved to bookmark-modals.js with the move picker (PR5e).
 
 // Build the chevron-left back button for page title headers
 function buildBackBtn(ariaLabel, fallback) {
@@ -1821,32 +1817,9 @@ function _runBookmarkSelectShare() {
 }
 
 // ── 이동 (dock): move the selection into a chosen folder ──
-// Overlay lifecycle via the shared controller (ADR-032). closeOnEsc off — the
-// central Escape router closes it (above select mode). Reuses the chapter-delete
-// modal styling family.
-const moveOverlay = createOverlay({
-  panel: $bmMoveModal,
-  scrim: $bmMoveScrim,
-  initialFocus: () => $bmMoveCancel,
-  onClose: () => { $bmMoveCancel.onclick = null; $bmMoveNewFolder.onclick = null; },
-});
-
-// One destination row in the move modal: leading glyph + label, indented by depth.
-// 최상위(root) gets a home glyph; folders get a folder glyph. (새 폴더 is a dedicated
-// button below the list, not a row.)
-/** @param {string} label @param {"root" | "folder"} kind @param {number} [depth] */
-function _buildMoveRow(label, kind, depth = 0) {
-  const btn = el("button", { className: "bm-move-item", type: "button" });
-  if (depth > 0) btn.style.setProperty("--bm-move-indent", `calc(var(--space-5) * ${depth})`);
-  const icon = el("span", { className: "bm-move-icon", "aria-hidden": "true" });
-  const paths = kind === "root"
-    ? ["M4 10.5 12 4l8 6.5", "M6 9.5V19a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1V9.5"]
-    : ["M3 7.5a2 2 0 0 1 2-2h3.6l1.8 2H19a2 2 0 0 1 2 2V18a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7.5Z"];
-  icon.appendChild(_bmMenuIcon(paths));
-  btn.appendChild(icon);
-  btn.appendChild(el("span", { className: "bm-move-label" }, label));
-  return btn;
-}
+// The move dialog (destination picker + 새 폴더) moved to bookmark-modals.js
+// (PR5e); select mode keeps the selection logic below and drives the picker via
+// openMoveModal({ excludeFolder, onPick }).
 
 // Move the top-most selected nodes into `targetFolderId` (null = root), preserving
 // each item (folders move whole). Skips a folder dropped into itself/its subtree.
@@ -1871,58 +1844,28 @@ function _moveSelectedToFolder(targetFolderId) {
     if (dest && dest.item.type === "folder") dest.item.expanded = true;
   }
   saveBookmarks(live);
-  closeMoveModal();
+  // The picker self-closes before invoking this (onPick), so no close here.
   announce(moved === 1 ? "1개 항목을 이동했습니다." : `${moved}개 항목을 이동했습니다.`);
   exitBookmarkSelectMode();
   _rerenderActiveBookmarkTree();
   refreshBookmarkHeaderBtn();
 }
 
-function openMoveModal() {
-  const store = loadBookmarks();
-  const parentMap = _bmBuildParentMap(store);
+// Open the move destination picker (bookmark-modals.js) for the current
+// selection: guard on having effective targets, then hand it the exclude
+// predicate (a selected folder or one under a selected ancestor can't be a
+// destination — that would be a no-op/empty-folder move) and the mover callback.
+function _openMoveSelection() {
+  const parentMap = _bmBuildParentMap(loadBookmarks());
   if (!_bmEffectiveTargets(parentMap).length) return;
-  clearNode($bmMoveList);
-
-  // 최상위 (root) first, then the folder list (indented by depth).
-  const rootRow = _buildMoveRow("최상위", "root");
-  rootRow.addEventListener("click", () => _moveSelectedToFolder(null));
-  $bmMoveList.appendChild(rootRow);
-
-  // Every folder except the ones being moved (a folder can't move into itself or
-  // its own subtree) — i.e. selected folders + folders under a selected folder.
-  for (const f of collectFolderOptions(store)) {
-    if (_bmSelected.has(f.id) || _bmAncestorSelected(f.id, parentMap)) continue;
-    const row = _buildMoveRow(f.name, "folder", f.depth);
-    row.addEventListener("click", () => _moveSelectedToFolder(f.id));
-    $bmMoveList.appendChild(row);
-  }
-
-  // 새 폴더 (below the list) — opens the new-folder modal where a parent can be
-  // chosen (미지정=최상위); the created folder then receives the selection. The
-  // parent options exclude the same folders the move list omits (selected folders +
-  // folders under a selected ancestor) so the new folder can't be created inside the
-  // selection — otherwise the move would be a no-op and leave a stray empty folder.
-  $bmMoveNewFolder.onclick = () => {
-    closeMoveModal();
-    openNewFolderModal(
-      (newId) => { if (newId) _moveSelectedToFolder(newId); },
-      null,
-      { folderFilter: (f) => !(_bmSelected.has(f.id) || _bmAncestorSelected(f.id, parentMap)) },
-    );
-  };
-
-  moveOverlay.open();
-  $bmMoveCancel.onclick = closeMoveModal;
+  const excludeFolder = (folderId) => _bmSelected.has(folderId) || _bmAncestorSelected(folderId, parentMap);
+  openMoveModal({ excludeFolder, onPick: _moveSelectedToFolder });
 }
 
-function closeMoveModal() { moveOverlay.close(); }
-
 $bmSelectShareBtn.addEventListener("click", _runBookmarkSelectShare);
-$bmSelectMoveBtn.addEventListener("click", openMoveModal);
+$bmSelectMoveBtn.addEventListener("click", _openMoveSelection);
 $bmSelectDeleteBtn.addEventListener("click", _runBookmarkSelectDelete);
 $bmSelectCancelBtn.addEventListener("click", exitBookmarkSelectMode);
-$bmMoveScrim.addEventListener("click", closeMoveModal);
 
 // ── Export / Import bookmarks (Phase 2a) ──
 
@@ -2146,10 +2089,7 @@ $bmExportBtn.addEventListener("click", exportBookmarks);
 
 document.addEventListener("keydown", (e) => {
   if (e.key === "Escape") {
-    // move sits above the bookmark-modals.js modals (z 78-79 vs ≤77), so it must
-    // be checked first when both are open; the rest are owned by closeTopmostModal.
-    if (!$bmMoveModal.hidden) { closeMoveModal(); return; }
-    if (closeTopmostModal(e)) return;
+    if (closeTopmostModal(e)) return;  // all bookmark modals incl. move (bookmark-modals.js)
     if (!$bookmarkDrawer.hidden) { closeBookmarkDrawer(); return; }
     if (readingContext.verseSelectMode) { exitVerseSelectMode(); return; }
     if (_bmSelectMode) { exitBookmarkSelectMode(); return; }
@@ -2225,11 +2165,7 @@ window.buildHomeBtn = buildHomeBtn;
 window.buildBookmarkHeaderBtn = buildBookmarkHeaderBtn;
 window.openBookmarkDrawer = openBookmarkDrawer;
 window.closeBookmarkDrawer = closeBookmarkDrawer;
-// Exposed so route() can dismiss the move-to-folder overlay on any nav (e.g. OS
-// back gesture mid-move) — its scrim would otherwise persist over the rebuilt
-// view. Safe to call when already hidden (self-guards). The confirm /
-// chapter-delete equivalents moved with their modals to bookmark-modals.js.
-window.closeMoveModal = closeMoveModal;
+// (window.closeMoveModal moved to bookmark-modals.js with the move picker, PR5e.)
 window.renderBookmarkTree = renderBookmarkTree;
 // Re-render whichever bookmark surface is mounted (drawer OR /bookmarks full
 // view). Sync layer + mutation flows use this so the visible tree refreshes.


### PR DESCRIPTION
## 무엇을

move 다이얼로그를 **select-mode 상태 없는 범용 폴더 picker**로 일반화해 `bookmark-modals.js`로 이동.

```js
openMoveModal({ excludeFolder, onPick })
// 호출자가 제외 술어 + 이동 콜백을 넘김
// 행 클릭 → self-close 후 onPick(folderId)
// 새 폴더 → openNewFolderModal(newId=>onPick(newId), …, { folderFilter })  ← 모듈 내부
```

- `bookmark.js` **2,260 → 2,198줄** · `bookmark-modals.js` 930 → 1,024줄
- 누적 `bookmark.js` 3,578 → **2,198줄 (−38%)**

## 왜 "파라미터화" (지속 DI 아님)
move 는 `_bmSelected`·`_bmAncestorSelected` 같은 select 상태를 읽어, 그대로 modals 로 옮기면 select 내부를 `_deps` 에 줄줄이 주입해야 함(계약 오염). 대신 **호출 시 인자**로 `excludeFolder`(제외 술어)와 `onPick`(이동 콜백)만 넘김 → select 로직(`_moveSelectedToFolder`·`_bmEffectiveTargets` 등)은 bookmark.js 의 `_openMoveSelection` 에 남고, picker 는 순수 UI.

## Escape 분할 해소 (#241 Bugbot 근본 수정)
이로써 **모든 모달이 `closeTopmostModal` 로 모임**. bookmark.js Escape 라우터는 전적으로 위임(`if (closeTopmostModal(e)) return;`). #241 의 임시 move-순서 수정을 구조적으로 흡수하고, 스택을 z-순서(new-folder>move>import>…)로 재배열.

## 검증
- ✅ tsc main·worker 0 · 유닛 678
- ✅ **e2e `test_move_into_folder` + `test_move_new_folder_with_parent` 통과**(파라미터화한 picker·onPick·새 폴더 경로 실동작) + bookmark/folders/select 28건
- ✅ playwright 로드 검사 pageerror 0

## 다음
모달 분리 시리즈 **완료**(7개 모달 전부 bookmark-modals.js). 다음은 **죽은 코드 정리 PR** — 잔재 `window.close*Modal` facade + 누적 미사용 core import(_deleteBtnLabel 등).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multi-select move UX and modal Escape stacking; behavior is intended to match prior flows but overlay order changes are user-visible if wrong.
> 
> **Overview**
> Moves the bookmark **move destination** dialog from `bookmark.js` into `bookmark-modals.js` as a reusable folder picker: **`openMoveModal({ excludeFolder, onPick })`**. Select-mode rules stay in `bookmark.js` (`_openMoveSelection` passes an exclude predicate and `_moveSelectedToFolder`); the modal only builds the list (root + folders + **새 폴더** via `openNewFolderModal` with the same filter), closes itself, then calls `onPick`.
> 
> **Escape** handling is consolidated: `closeTopmostModal` now includes move (and reorders move before import to match z-index), so `bookmark.js` no longer special-cases move on Escape. `window.closeMoveModal` moves with the modal module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c5c80a93e42358e3648019200439a00d49d036d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->