### PR TITLE
chore: 모듈 분할 후 죽은 facade·미사용 import 정리 (ADR-034 후속)

### DIFF
--- a/js/app/bookmark-core.js
+++ b/js/app/bookmark-core.js
@@ -5,8 +5,8 @@
 // bookmark logic: query/tree ops (QUERY block, loadBookmarks-backed), href/share
 // builders (HREF), sort/last-viewed helpers (SORT, localStorage), active-route
 // highlight predicates (ACTIVE, _renderPathname set by UI via setRenderPathname).
-// bookmark.js (UI) imports these; a few QUERY fns keep a window facade for the
-// legacy bare-global contract (types.d.ts). Deps: appStorage, localStorage.
+// bookmark.js (UI) and bookmark-modals.js import these via ESM. Deps: appStorage,
+// localStorage.
 
 /** @typedef {import("../types").BookmarkTreeNode} BookmarkTreeNode */
 /** @typedef {import("../types").BookmarkTreeBookmark} BookmarkTreeBookmark */
@@ -346,18 +346,6 @@ function _hasActiveDescendant(folder, pathname = _renderPathname) {
   return false;
 }
 // ── END BOOKMARK_ACTIVE ──
-
-// ── Window facade ──
-// QUERY tree helpers keep the legacy bare-global contract (types.d.ts declares
-// them on Window). No current module reads them, but preserved to avoid a hidden
-// runtime break.
-window._walkBookmarks = _walkBookmarks;
-window.findExistingChapterBookmarks = findExistingChapterBookmarks;
-window._findItemInStore = _findItemInStore;
-window._findParentFolderId = _findParentFolderId;
-window.removeItemById = removeItemById;
-window.insertItem = insertItem;
-window.collectFolderOptions = collectFolderOptions;
 
 export {
   _bookmarkHref, _buildSharePayload,

--- a/js/app/bookmark-modals.js
+++ b/js/app/bookmark-modals.js
@@ -1000,22 +1000,10 @@ function closeTopmostModal(e) {
   return false;
 }
 
-// ── Window facade ──
-// Vestigial: route() now dismisses every open overlay via
-// appOverlay.closeAllOverlays() (ADR-034), which superseded these per-modal
-// close facades. Kept behavior-neutral until a dedicated facade-cleanup pass
-// confirms no remaining caller, then removable.
-window.closeConfirmModal = closeConfirmModal;
-window.closeChapterDeleteModal = closeChapterDeleteModal;
-window.closeNewFolderModal = closeNewFolderModal;
-window.closeSaveModal = closeSaveModal;
-window.closeMergeModal = closeMergeModal;
-window.closeImportModal = closeImportModal;
-window.closeMoveModal = closeMoveModal;
-
-// Only the entry points bookmark.js calls are exported; each modal's close fn
-// stays module-internal (reached via closeTopmostModal + scrim/cancel listeners
-// here) and, where route() needs it, via the window facade above.
+// Each modal's close fn stays module-internal (reached via closeTopmostModal +
+// the scrim/cancel listeners above). route() dismisses any open overlay through
+// appOverlay.closeAllOverlays() (ADR-034), so no per-modal window facade is
+// needed. Only the entry points bookmark.js calls are exported.
 export {
   initBookmarkModals, closeTopmostModal,
   openConfirmModal, openChapterDeleteModal,

--- a/js/app/bookmark.js
+++ b/js/app/bookmark.js
@@ -39,8 +39,8 @@ import {
   getBookmarkSort, setBookmarkSort, markBookmarkViewed, _forgetViewed,
   sortBookmarkNodes,
   _walkBookmarks, findExistingChapterBookmarks, _findItemInStore,
-  _findParentFolderId, removeItemById, insertItem,
-  _selectAllState, _deleteBtnLabel, _bmSelectCountLabel, _descendantIds,
+  removeItemById, insertItem,
+  _selectAllState, _bmSelectCountLabel, _descendantIds,
   _isActiveBookmark, _hasActiveDescendant, setRenderPathname,
 } from "./bookmark-core.js";
 

--- a/js/types.d.ts
+++ b/js/types.d.ts
@@ -787,31 +787,9 @@ export interface AppBookmark {
   collapseFullVerseRefs: (refs: string[], article: Element | null | undefined) => string[];
   selectedVersesToSpec: (refs: string[]) => string;
   mergeVerseSpecs: (specA: string, specB: string) => string;
-  findExistingChapterBookmarks: (bookId: string, chapter: number) => BookmarkTreeBookmark[];
-  _walkBookmarks: (
-    store: BookmarkTreeNode[],
-    fn: (item: BookmarkTreeNode, parent: BookmarkTreeNode[]) => unknown,
-  ) => boolean;
-  _findItemInStore: (
-    store: BookmarkTreeNode[],
-    id: string,
-  ) => { item: BookmarkTreeNode; parent: BookmarkTreeNode[]; index: number } | null;
-  _findParentFolderId: (
-    store: BookmarkTreeNode[],
-    id: string,
-    parentId?: string | null,
-  ) => string | null | undefined;
-  removeItemById: (store: BookmarkTreeNode[], id: string) => void;
-  insertItem: (
-    store: BookmarkTreeNode[],
-    folderId: string | null | undefined,
-    item: BookmarkTreeNode,
-  ) => void;
-  collectFolderOptions: (
-    store: BookmarkTreeNode[],
-    depth?: number,
-    options?: Array<{ id: string; name: string; depth: number }>,
-  ) => Array<{ id: string; name: string; depth: number }>;
+  // bookmark-core QUERY helpers (findExistingChapterBookmarks / _walkBookmarks /
+  // _findItemInStore / _findParentFolderId / removeItemById / insertItem /
+  // collectFolderOptions) are ESM-only now — no window/global facade.
   moveBookmarkItem: (draggedId: string, targetId: string, position: "before" | "after" | "into") => void;
   closeSwipedRow: (except: HTMLElement | null) => void;
   _setupDragHandle: (li: HTMLElement, row: HTMLElement) => void;
@@ -1015,31 +993,7 @@ declare global {
   function collapseFullVerseRefs(refs: string[], article: Element | null | undefined): string[];
   function selectedVersesToSpec(refs: string[]): string;
   function mergeVerseSpecs(specA: string, specB: string): string;
-  function findExistingChapterBookmarks(bookId: string, chapter: number): BookmarkTreeBookmark[];
-  function _walkBookmarks(
-    store: BookmarkTreeNode[],
-    fn: (item: BookmarkTreeNode, parent: BookmarkTreeNode[]) => unknown,
-  ): boolean;
-  function _findItemInStore(
-    store: BookmarkTreeNode[],
-    id: string,
-  ): { item: BookmarkTreeNode; parent: BookmarkTreeNode[]; index: number } | null;
-  function _findParentFolderId(
-    store: BookmarkTreeNode[],
-    id: string,
-    parentId?: string | null,
-  ): string | null | undefined;
-  function removeItemById(store: BookmarkTreeNode[], id: string): void;
-  function insertItem(
-    store: BookmarkTreeNode[],
-    folderId: string | null | undefined,
-    item: BookmarkTreeNode,
-  ): void;
-  function collectFolderOptions(
-    store: BookmarkTreeNode[],
-    depth?: number,
-    options?: Array<{ id: string; name: string; depth: number }>,
-  ): Array<{ id: string; name: string; depth: number }>;
+  // bookmark-core QUERY helpers are ESM-only now (see Window interface note above).
   function moveBookmarkItem(draggedId: string, targetId: string, position: "before" | "after" | "into"): void;
   function closeSwipedRow(except: HTMLElement | null): void;
   function _setupDragHandle(li: HTMLElement, row: HTMLElement): void;


### PR DESCRIPTION
## 무엇을

모달 분리 시리즈(PR5a~5e) 동안 보존만 해두었던 **검증된 죽은 코드**를 일괄 제거. 사용자 발의(2026-06-08).

**제거 전 무참조 확증**(전 저장소 grep js/ + 인라인 HTML + 로드 검사) — blind 삭제 아님:

1. **`window.close{Confirm,ChapterDelete,NewFolder,Save,Merge,Import,Move}Modal` 7종** (bookmark-modals.js)
   - route() 가 `appOverlay.closeAllOverlays()`(ADR-034)로 대체 → 외부 호출 0건
2. **bookmark-core.js QUERY 헬퍼 7종 window facade** + types.d.ts Window·전역 function 선언
   - `_walkBookmarks`·`findExistingChapterBookmarks`·`_findItemInStore`·`_findParentFolderId`·`removeItemById`·`insertItem`·`collectFolderOptions` — ESM import 로만 사용, facade·bare-global 호출 0건 (PR3 에서 "숨은 깨짐 방지"로 보존했던 계약, 이제 안전 확인)
3. **bookmark.js 미사용 core import 2개**: `_deleteBtnLabel`(PR5a 잔재), `_findParentFolderId`(PR5c 잔재)

순삭제 **−82 / +12**(주석 breadcrumb).

## 검증
- ✅ tsc main·worker 0 · 유닛 678
- ✅ e2e 52건(confirm 삭제·QUERY 트리연산·move·import 등 facade 가 쓰이던 흐름)
- ✅ **로드 검사 pageerror 0** + 제거된 facade 가 런타임에서 `undefined` 확인(앱·core 정상 로드)

## 맥락
ADR-034 모달 분리 시리즈의 마무리 정리. modals.js export 는 이미 진입점과 일치해 손댈 것 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Verified no callers of removed globals; pure deletion and type/doc updates with no logic changes.
> 
> **Overview**
> **ADR-034 follow-up cleanup** after bookmark modularization: drops legacy `window` facades that nothing calls anymore, and trims stale ESM imports.
> 
> **`bookmark-modals.js`** no longer assigns seven `window.close*Modal` hooks; routing already dismisses overlays via `appOverlay.closeAllOverlays()`.
> 
> **`bookmark-core.js`** stops exposing QUERY tree helpers (`_walkBookmarks`, `findExistingChapterBookmarks`, `_findItemInStore`, `_findParentFolderId`, `removeItemById`, `insertItem`, `collectFolderOptions`) on `window`; consumers use ESM imports only.
> 
> **`bookmark.js`** drops unused imports `_deleteBtnLabel` and `_findParentFolderId` (chapter-delete label still comes from core via `bookmark-modals.js`).
> 
> **`types.d.ts`** documents that QUERY helpers are ESM-only and removes them from `AppBookmark` and bare-global `function` declarations.
> 
> Behavior is unchanged for paths that already imported from `bookmark-core` / used the overlay stack.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78034e9f94186d062cb6e457c5d62110a9b05ac8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->