### PR TITLE
style: 북마크 읽기 본문 좌우 여백을 장 읽기 화면과 일치

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -486,9 +486,12 @@ body {
    headings (folder sub-heading + per-group reference/label) are sans-serif
    chrome, matching the other in-page views. */
 .bookmark-read {
-  max-width: var(--max-width);
-  margin: 0 auto;
-  padding: var(--space-3) var(--space-4) var(--space-12);
+  /* #app already owns the reading column (max-width + centering + --space-4 side
+     padding) and the tab-bar bottom reserve, so add NO inset of our own —
+     otherwise the text is double-padded and sits in a narrower column than the
+     regular chapter view. This makes the passage left/right margins identical to
+     the chapter reading screen (ADR-035: same paragraph layout, study aids off). */
+  padding: 0;
 }
 
 /* Nested-folder name → section sub-heading (depth-stepped). */


### PR DESCRIPTION
## 요약

북마크 모아 읽기 화면의 본문 단락 **좌우 여백**을 일반 장 읽기 화면과 동일하게 맞춥니다.

PR #256(라벨 제거)을 머지하실 때 이 여백 수정 커밋이 함께 포함되지 않아, 별도 PR로 다시 올립니다.

## 문제

`#app`이 좌우 `--space-4`(16px) 패딩을 주는데, `.bookmark-read`가 그 위에 자체 `--space-4`를 더해 본문 열이 **32px**로 들어가, 장 읽기 화면(16px)보다 좁고 안쪽으로 치우쳐 보였습니다(스크린샷).

## 변경

- `css/style.css` `.bookmark-read`: 자체 좌우 패딩 + 중복 `max-width`/`margin:auto` 제거 → `#app` 열에 그대로 정렬. 좌우 여백이 장 읽기 화면과 동일해집니다. (인용·주석·병행구절은 기존대로 모두 숨김.)

## 검증

- 유닛 708 통과, `tsc --noEmit` 0 에러 (CSS만 변경).

ADR-035 후속.

https://claude.ai/code/session_019bQ3jNjbVP2kWa2Zy5C43J

---
_Generated by [Claude Code](https://claude.ai/code/session_019bQ3jNjbVP2kWa2Zy5C43J)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> `css/style.css`의 `.bookmark-read` 레이아웃 패딩만 조정하는 시각적 변경이며 로직·데이터·인증에는 영향 없음.
> 
> **Overview**
> 북마크 **모아 읽기** 본문이 장 읽기보다 좁아 보이던 문제를 **CSS만**으로 고칩니다. `#app`이 이미 읽기 열(`max-width`, 가운데 정렬, 좌우 `--space-4`)을 담당하는데 `.bookmark-read`가 같은 역할을 또 해 **좌우 패딩이 이중**이었습니다.
> 
> `.bookmark-read`에서 자체 `max-width`·`margin: auto`·측면 패딩을 없애고 `padding: 0`만 두어, 본문 여백이 일반 장 읽기 화면과 같아집니다(ADR-035 후속).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77b5892770616fb4d461fde9292af475172e2317. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->