### PR TITLE
fix: 선택 모드 폴더 이동 ReferenceError 수정 (_isDescendant export 누락)

### DIFF
--- a/js/app/bookmark-gestures.js
+++ b/js/app/bookmark-gestures.js
@@ -536,6 +536,6 @@ function _setupDragHandle(li, row) {
 
 export {
   initBookmarkGestures,
-  moveBookmarkItem, _setupDragHandle, _isMobileViewport,
+  moveBookmarkItem, _setupDragHandle, _isMobileViewport, _isDescendant,
   closeSwipedRow, resetSwipedRow, closeSwipedRowIfOutside,
 };

--- a/js/app/bookmark.js
+++ b/js/app/bookmark.js
@@ -63,7 +63,7 @@ import {
 // — see the call right after _bmSelectMode is declared below.
 import {
   initBookmarkGestures,
-  moveBookmarkItem, _setupDragHandle, _isMobileViewport,
+  moveBookmarkItem, _setupDragHandle, _isMobileViewport, _isDescendant,
   closeSwipedRow, resetSwipedRow, closeSwipedRowIfOutside,
 } from "./bookmark-gestures.js";
 

--- a/tests/e2e/test_bookmark_select_delete.py
+++ b/tests/e2e/test_bookmark_select_delete.py
@@ -291,6 +291,52 @@ def test_move_into_folder(browser):
         ctx.close()
 
 
+def test_move_folder_into_folder(browser):
+    """이동 → 선택한 폴더를 다른 폴더로 옮긴다 (자기/하위 드롭 방지에 _isDescendant 사용).
+
+    회귀 가드: 선택 항목이 폴더일 때만 _moveSelectedToFolder 가 _isDescendant 를 호출한다.
+    제스처 모듈 분리(ADR-034 후속) 때 _isDescendant 가 bookmark-gestures.js 로 옮겨졌는데
+    export 누락으로 이 경로가 ReferenceError 로 깨졌었다(북마크만 옮기던 기존 테스트는 폴더
+    분기를 안 밟아 못 잡음). pageerror 가 0 이어야 하고 이동이 실제로 일어나야 한다.
+    """
+    ctx = browser.new_context(viewport=MOBILE_VIEWPORT, user_agent=IPHONE_UA)
+    ctx.add_init_script(CLEAR_APP_STORAGE)
+    ctx.add_init_script(_PIN_NUDGE)
+    page = ctx.new_page()
+    errors = []
+    page.on("pageerror", lambda e: errors.append(str(e)))
+    try:
+        _open_bookmarks_view(page)
+        # folder-a(이동 대상, 안에 북마크 1개) + folder-b(목적지, 비어 있음).
+        _set_store(page, [
+            {"type": "folder", "id": "folder-a", "name": "이동대상",
+             "children": [dict(_BM_NESTED)], "expanded": True},
+            {"type": "folder", "id": "folder-b", "name": "목적지",
+             "children": [], "expanded": True},
+        ])
+        _enter_select_mode(page)
+        # Tick folder-a (direct child row — a nested row would also match in strict mode).
+        page.locator("li.bm-folder[data-id='folder-a'] > .bm-folder-row").click()
+        page.wait_for_selector(".bm-select-circle.is-selected")
+        page.locator("#bm-select-move-btn").click()
+        page.wait_for_selector("#bm-move-modal:not([hidden])")
+        # folder-a is excluded (it's the moving item); 목적지(folder-b) is the destination.
+        page.get_by_role("button", name="목적지").click()
+        page.wait_for_selector("#bm-move-modal", state="hidden")
+        page.wait_for_selector("#bm-select-bar", state="hidden")
+
+        store = _get_store(page)
+        # folder-a is now inside folder-b (with its bm-nested child intact), not at root.
+        assert all(n["id"] != "folder-a" for n in store), store
+        folder_b = next(n for n in store if n["id"] == "folder-b")
+        moved = next(c for c in folder_b["children"] if c["id"] == "folder-a")
+        assert any(c["id"] == "bm-nested" for c in moved["children"])
+        # No ReferenceError (the regression) reached the page.
+        assert errors == [], errors
+    finally:
+        ctx.close()
+
+
 def test_move_new_folder_with_parent(browser):
     """이동 → 새 폴더: 상위 폴더(대림시기)를 지정해 만든 폴더로 선택 항목이 이동한다."""
     ctx = browser.new_context(viewport=MOBILE_VIEWPORT, user_agent=IPHONE_UA)


### PR DESCRIPTION
## 무엇이 문제였나

제스처 모듈 분리(#275, ADR-034 후속)에서 `_isDescendant`를 `bookmark-gestures.js`로 옮기면서 **export를 누락**했다. `bookmark.js`의 `_moveSelectedToFolder`가 이 함수를 bare로 참조하므로, ESM 모듈에서 미해결 바인딩 → **런타임 `ReferenceError`**.

**증상**: 선택 모드에서 **폴더(또는 폴더를 포함한 항목)를 다른 폴더로 이동**하면 이동이 중단된다(select bar가 사라지지 않음). 북마크만 이동하는 경우는 폴더 분기를 안 밟아 정상.

**왜 #275 검증을 통과했나**: `_isDescendant`는 `found.item.type === "folder"`일 때만 호출된다.
- tsc — checkJs가 모듈 미선언 식별자를 하드 에러로 안 잡음
- 유닛 — 이 통합 경로 미커버
- 로드 스모크 — 이동을 트리거하지 않음
- 기존 move e2e(`test_move_into_folder` 등) — **북마크만** 이동, 폴더 분기 미진입

## 수정

- `bookmark-gestures.js`가 `_isDescendant` export, `bookmark.js`가 import (이미 같은 모듈에서 import 중인 목록에 추가).

## 회귀 가드

- e2e `test_move_folder_into_folder` 추가: 폴더를 선택해 다른 폴더로 **이동 완료** + `pageerror == 0` 검증.
- 픽스를 #275 상태로 되돌려 새 테스트가 실패(select bar 잔존)하는 것을 확인 → 버그 실재 증명.

## 검증

- ✅ tsc (main · worker)
- ✅ 유닛 728건
- ✅ e2e 26건 (`test_bookmark_select_delete` 신규 회귀 포함 + `dnd` + `swipe`)

> 후속(비긴급): `_isDescendant`는 드래그(gestures)와 이동(select) 양쪽이 쓰는 순수 트리 헬퍼이므로, 본래 자리인 `bookmark-core.js`로 옮기는 정리를 다음 라운드(bookmark-select 분리)에서 함께 검토.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Minimal wiring fix plus a regression test; behavior is restoring an intended guard path, not new logic.
> 
> **Overview**
> Fixes a **runtime `ReferenceError`** when moving a **folder** (not just bookmarks) in bookmark select mode: after the gesture module split, `_isDescendant` lived in `bookmark-gestures.js` but was not exported, while `bookmark.js`’s `_moveSelectedToFolder` still called it for circular-drop checks.
> 
> **`_isDescendant`** is now exported from `bookmark-gestures.js` and imported in `bookmark.js` alongside the other gesture helpers.
> 
> Adds e2e **`test_move_folder_into_folder`**: select a folder, move it into another folder, assert the tree updates and **`pageerror` is empty**—covering the folder branch that bookmark-only move tests missed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b84494fa8f3a8c077275de21ddbeb134ce93acf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->