### PR TITLE
refactor: _isDescendant를 bookmark-core로 이전 (ADR-034 후속 정리)

### DIFF
--- a/docs/decisions/034-views-routing-second-split.md
+++ b/docs/decisions/034-views-routing-second-split.md
@@ -210,4 +210,8 @@ bookmark.js는 별도 후속 라운드(순수 로직 `bookmark-core.js` / UI `bo
 
 **검증서 배운 것 (중요).** 처음 tree.js에서 **import 8개를 통째로 누락**(`setRenderPathname`·`saveBookmarks`·`openSaveModal`·`openConfirmModal`·core 4종)했는데 **tsc·worker tsc 모두 통과** — checkJs가 미선언 식별자를 전역으로 묵인하는 사각지대(ADR-019 계열). **로드 스모크가 렌더 경로(`setRenderPathname`)를, 상호작용 e2e가 모달 경로(`openSaveModal` 등)를** 잡는다. 대상 모듈의 _전체_ export를 본문에 일괄 grep해 import을 도출해야 함. → `docs/known-issues.md` 추적, [[project_export_tsc_blindspot]].
 
-**테스트.** 마커 블록 없어 `bookmark.test.js` 무변경. 검증 tsc(main·worker)·유닛 728·로드 스모크(드로어+풀뷰 트리 렌더)·e2e 78통과(bookmark·edit·swipe·dnd·select-delete·add-help·export-import·copy + folders, 사전 실패 2건 제외). `_isDescendant`→core 정리는 향후 백로그로 남김.
+**테스트.** 마커 블록 없어 `bookmark.test.js` 무변경. 검증 tsc(main·worker)·유닛 728·로드 스모크(드로어+풀뷰 트리 렌더)·e2e 78통과(bookmark·edit·swipe·dnd·select-delete·add-help·export-import·copy + folders, 사전 실패 2건 제외).
+
+### 후속 정리 (2026-06-11): `_isDescendant` → bookmark-core
+
+순수 트리 술어 `_isDescendant`(폴더가 id를 하위에 품는지)를 `bookmark-gestures.js`의 DRAG_CORE 블록에서 본래 자리 `bookmark-core.js`의 BOOKMARK_QUERY 블록으로 이전. gestures(moveBookmarkItem)·select(_moveSelectedToFolder) 둘 다 쓰는 공유 헬퍼라 core가 맞는 집. gestures/select가 core에서 import, gestures export에서 제거. 테스트: QUERY 블록에 들어가 DRAG_CORE 로더(QUERY 선이어붙임)가 moveBookmarkItem 호출을 그대로 해결, `_isDescendant` 단위 테스트는 QUERY 로더로 이관. 검증 tsc·유닛 728·로드 스모크·e2e 8(folder-move 회귀·folder-exclude·dnd) 통과.

--- a/js/app/bookmark-core.js
+++ b/js/app/bookmark-core.js
@@ -26,6 +26,16 @@ const BOOKMARK_ADD_HELP =
 // to `loadBookmarks` (provided as a stub by the test loader prelude).
 // ── Bookmark query helpers ──
 
+// True when `id` is anywhere inside `folder`'s subtree. A pure tree predicate used
+// by drag-reorder (bookmark-gestures) and select-mode move (bookmark-select) to
+// reject dropping a folder into itself/its descendants. Lives here as core tree
+// logic (was in bookmark-gestures' DRAG_CORE block; moved ADR-034 후속).
+/** @param {BookmarkTreeFolder} folder @param {string} id @returns {boolean} */
+function _isDescendant(folder, id) {
+  return (folder.children || []).some((c) =>
+    c.id === id || (c.type === "folder" && _isDescendant(c, id)));
+}
+
 /**
  * @param {BookmarkTreeNode[]} store
  * @param {(item: BookmarkTreeNode, parent: BookmarkTreeNode[]) => unknown} fn
@@ -387,6 +397,7 @@ export {
   getBookmarkSort, setBookmarkSort, getBookmarkSortDir, setBookmarkSortDir,
   markBookmarkViewed, _forgetViewed,
   sortBookmarkNodes,
+  _isDescendant,
   _walkBookmarks, findExistingChapterBookmarks, _findItemInStore,
   _findParentFolderId, removeItemById, insertItem, collectFolderOptions,
   _selectAllState, _bmSelectCountLabel, _descendantIds,

--- a/js/app/bookmark-gestures.js
+++ b/js/app/bookmark-gestures.js
@@ -23,7 +23,7 @@
 
 const { loadBookmarks, saveBookmarks } = window.appStorage;
 
-import { _findItemInStore, getBookmarkSort } from "./bookmark-core.js";
+import { _findItemInStore, getBookmarkSort, _isDescendant } from "./bookmark-core.js";
 
 // ── Dependency injection ──
 // bookmark.js injects these at startup (initBookmarkGestures). Defaults are
@@ -42,12 +42,9 @@ function initBookmarkGestures(deps) {
 // `_findItemInStore` from there) and provides `loadBookmarks` /
 // `saveBookmarks` / `_rerenderTree` stubs in the prelude.
 // ── Drag & drop helpers ──
-
-/** @param {BookmarkTreeFolder} folder @param {string} id */
-function _isDescendant(folder, id) {
-  return (folder.children || []).some((c) =>
-    c.id === id || (c.type === "folder" && _isDescendant(c, id)));
-}
+// (_isDescendant moved to bookmark-core.js as a shared tree predicate, ADR-034 후속;
+// imported above. The DRAG_CORE test loader concatenates BOOKMARK_QUERY first, so
+// moveBookmarkItem's call still resolves in the vm slice.)
 
 /**
  * @param {string} draggedId
@@ -536,6 +533,6 @@ function _setupDragHandle(li, row) {
 
 export {
   initBookmarkGestures,
-  moveBookmarkItem, _setupDragHandle, _isMobileViewport, _isDescendant,
+  moveBookmarkItem, _setupDragHandle, _isMobileViewport,
   closeSwipedRow, resetSwipedRow, closeSwipedRowIfOutside,
 };

--- a/js/app/bookmark-select.js
+++ b/js/app/bookmark-select.js
@@ -28,9 +28,10 @@ const { loadBookmarks, saveBookmarks } = window.appStorage;
 import {
   _findItemInStore, _descendantIds, _selectAllState, _bmSelectCountLabel,
   _walkBookmarks, _forgetViewed, removeItemById, insertItem, _buildSharePayload,
+  _isDescendant,
 } from "./bookmark-core.js";
 import { openConfirmModal, openMoveModal } from "./bookmark-modals.js";
-import { closeSwipedRow, _isDescendant } from "./bookmark-gestures.js";
+import { closeSwipedRow } from "./bookmark-gestures.js";
 
 // ── Dependency injection ──
 // bookmark.js injects these at startup (initBookmarkSelect) so a delete/move can

--- a/tests/unit/bookmark.test.js
+++ b/tests/unit/bookmark.test.js
@@ -13,11 +13,11 @@
 //   - VERSE_SPEC block — verse spec parse / compare / serialize / merge
 //     (+ collapseFullVerseRefs, with a tiny `article.querySelectorAll`
 //     stub so the rendered-spans lookup resolves)
-//   - BOOKMARK_QUERY block — _walkBookmarks / findExistingChapterBookmarks
+//   - BOOKMARK_QUERY block — _isDescendant / _walkBookmarks / findExistingChapterBookmarks
 //     / _findItemInStore / _findParentFolderId / removeItemById / insertItem
 //     / collectFolderOptions. `loadBookmarks` provided as stub.
-//   - DRAG_CORE block (loaded after BOOKMARK_QUERY so `_findItemInStore`
-//     resolves) — _isDescendant / moveBookmarkItem.
+//   - DRAG_CORE block (loaded after BOOKMARK_QUERY so `_findItemInStore` and
+//     `_isDescendant` resolve) — moveBookmarkItem.
 //   - SWIPED_ROW block — closeSwipedRow / _openSwipedRow / resetSwipedRow
 //     / closeSwipedRowIfOutside, with a minimal Element stub.
 //   - BOOKMARK_HREF block — _bookmarkHref (pure URL builder).
@@ -165,6 +165,7 @@ function loadBookmarkQuery(initialStore = []) {
     insertItem: ctx.insertItem,
     collectFolderOptions: ctx.collectFolderOptions,
     _descendantIds: ctx._descendantIds,
+    _isDescendant: ctx._isDescendant,
   };
 }
 
@@ -229,7 +230,6 @@ function loadDragCore() {
     getStore: () => ctx._store,
     saveCalls,
     renderCalls,
-    _isDescendant: ctx._isDescendant,
     moveBookmarkItem: ctx.moveBookmarkItem,
     _findItemInStore: ctx._findItemInStore,
   };
@@ -878,7 +878,7 @@ test('_collectSelectedBookmarks: nothing selected → empty', () => {
 // ── _isDescendant ────────────────────────────────────────────────────────────
 
 test('_isDescendant: direct child detected', () => {
-  const h = loadDragCore();
+  const h = loadBookmarkQuery();
   const folder = {
     type: "folder", id: "f1", name: "F1",
     children: [{ type: "bookmark", id: "child-bm" }],
@@ -887,7 +887,7 @@ test('_isDescendant: direct child detected', () => {
 });
 
 test('_isDescendant: deeply nested descendant detected', () => {
-  const h = loadDragCore();
+  const h = loadBookmarkQuery();
   const folder = {
     type: "folder", id: "f1", name: "F1",
     children: [{
@@ -902,7 +902,7 @@ test('_isDescendant: deeply nested descendant detected', () => {
 });
 
 test('_isDescendant: id not present → false', () => {
-  const h = loadDragCore();
+  const h = loadBookmarkQuery();
   const folder = {
     type: "folder", id: "f1", name: "F1",
     children: [{ type: "bookmark", id: "child-bm" }],
@@ -911,7 +911,7 @@ test('_isDescendant: id not present → false', () => {
 });
 
 test('_isDescendant: empty children → false', () => {
-  const h = loadDragCore();
+  const h = loadBookmarkQuery();
   const folder = { type: "folder", id: "f1", name: "F1", children: [] };
   assert.equal(h._isDescendant(folder, "anything"), false);
 });


### PR DESCRIPTION
## 무엇을

순수 트리 술어 `_isDescendant`(폴더가 id를 하위에 품는지)를 `bookmark-gestures.js`의 DRAG_CORE 블록에서 본래 자리 `bookmark-core.js`의 BOOKMARK_QUERY 블록으로 이전. 분할 시리즈의 마지막 백로그 정리.

`_isDescendant`는 reorder 드래그(gestures `moveBookmarkItem`)와 선택-모드 이동(select `_moveSelectedToFolder`) **양쪽이 쓰는 공유 트리 헬퍼**라, DOM-free 로직 모듈인 core가 맞는 집이다. (#276에서 export 누락으로 한 번 깨졌던 그 함수 — 이제 제자리로.)

## 변경

- **core**: BOOKMARK_QUERY 블록에 `_isDescendant` 추가 + export.
- **gestures**: 정의 제거, core에서 import, export에서 제거.
- **select**: `_isDescendant` import를 gestures→core로 전환.
- **test**: QUERY 블록에 들어가므로 DRAG_CORE 로더(QUERY를 선이어붙임)가 `moveBookmarkItem`의 호출을 그대로 해결. `_isDescendant` 단위 테스트 4건은 의미에 맞게 QUERY 로더로 이관, DRAG_CORE 로더 반환에서 제거.

## 테스트

- ✅ tsc (main · worker)
- ✅ 유닛 728건 (`_isDescendant` QUERY 슬라이스 + `moveBookmarkItem` "폴더를 자기 하위로 드롭 거부"가 마커 슬라이싱 정상 동작 확인)
- ✅ 로드 스모크 (gestures·select가 core의 `_isDescendant` 런타임 해결)
- ✅ e2e 8건 (folder-move 회귀 + folder-exclude + dnd — `_isDescendant` 실행 경로)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor with no logic changes; folder-into-descendant guards still run via the same predicate from a shared module.
> 
> **Overview**
> ADR-034 후속 정리로 순수 트리 술어 **`_isDescendant`**(폴더 하위에 id가 있는지)를 `bookmark-gestures.js` DRAG_CORE에서 **`bookmark-core.js` BOOKMARK_QUERY**로 옮깁니다. 드래그 재정렬(`moveBookmarkItem`)과 선택 모드 이동(`_moveSelectedToFolder`)이 같이 쓰는 DOM-free 헬퍼라 core가 맞는 위치입니다.
> 
> `bookmark-gestures`·`bookmark-select`는 core에서 import하고, gestures export에서는 제거합니다. 유닛 테스트는 `_isDescendant` 4건을 **QUERY 슬라이스 로더**로 옮기고, DRAG_CORE는 QUERY를 앞에 이어붙이는 기존 방식으로 `moveBookmarkItem` 검증은 그대로 둡니다. ADR-034에 후속 정리 절을 추가합니다.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fe903ee44cf2a388b4eb343d6666d837a1d1873. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->