### PR TITLE
test: 북마크 e2e 커버리지 빈틈 보강 + tests/README.md 신설

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,137 @@
+# 테스트 안내
+
+이 저장소의 자동 시험은 **세 겹(+데이터 한 겹)** 으로 나뉩니다. 각 겹이 잡는 문제가 다르므로, "무엇이 어디서 검증되는가"를 여기 정리해 둡니다. 코드를 직접 읽지 않아도 어떤 시험이 무엇을 보장하는지 파악할 수 있도록 한 것입니다.
+
+> 권위 있는 "지금 무엇이 동작하는가"는 [`docs/status.md`](../docs/status.md), 결정 배경은 각 ADR([`docs/decisions/`](../docs/decisions/)) 참조.
+
+## 한눈에 보기
+
+| 겹 | 도구 | 무엇을 보나 | 어디서 도나 | 규모 |
+|---|---|---|---|---|
+| **유닛** | `node --test` (의존성 0) | 순수 로직 — 함수 입출력·상태 계산 | **CI 자동** (PR마다) | 19파일 · 728케이스 |
+| **타입 검사** | `tsc --noEmit` (`@ts-check`+JSDoc) | 타입 불일치·오타 | 로컬 훅 + 수동 | 설정 2종(앱·워커) |
+| **E2E** | Playwright (실제 브라우저) | 화면·상호작용·모듈 간 배선 | **로컬 전용**(수동) | 26파일 · 208케이스 |
+| **데이터** | pytest (`common-bible-data` 서브모듈) | 성경 본문·검색 인덱스 정합성 | 그 저장소 CI | 별도 저장소 |
+
+### 각 겹이 "혼자만 잡는" 것 — 왜 셋 다 필요한가
+
+- **유닛**: 정렬·절 범위 계산 같은 순수 로직의 정확성. 빠르고 CI 자동이지만 **화면·브라우저 동작은 못 본다**.
+- **타입 검사(tsc)**: JSDoc 타입 오류·오타. 단, **모듈에서 import을 빠뜨려도 통과**하는 사각지대가 있다(미선언 식별자를 전역으로 간주). 그래서 "tsc 통과 = 안전"이 아니다 — 자세한 사례는 [`docs/known-issues.md`](../docs/known-issues.md) 및 ADR-019 참조.
+- **E2E**: 위 사각지대(주입 콜백·모듈 간 import 누락)와 실제 클릭·내비게이션을 **유일하게 잡는 안전망**. 단 로컬에서 수동으로 돌려야 한다(CI 아님).
+
+---
+
+## 1. 유닛 테스트 — `tests/unit/`
+
+순수 JS 로직을 Node 자체 테스트 러너 + 자체 `vm` 하네스로 검증한다. 의존성 0, CI가 PR마다 자동 실행. 한 모듈 = 한 테스트 파일(`<소스이름>.test.js`). 상세 규약은 [ADR-013](../docs/decisions/013-client-js-unit-tests.md).
+
+```bash
+node --test tests/unit/*.test.js          # 전체 (CI와 동일)
+node --test tests/unit/storage.test.js    # 개별 파일
+```
+
+| 파일 | 검증 대상 | 케이스 |
+|---|---|---|
+| `bookmark.test.js` | 북마크 핵심 로직 — 절 스펙 파싱, 트리 질의(`_isDescendant` 등), 드래그 이동, 스와이프 제스처 수학, 선택 캐스케이드, 정렬 | 169 |
+| `storage.test.js` | 로컬 저장소 — 북마크 v1→v2 마이그레이션, 읽음 표시, 설정 영속화 | 99 |
+| `search.test.js` | 검색 파이프라인 — 토큰화, 절 검색, 결과 랭킹/필터 | 77 |
+| `views.test.js` | 본문 렌더 — 절 span, 운문/산문, 인용 마크업 | 54 |
+| `state-machine.test.js` | Drive 동기화 상태기계 — 전이·충돌·재시도 | 46 |
+| `install.test.js` | 설치 안내 — 플랫폼 분기, 넛지 타이밍 | 46 |
+| `helpers.test.js` | 공용 헬퍼 — DOM 빌더(`el`), 빈 상태, 단위 변환 | 42 |
+| `overlay.test.js` | 오버레이 컨트롤러(ADR-032) — 포커스 트랩, 닫기 스택 | 27 |
+| `parallels.test.js` | 평행 본문(인용·각주) 해석 | 26 |
+| `bookmark-read.test.js` | 폴더 모아 읽기(ADR-035) — 범위 해석, 연속 구절 병합 | 25 |
+| `transport.test.js` | 동기화 전송 계층 — 요청/응답·에러 매핑 | 25 |
+| `citations.test.js` | 인용 표시 — 참조 파싱, 시트 데이터 | 22 |
+| `audio-cache.test.js` | 오디오 캐시 — 장별 mp3 캐싱·정리 | 14 |
+| `manifest-sync.test.js` | 콘텐츠 해시 매니페스트 동기화(ADR-021) | 14 |
+| `refresh-store.test.js` | 백그라운드 새로고침 상태 | 13 |
+| `tabbar.test.js` | 모바일 탭 바 — 활성 표시·인디케이터 | 12 |
+| `tab-history.test.js` | 탭별 히스토리 복원(ADR-031) | 11 |
+| `sw.test.js` | 서비스 워커 `SHELL_FILES` 정적 검증 | 4 |
+| `csp.test.js` | `index.html` CSP 인라인 해시 일관성 | 2 |
+
+## 2. 타입 검사 — `tsc`
+
+순수 JS에 `// @ts-check` + JSDoc 주석으로 타입을 달고, `tsc --noEmit`으로 **출력 없이 타입만** 검사한다(ADR-012). "컴파일"이 아니라 타입 검사 용도. `tsc`는 TypeScript Compiler의 약자.
+
+```bash
+npx tsc -p tsconfig.json --noEmit          # 앱 코드
+npx tsc -p tsconfig.worker.json --noEmit   # 서비스 워커(다른 전역 환경)
+```
+
+- 잡는 것: 잘못된 타입 사용, 존재하지 않는 속성 접근, 함수 인자 불일치, 오타.
+- **사각지대**: 모듈에서 `import`을 통째로 빠뜨려도, 그 이름이 전역으로 선언돼 있으면 통과시킨다 → 런타임에서야 깨진다. 이 부류는 **로드 스모크/E2E로만** 잡힌다([`docs/known-issues.md`](../docs/known-issues.md)).
+
+## 3. E2E 테스트 — `tests/e2e/`
+
+실제 크롬(Playwright)을 띄워 화면 렌더·클릭·내비게이션·모듈 간 배선을 검증한다. **CI에서는 돌지 않으며**, 기능 개발 후 로컬에서 수동 확인한다.
+
+```bash
+# 1. 의존성(최초 1회)
+pip install pytest-playwright && playwright install chromium
+
+# 2. 개발 서버(별도 터미널) — SPA-aware 서버여야 History API 경로가 동작
+python3 scripts/serve.py 8080
+
+# 3. 실행
+pytest tests/e2e/ -v
+pytest tests/e2e/test_bookmark_sort.py -q   # 개별 파일
+```
+
+> 서버가 `http://localhost:8080`에 떠 있어야 한다. `conftest.py`의 `base_url`이 8080을 하드코딩하므로 다른 포트는 안 된다.
+
+### 북마크 (이 영역이 가장 촘촘하다 — 9개 파일)
+
+| 파일 | 검증 대상 | 케이스 |
+|---|---|---|
+| `test_bookmark.py` | 드로어 열기·장 저장·목록 갱신, **북마크 링크 클릭→내비+드로어 닫힘**, **트리 키보드 내비** | 8 |
+| `test_bookmark_export_import.py` | 내보내기/가져오기(JSON) — 다운로드·병합·덮어쓰기·오류 처리·드로어 ⋯ 패널 | 24 |
+| `test_bookmark_select_delete.py` | 선택 모드 — 진입·삭제·캐스케이드·공유·이동(폴더 포함) | 12 |
+| `test_bookmark_folders.py` | 폴더 CRUD — 생성·이름변경·삭제·펼침/접음 | 8 |
+| `test_bookmark_swipe.py` | 모바일 스와이프/롱프레스 — 삭제·수정 노출, 드래그 진입 | 8 |
+| `test_bookmark_dnd.py` | 드래그&드롭 재정렬 — before/after/into·순환 방지 | 6 |
+| `test_bookmark_add_help.py` | 전체뷰 🛈 안내 팝오버 — 위치·열고닫기·포커스 | 5 |
+| `test_bookmark_edit.py` | 항목 편집 — 레이블·메모·빈 레이블 거부 | 4 |
+| `test_bookmark_sort.py` | ⋯ 메뉴 정렬 — 기준(제목/날짜)+순서(오름/내림) 변경→재렌더 | 2 |
+| `test_bookmark_read.py` | 폴더 "모아 읽기" 버튼→`/read/<id>` 읽기 화면(ADR-035) | 1 |
+
+### 읽기·내비·검색·본문
+
+| 파일 | 검증 대상 | 케이스 |
+|---|---|---|
+| `test_search.py` | 검색 흐름 — 입력·결과·필터·딥링크 | 12 |
+| `test_navigation.py` | 절 단위 딥링크 URL 라우팅 | 5 |
+| `test_copy.py` | 절 선택→클립보드 복사 — 절 경계 확장·인용 포함 | 7 |
+| `test_cite_sheet.py` | 인용 바텀 시트 — 열기/닫기·Escape·포커스 | 4 |
+| `test_book_name_swap.py` | 책 이름 전체/짧은 명칭 뷰포트별 교체 | 7 |
+
+### 오디오·동기화·설정·셸
+
+| 파일 | 검증 대상 | 케이스 |
+|---|---|---|
+| `test_drive_sync.py` | Google Drive 동기화 — 연결·업로드·충돌 | 13 |
+| `test_drive_sync_ios.py` | iOS Drive 동기화(OAuth BFF 경유) | 8 |
+| `test_audio.py` / `test_audio_controls.py` | 오디오 플레이어 — 표시·해제·에러 / 재생·배속·seek·위치복원 | 6 / 6 |
+| `test_settings.py` | 설정 팝오버 — 시작화면·책순서·글자크기·테마·색상·캐시 | 13 |
+| `test_install_guide.py` | 설치 안내 모달 — 플랫폼별 콘텐츠·진입점 | 15 |
+| `test_tabbar.py` | 모바일 모핑 탭 바(ADR-029/030) | 11 |
+| `test_update_toast.py` | SW 업데이트 토스트 | 6 |
+
+### 접근성
+
+| 파일 | 검증 대상 | 케이스 |
+|---|---|---|
+| `test_a11y_axe.py` | axe-core 자동 스캔(WCAG 2.1 AA) | 7 |
+| `test_a11y_keyboard.py` | 키보드 인터랙션 | 7 |
+
+> **알려진 사전 실패**: `test_bookmark_folders.py`의 폴더 토글 2건 등 일부는 headless 환경 의존으로 실패한다(앱 버그 아님). 목록·원인은 [`docs/known-issues.md`](../docs/known-issues.md) §1.
+
+## 4. 데이터 파이프라인 테스트 (서브모듈)
+
+성경 본문(마크다운→JSON)과 검색 인덱스의 정합성 검증은 `common-bible-data` 저장소에 있다(ADR-004). 본 저장소 CI는 실행하지 않으며, 그 저장소의 `validate.yml`이 push마다 자동 실행한다. 로컬에서 보려면:
+
+```bash
+cd data && pytest tests/   # 서브모듈 디렉터리
+```

--- a/tests/e2e/test_bookmark.py
+++ b/tests/e2e/test_bookmark.py
@@ -197,3 +197,71 @@ def test_mobile_header_bookmark_when_absent_opens_save_modal(browser):
         assert page.locator("#bm-confirm-modal").is_hidden()
     finally:
         ctx.close()
+
+
+def test_drawer_bookmark_link_navigates_and_closes_drawer(browser):
+    """드로어에서 북마크 행을 누르면 그 장으로 이동하고 드로어가 닫힌다.
+
+    회귀 가드: tree.js 의 링크 클릭 핸들러가 주입된 closeBookmarkDrawer() + navigate()
+    + markBookmarkViewed/_bookmarkHref(core) 를 부르는 모듈 간 경로. 다른 e2e 는 링크의
+    *존재*만 확인하고 클릭→내비를 구동하지 않는다.
+    """
+    ctx = browser.new_context()
+    page = ctx.new_page()
+    page.add_init_script("localStorage.removeItem('bible-bookmarks');")
+    _open_chapter_and_wait(page, "gen/2")
+    # Seed a gen/1 whole-chapter bookmark (so the drawer lists it).
+    page.evaluate(
+        "() => window.syncStoreV2.saveBookmarks(["
+        "{type:'bookmark', id:'b1', bookId:'gen', chapter:1, label:'창세기 1장', verseSpec:'all'}"
+        "])"
+    )
+    page.locator(".title-bookmark-btn").click()
+    page.wait_for_selector("#bookmark-drawer:not([hidden])")
+
+    page.locator(".bm-bookmark-link", has_text="창세기 1장").click()
+
+    # Navigated to gen/1 and the drawer dismissed (the injected closeBookmarkDrawer).
+    page.wait_for_url("**/gen/1")
+    assert page.url.rstrip("/").endswith("/gen/1")
+    page.wait_for_selector("#bookmark-drawer[hidden]")
+    ctx.close()
+
+
+def test_drawer_tree_keyboard_navigation(browser):
+    """드로어 트리: ArrowRight 로 폴더 펼침, ArrowDown 으로 다음 treeitem 포커스 이동.
+
+    tree.js 의 드로어 body keydown 핸들러(roving tabindex)를 검증한다 — 어떤 e2e 도
+    트리 키보드 내비를 다루지 않았다. (펼침은 클릭이 아닌 _toggleFolder 직접 호출이라
+    headless 포인터 이슈와 무관하다.)
+    """
+    ctx = browser.new_context()
+    page = ctx.new_page()
+    page.add_init_script("localStorage.removeItem('bible-bookmarks');")
+    _open_chapter_and_wait(page, "gen/1")
+    # A collapsed folder (folders sort first) holding one child + a root bookmark.
+    page.evaluate(
+        "() => window.syncStoreV2.saveBookmarks(["
+        "{type:'folder', id:'f1', name:'폴더', expanded:false, children:["
+        "  {type:'bookmark', id:'c1', bookId:'exo', chapter:3, label:'자식', verseSpec:'all'}]},"
+        "{type:'bookmark', id:'b1', bookId:'gen', chapter:1, label:'뿌리', verseSpec:'all'}"
+        "])"
+    )
+    page.locator(".title-bookmark-btn").click()
+    page.wait_for_selector("#bookmark-drawer:not([hidden])")
+
+    folder = page.locator("li.bm-folder[data-id='f1']")
+    assert folder.get_attribute("aria-expanded") == "false"
+
+    # Focus the folder treeitem, then ArrowRight expands it.
+    folder.evaluate("el => el.focus()")
+    page.keyboard.press("ArrowRight")
+    assert folder.get_attribute("aria-expanded") == "true"
+
+    # ArrowDown moves the roving focus to the next visible treeitem (the child).
+    page.keyboard.press("ArrowDown")
+    focused_id = page.evaluate(
+        "() => document.activeElement?.closest('[role=treeitem]')?.dataset.id"
+    )
+    assert focused_id == "c1"
+    ctx.close()

--- a/tests/e2e/test_bookmark_read.py
+++ b/tests/e2e/test_bookmark_read.py
@@ -1,0 +1,47 @@
+"""E2E: 폴더 "모아 읽기" 버튼 → /read/<folderId> 읽기 화면 (ADR-035).
+
+폴더 행의 모아 읽기 버튼(.bm-folder-read-btn)을 누르면 그 폴더의 북마크 성경
+본문을 한 화면에 모은 읽기 뷰(bookmark-read.js)로 이동한다. 트리(bookmark-tree)→
+navigate→라우팅→bookmark-read 렌더까지의 모듈 간 경로를 검증한다 — 이 버튼 클릭과
+읽기 뷰 렌더는 다른 어떤 e2e 도 다루지 않던 경로다.
+"""
+import json
+
+BASE = "http://localhost:8080"
+
+_FOLDER = {
+    "type": "folder", "id": "folder-1", "name": "묶음", "expanded": True,
+    "children": [
+        {"type": "bookmark", "id": "bm-gen1", "bookId": "gen", "chapter": 1,
+         "label": "창세기 1장", "verseSpec": "all"},
+    ],
+}
+
+
+def _open_chapter(page, path="gen/2"):
+    page.goto(f"{BASE}/{path}")
+    page.wait_for_selector("article.chapter-text .verse")
+    page.wait_for_timeout(200)
+
+
+def test_folder_read_button_opens_reading_view(browser):
+    """폴더 모아 읽기 버튼 → /read/folder-1 로 이동, 읽기 뷰에 본문이 모인다."""
+    ctx = browser.new_context()
+    page = ctx.new_page()
+    page.add_init_script("localStorage.removeItem('bible-bookmarks');")
+    _open_chapter(page, "gen/2")
+    page.evaluate(f"() => window.syncStoreV2.saveBookmarks({json.dumps([_FOLDER])})")
+
+    page.locator(".title-bookmark-btn").click()
+    page.wait_for_selector("#bookmark-drawer:not([hidden])")
+
+    page.locator("li.bm-folder[data-id='folder-1'] .bm-folder-read-btn").click()
+
+    # Navigated to the collected-read route and rendered the read panel.
+    page.wait_for_url("**/read/folder-1")
+    page.wait_for_selector(".bookmark-read", timeout=5_000)
+    # The folder's bookmark (창세기 1장) scripture is gathered into the view.
+    assert page.locator(".bookmark-read .verse").count() > 0
+    # The drawer closed on navigation.
+    assert page.locator("#bookmark-drawer[hidden]").count() == 1
+    ctx.close()

--- a/tests/e2e/test_bookmark_sort.py
+++ b/tests/e2e/test_bookmark_sort.py
@@ -1,0 +1,81 @@
+"""E2E: 북마크 전체뷰 ⋯ 메뉴의 정렬 — 기준(제목/날짜) + 순서(오름/내림).
+
+전체뷰(buildBmViewActions)는 모바일 전용이므로 mobile_context 픽스처를 쓴다.
+정렬 기준/순서를 고르면 bookmark-menu.js 가 bookmark-core 의 setBookmarkSort /
+setBookmarkSortDir 를 호출하고 주입된 재렌더 훅으로 트리를 다시 그린다 — 이 UI→코어→
+재렌더 배선을 검증한다(유닛은 정렬 *로직*만 다루고 메뉴 배선은 안 다룬다).
+"""
+import json
+
+BASE = "http://localhost:8080"
+
+_MORE_BTN = ".title-action-btn[aria-label='더 보기']"
+
+# On the iPhone UA the install nudge auto-opens after ~1.5s; pin neverShow.
+_PIN_NUDGE = (
+    "localStorage.setItem('bible-install-nudge',"
+    " JSON.stringify({visits: 0, nextShow: 9999, neverShow: true}));"
+)
+
+# Two root bookmarks whose insertion ("manual") order is the REVERSE of their
+# title (가나다) order, so a sort change visibly flips the first row.
+#   manual order : 하늘, 가나   →   title asc : 가나, 하늘
+_STORE = [
+    {"type": "bookmark", "id": "b-ha", "bookId": "gen", "chapter": 1,
+     "label": "하늘", "verseSpec": "all", "createdAt": 1000},
+    {"type": "bookmark", "id": "b-ga", "bookId": "gen", "chapter": 2,
+     "label": "가나", "verseSpec": "all", "createdAt": 2000},
+]
+
+
+def _seed(mobile_context):
+    mobile_context.add_init_script(_PIN_NUDGE)
+    page = mobile_context.new_page()
+    page.goto(f"{BASE}/bookmarks")
+    page.wait_for_selector("#bookmarks-view-tree", timeout=5_000)
+    page.evaluate(f"() => window.syncStoreV2.saveBookmarks({json.dumps(_STORE)})")
+    page.evaluate("() => window.rerenderActiveBookmarkTree()")
+    return page
+
+
+def _first_label(page):
+    return page.locator("#bookmarks-view-tree .bm-bookmark-link").first.inner_text()
+
+
+def _open_menu(page):
+    page.locator(_MORE_BTN).click()
+    page.wait_for_selector(".title-action-menu:not([hidden])")
+
+
+def test_sort_by_title_reorders_tree(mobile_context):
+    """⋯ → 정렬 '제목' 을 고르면 트리가 가나다순으로 다시 그려진다."""
+    page = _seed(mobile_context)
+    # Default "manual" = insertion order, so 하늘 (inserted first) leads.
+    assert "하늘" in _first_label(page)
+
+    _open_menu(page)
+    page.get_by_role("menuitemradio", name="제목", exact=True).click()
+    page.wait_for_selector(".title-action-menu", state="hidden")
+
+    # Title ascending (가나다) → 가나 now leads.
+    assert "가나" in _first_label(page)
+    # Preference persisted per device.
+    assert page.evaluate("() => localStorage.getItem('bible-bookmark-sort')") == "title"
+
+
+def test_sort_direction_descending_reverses(mobile_context):
+    """제목 정렬 상태에서 '내림차순' 을 고르면 ㅎ→ㄱ 으로 뒤집힌다."""
+    page = _seed(mobile_context)
+    _open_menu(page)
+    page.get_by_role("menuitemradio", name="제목", exact=True).click()
+    page.wait_for_selector(".title-action-menu", state="hidden")
+    assert "가나" in _first_label(page)  # asc
+
+    _open_menu(page)
+    # The 오름/내림 rows gain a field-specific clarifier note once a key-sort is
+    # active (제목 → "ㅎ→ㄱ"), so the accessible name is no longer exactly "내림차순".
+    page.get_by_role("menuitemradio", name="내림차순").click()
+    page.wait_for_selector(".title-action-menu", state="hidden")
+
+    # Title descending → 하늘 leads again.
+    assert "하늘" in _first_label(page)


### PR DESCRIPTION
## 배경

ADR-034 북마크 분할 완료 후 **e2e 커버리지 감사**에서, tsc가 못 잡는(미선언 식별자를 전역으로 묵인) **모듈 간 import·주입 콜백 경로** 중 e2e가 없던 곳을 발견했다. 이번 분할에서 그 배선이 깨졌어도 어떤 e2e도 못 잡았을 위험 지점들이다.

## 1. e2e 빈틈 4종 보강

| 경로 | 모듈 간 결합 | 신규 테스트 |
|---|---|---|
| 드로어 북마크 링크 클릭 → 내비+드로어 닫힘 | tree → **주입 `closeBookmarkDrawer`** + `navigate`·`markBookmarkViewed`·`_bookmarkHref` | `test_bookmark.py::test_drawer_bookmark_link_navigates_and_closes_drawer` |
| 트리 키보드 내비(ArrowRight 펼침·ArrowDown 포커스) | tree.js keydown(roving tabindex) | `test_bookmark.py::test_drawer_tree_keyboard_navigation` |
| ⋯ 메뉴 정렬(제목·내림차순) → 재렌더 | menu → core `setBookmarkSort`/`setBookmarkSortDir` + **주입 rerender** | `test_bookmark_sort.py` (2건) |
| 폴더 "모아 읽기" → `/read` 화면 | tree → navigate → bookmark-read(ADR-035) | `test_bookmark_read.py` (1건) |

신규 파일 2개 + `test_bookmark.py` 2건. 서버 8080 기준 **5건 전부 통과**, test_bookmark.py 전체 8건 회귀 없음.

## 2. `tests/README.md` 신설

비개발자도 코드 없이 "무엇이 어디서 검증되는가"를 파악하도록:
- 네 겹(유닛 `node --test` · 타입검사 `tsc` · E2E Playwright · 데이터 파이프라인)의 **역할 차이·실행법·CI 여부**
- 유닛 19파일 · e2e 26파일 각각의 **검증 대상 일람**
- **tsc가 import 누락을 못 잡는 사각지대** 명시 — E2E가 안전망인 이유

## 검증

- ✅ 신규 e2e 5건 (sort 2 · read 1 · 링크내비 1 · 키보드 1)
- ✅ `test_bookmark.py` 8건 (기존 6 + 신규 2)
- 유닛/소스 무변경 → tsc·유닛 영향 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and local-only E2E additions; no runtime or CI unit/tsc behavior changes.
> 
> **Overview**
> Adds **`tests/README.md`** so reviewers can see how unit, `tsc`, E2E, and submodule data tests differ, how to run them, and why E2E is the safety net for missing imports/injected callbacks that `tsc` can miss.
> 
> **E2E bookmark coverage** grows by five Playwright cases (no app/source changes): in `test_bookmark.py`, drawer bookmark link click → navigate + drawer close, and tree keyboard nav (ArrowRight expand, ArrowDown roving focus); new `test_bookmark_sort.py` (mobile ⋯ menu title sort + descending reorder + `localStorage` persistence); new `test_bookmark_read.py` (folder “모아 읽기” → `/read/<id>` with scripture rendered and drawer closed). The README tables are updated to reflect the new files and case counts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 957a0e47708bbf1ed004c1c1fb04f2e30be0df26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->