### PR TITLE
test: e2e 헤드리스 견고성 보강 — 대기·SW·설치 너지·앱 동작 맞춤

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -28,6 +28,13 @@ CLEAR_APP_STORAGE = """
     'bible-bookmarks-v2', 'bible-sync-meta',
   ];
   for (const k of keys) try { localStorage.removeItem(k); } catch(_) {}
+  // Suppress the install-promo nudge: its default state ({visits:0, nextShow:1})
+  // fires on the very first visit (visits→1, 1<1 is false), so the #install-scrim
+  // overlay covers the tab bar and intercepts clicks in every fresh context —
+  // failing the tab-bar tests for a reason unrelated to what they assert. Persist
+  // a neverShow state (the real "다시 보지 않기" path) so maybeShowInstallNudge
+  // returns early.
+  try { localStorage.setItem('bible-install-nudge', JSON.stringify({ visits: 0, nextShow: 9999, neverShow: true })); } catch(_) {}
 })();
 """
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -56,8 +56,14 @@ def mobile_context(browser):
 
 
 def wait_app_ready(page) -> None:
-    """Block until the SPA shell has rendered at least one child element."""
-    page.wait_for_selector("#search-input")
+    """Block until the SPA shell has rendered at least one child element.
+
+    Wait for ``#search-input`` *attached* (in DOM), not *visible*: on mobile the
+    header ``#breadcrumb-row`` (which contains the search bar) is ``display:none``
+    by design — search lives in the bottom tab dock instead — so the default
+    ``visible`` state never resolves and every mobile test would time out.
+    """
+    page.wait_for_selector("#search-input", state="attached")
     page.wait_for_function(
         "() => !!document.getElementById('app') && "
         "document.getElementById('app').children.length > 0"

--- a/tests/e2e/test_bookmark.py
+++ b/tests/e2e/test_bookmark.py
@@ -6,14 +6,6 @@ from .conftest import CLEAR_APP_STORAGE, MOBILE_VIEWPORT, IPHONE_UA
 
 BASE = "http://localhost:8080"
 
-# On the iPhone UA the install nudge auto-opens after ~1.5s; its scrim then
-# intercepts header taps and races these tests. Pin neverShow so the nudge
-# stays down. CLEAR_APP_STORAGE removes the key, so this must run after it.
-SUPPRESS_INSTALL_NUDGE = (
-    "localStorage.setItem('bible-install-nudge',"
-    " JSON.stringify({visits: 0, nextShow: 9999, neverShow: true}));"
-)
-
 
 def _open_chapter_and_wait(page, path: str) -> None:
     page.goto(f"{BASE}/{path}")
@@ -188,7 +180,6 @@ def test_mobile_header_bookmark_when_absent_opens_save_modal(browser):
     """모바일: 북마크가 없는 장에서는 헤더 아이콘이 저장 모달을 연다(토글 add)."""
     ctx = browser.new_context(viewport=MOBILE_VIEWPORT, user_agent=IPHONE_UA)
     ctx.add_init_script(CLEAR_APP_STORAGE)
-    ctx.add_init_script(SUPPRESS_INSTALL_NUDGE)
     page = ctx.new_page()
     try:
         _open_chapter_and_wait(page, "gen/1")

--- a/tests/e2e/test_bookmark_add_help.py
+++ b/tests/e2e/test_bookmark_add_help.py
@@ -25,17 +25,9 @@ _MENU = ".title-action-menu"
 _BM_ROOT = {"type": "bookmark", "id": "bm-root", "bookId": "gen", "chapter": 1,
             "label": "창세기 1장", "verseSpec": "all"}
 
-# On the iPhone UA the install nudge auto-opens after ~1.5s; its scrim then
-# intercepts taps and races these tests. Pin neverShow so the nudge never fires.
-_PIN_NUDGE = (
-    "localStorage.setItem('bible-install-nudge',"
-    " JSON.stringify({visits: 0, nextShow: 9999, neverShow: true}));"
-)
-
 
 def _seed(mobile_context):
     """Open the mobile /bookmarks full view with one bookmark already saved."""
-    mobile_context.add_init_script(_PIN_NUDGE)
     page = mobile_context.new_page()
     page.goto(f"{BASE}/bookmarks")
     page.wait_for_selector("#bookmarks-view-tree", timeout=5_000)
@@ -46,7 +38,6 @@ def _seed(mobile_context):
 
 def test_info_button_hidden_when_empty(mobile_context):
     """빈 목록에선 🛈 가 숨는다 — 빈 상태 안내가 이미 추가 방법을 보여주므로 중복."""
-    mobile_context.add_init_script(_PIN_NUDGE)
     page = mobile_context.new_page()
     page.goto(f"{BASE}/bookmarks")
     page.wait_for_selector("#bookmarks-view-tree", timeout=5_000)

--- a/tests/e2e/test_bookmark_folders.py
+++ b/tests/e2e/test_bookmark_folders.py
@@ -111,11 +111,15 @@ def test_folder_toggle_expand_collapse(browser):
         folder_li = page.locator("li.bm-folder[data-id='folder-1']")
         assert folder_li.get_attribute("aria-expanded") == "false"
 
-        page.locator("li.bm-folder[data-id='folder-1'] .bm-folder-row").click()
+        # 폴더명을 클릭한다. .bm-folder-row 의 기하학적 중심엔 액션 버튼
+        # (.bm-action-btn)이 깔려 있어 Playwright 의 center-click 이 버튼에
+        # 맞아 토글 핸들러의 early-return 에 걸린다(실사용자도 그 자리는 토글
+        # 안 됨). 토글 영역인 폴더명을 클릭해야 펼침/접음이 일어난다.
+        page.locator("li.bm-folder[data-id='folder-1'] .bm-folder-name").click()
         page.wait_for_timeout(100)
         assert folder_li.get_attribute("aria-expanded") == "true"
 
-        page.locator("li.bm-folder[data-id='folder-1'] .bm-folder-row").click()
+        page.locator("li.bm-folder[data-id='folder-1'] .bm-folder-name").click()
         page.wait_for_timeout(100)
         assert folder_li.get_attribute("aria-expanded") == "false"
     finally:
@@ -158,7 +162,8 @@ def test_folder_expanded_state_persists(browser):
         assert page.locator("li.bm-folder[data-id='folder-1']").get_attribute("aria-expanded") == "false"
 
         # 클릭으로 펼침
-        page.locator("li.bm-folder[data-id='folder-1'] .bm-folder-row").click()
+        # 폴더명 클릭 = 토글(행 중심의 액션 버튼을 피한다 — 위 토글 테스트 참조).
+        page.locator("li.bm-folder[data-id='folder-1'] .bm-folder-name").click()
         page.wait_for_timeout(200)
         assert page.locator("li.bm-folder[data-id='folder-1']").get_attribute("aria-expanded") == "true"
 

--- a/tests/e2e/test_bookmark_select_delete.py
+++ b/tests/e2e/test_bookmark_select_delete.py
@@ -15,12 +15,7 @@ from .conftest import CLEAR_APP_STORAGE, MOBILE_VIEWPORT, IPHONE_UA
 BASE = "http://localhost:8080"
 
 # The full /bookmarks view (renderBookmarksView → #bookmarks-view-tree) and select
-# mode are mobile only, so these tests need a mobile viewport. On the iPhone UA the
-# install nudge auto-opens after ~1.5s and its scrim intercepts taps; pin neverShow.
-_PIN_NUDGE = (
-    "localStorage.setItem('bible-install-nudge',"
-    " JSON.stringify({visits: 0, nextShow: 9999, neverShow: true}));"
-)
+# mode are mobile only, so these tests need a mobile viewport.
 
 _BM_ROOT = {"type": "bookmark", "id": "bm-root", "bookId": "gen", "chapter": 1,
             "label": "창세기 1장", "verseSpec": "all"}
@@ -61,7 +56,6 @@ def test_enter_select_mode_swaps_chrome(browser):
     """삭제 진입 → body.bm-select-active, 하단 바 노출, 제목줄이 전체 선택 토글로 교체."""
     ctx = browser.new_context(viewport=MOBILE_VIEWPORT, user_agent=IPHONE_UA)
     ctx.add_init_script(CLEAR_APP_STORAGE)
-    ctx.add_init_script(_PIN_NUDGE)
     page = ctx.new_page()
     try:
         _open_bookmarks_view(page)
@@ -85,7 +79,6 @@ def test_select_one_bookmark_and_delete(browser):
     """행을 눌러 선택 → 하단 삭제 → 확인 → 그 북마크만 사라지고 모드 종료."""
     ctx = browser.new_context(viewport=MOBILE_VIEWPORT, user_agent=IPHONE_UA)
     ctx.add_init_script(CLEAR_APP_STORAGE)
-    ctx.add_init_script(_PIN_NUDGE)
     page = ctx.new_page()
     try:
         _open_bookmarks_view(page)
@@ -115,7 +108,6 @@ def test_folder_tick_cascades_and_deletes_subtree(browser):
     """폴더를 누르면 안의 북마크가 covered 로 표시되고, 삭제 시 함께 사라진다."""
     ctx = browser.new_context(viewport=MOBILE_VIEWPORT, user_agent=IPHONE_UA)
     ctx.add_init_script(CLEAR_APP_STORAGE)
-    ctx.add_init_script(_PIN_NUDGE)
     page = ctx.new_page()
     try:
         _open_bookmarks_view(page)
@@ -146,7 +138,6 @@ def test_select_all_then_delete_empties(browser):
     """전체 선택 토글 → 모든 행 표시 → 삭제하면 목록이 빈다."""
     ctx = browser.new_context(viewport=MOBILE_VIEWPORT, user_agent=IPHONE_UA)
     ctx.add_init_script(CLEAR_APP_STORAGE)
-    ctx.add_init_script(_PIN_NUDGE)
     page = ctx.new_page()
     try:
         _open_bookmarks_view(page)
@@ -173,7 +164,6 @@ def test_cancel_exits_without_deleting(browser):
     """취소(✕) 는 선택을 버리고 모드를 빠져나오며 아무것도 지우지 않는다."""
     ctx = browser.new_context(viewport=MOBILE_VIEWPORT, user_agent=IPHONE_UA)
     ctx.add_init_script(CLEAR_APP_STORAGE)
-    ctx.add_init_script(_PIN_NUDGE)
     page = ctx.new_page()
     try:
         _open_bookmarks_view(page)
@@ -197,7 +187,6 @@ def test_confirm_cancel_keeps_store_and_stays_in_mode(browser):
     """확인 알림에서 취소하면 삭제되지 않고 선택 모드는 유지된다."""
     ctx = browser.new_context(viewport=MOBILE_VIEWPORT, user_agent=IPHONE_UA)
     ctx.add_init_script(CLEAR_APP_STORAGE)
-    ctx.add_init_script(_PIN_NUDGE)
     page = ctx.new_page()
     try:
         _open_bookmarks_view(page)
@@ -222,7 +211,6 @@ def test_select_item_disabled_when_empty(browser):
     """목록이 비어 있으면 ⋯ 메뉴의 선택 항목이 비활성된다."""
     ctx = browser.new_context(viewport=MOBILE_VIEWPORT, user_agent=IPHONE_UA)
     ctx.add_init_script(CLEAR_APP_STORAGE)
-    ctx.add_init_script(_PIN_NUDGE)
     page = ctx.new_page()
     try:
         _open_bookmarks_view(page)
@@ -238,7 +226,6 @@ def test_share_invokes_native_share_with_links(browser):
     """공유 → navigator.share 가 bible.anglican.kr 링크 payload 로 호출된다."""
     ctx = browser.new_context(viewport=MOBILE_VIEWPORT, user_agent=IPHONE_UA)
     ctx.add_init_script(CLEAR_APP_STORAGE)
-    ctx.add_init_script(_PIN_NUDGE)
     # Stub navigator.share to capture the payload (headless has no share sheet).
     ctx.add_init_script(
         "navigator.share = (data) => { window.__shared = data; return Promise.resolve(); };"
@@ -265,7 +252,6 @@ def test_move_into_folder(browser):
     """이동 → 폴더 목록 모달에서 폴더를 탭하면 선택 항목이 그 폴더로 이동한다."""
     ctx = browser.new_context(viewport=MOBILE_VIEWPORT, user_agent=IPHONE_UA)
     ctx.add_init_script(CLEAR_APP_STORAGE)
-    ctx.add_init_script(_PIN_NUDGE)
     page = ctx.new_page()
     try:
         _open_bookmarks_view(page)
@@ -301,7 +287,6 @@ def test_move_folder_into_folder(browser):
     """
     ctx = browser.new_context(viewport=MOBILE_VIEWPORT, user_agent=IPHONE_UA)
     ctx.add_init_script(CLEAR_APP_STORAGE)
-    ctx.add_init_script(_PIN_NUDGE)
     page = ctx.new_page()
     errors = []
     page.on("pageerror", lambda e: errors.append(str(e)))
@@ -341,7 +326,6 @@ def test_move_new_folder_with_parent(browser):
     """이동 → 새 폴더: 상위 폴더(대림시기)를 지정해 만든 폴더로 선택 항목이 이동한다."""
     ctx = browser.new_context(viewport=MOBILE_VIEWPORT, user_agent=IPHONE_UA)
     ctx.add_init_script(CLEAR_APP_STORAGE)
-    ctx.add_init_script(_PIN_NUDGE)
     page = ctx.new_page()
     try:
         _open_bookmarks_view(page)
@@ -381,7 +365,6 @@ def test_move_new_folder_excludes_selected_parent(browser):
     """
     ctx = browser.new_context(viewport=MOBILE_VIEWPORT, user_agent=IPHONE_UA)
     ctx.add_init_script(CLEAR_APP_STORAGE)
-    ctx.add_init_script(_PIN_NUDGE)
     page = ctx.new_page()
     try:
         _open_bookmarks_view(page)

--- a/tests/e2e/test_bookmark_sort.py
+++ b/tests/e2e/test_bookmark_sort.py
@@ -11,11 +11,6 @@ BASE = "http://localhost:8080"
 
 _MORE_BTN = ".title-action-btn[aria-label='더 보기']"
 
-# On the iPhone UA the install nudge auto-opens after ~1.5s; pin neverShow.
-_PIN_NUDGE = (
-    "localStorage.setItem('bible-install-nudge',"
-    " JSON.stringify({visits: 0, nextShow: 9999, neverShow: true}));"
-)
 
 # Two root bookmarks whose insertion ("manual") order is the REVERSE of their
 # title (가나다) order, so a sort change visibly flips the first row.
@@ -29,7 +24,6 @@ _STORE = [
 
 
 def _seed(mobile_context):
-    mobile_context.add_init_script(_PIN_NUDGE)
     page = mobile_context.new_page()
     page.goto(f"{BASE}/bookmarks")
     page.wait_for_selector("#bookmarks-view-tree", timeout=5_000)

--- a/tests/e2e/test_bookmark_swipe.py
+++ b/tests/e2e/test_bookmark_swipe.py
@@ -20,12 +20,6 @@ _BM_A = {"type": "bookmark", "id": "bm-a", "bookId": "gen", "chapter": 1,
 _BM_B = {"type": "bookmark", "id": "bm-b", "bookId": "john", "chapter": 3,
           "label": "요한 3장", "verseSpec": "all"}
 
-# iPhone UA auto-opens the install nudge ~1.5s in; its scrim then intercepts taps
-# in the longer (click-through) tests. Pin neverShow so it never fires.
-_PIN_NUDGE = (
-    "localStorage.setItem('bible-install-nudge',"
-    " JSON.stringify({visits: 0, nextShow: 9999, neverShow: true}));"
-)
 
 _SWIPE_JS = """(args) => {
     const rows = document.querySelectorAll('li.bm-bookmark .bm-bookmark-row');
@@ -106,7 +100,6 @@ def test_swipe_left_reveals_delete(browser):
     오른쪽(leading) = 수정(좌측 가장자리)."""
     ctx = browser.new_context(viewport=MOBILE_VIEWPORT, user_agent=IPHONE_UA)
     ctx.add_init_script(CLEAR_APP_STORAGE)
-    ctx.add_init_script(_PIN_NUDGE)
     page = ctx.new_page()
     try:
         _open_drawer(page, [_BM_A])
@@ -121,7 +114,6 @@ def test_swipe_right_reveals_edit(browser):
     """오른쪽으로 스와이프하면 수정 액션이 노출된다 (leading edge)."""
     ctx = browser.new_context(viewport=MOBILE_VIEWPORT, user_agent=IPHONE_UA)
     ctx.add_init_script(CLEAR_APP_STORAGE)
-    ctx.add_init_script(_PIN_NUDGE)
     page = ctx.new_page()
     try:
         _open_drawer(page, [_BM_A])
@@ -136,7 +128,6 @@ def test_swipe_other_row_closes_previous(browser):
     """두 번째 행을 스와이프하면 첫 번째 행의 액션이 자동으로 닫힌다."""
     ctx = browser.new_context(viewport=MOBILE_VIEWPORT, user_agent=IPHONE_UA)
     ctx.add_init_script(CLEAR_APP_STORAGE)
-    ctx.add_init_script(_PIN_NUDGE)
     page = ctx.new_page()
     try:
         _open_drawer(page, [_BM_A, _BM_B])
@@ -153,7 +144,6 @@ def test_longpress_starts_drag(browser):
     """500ms 이상 롱프레스하면 드래그-재정렬 모드가 시작된다 (액션 패널이 아님)."""
     ctx = browser.new_context(viewport=MOBILE_VIEWPORT, user_agent=IPHONE_UA)
     ctx.add_init_script(CLEAR_APP_STORAGE)
-    ctx.add_init_script(_PIN_NUDGE)
     page = ctx.new_page()
     try:
         _open_drawer(page, [_BM_A])
@@ -174,7 +164,6 @@ def test_short_press_does_not_start_drag(browser):
     """짧은 press(<500ms)는 드래그를 시작하지 않고 액션 패널도 열리지 않는다."""
     ctx = browser.new_context(viewport=MOBILE_VIEWPORT, user_agent=IPHONE_UA)
     ctx.add_init_script(CLEAR_APP_STORAGE)
-    ctx.add_init_script(_PIN_NUDGE)
     page = ctx.new_page()
     try:
         _open_drawer(page, [_BM_A])
@@ -190,7 +179,6 @@ def test_swipe_no_effect_on_desktop(browser):
     """데스크톱 viewport(>768px)에서는 canSwipe=false이므로 스와이프가 동작하지 않는다."""
     ctx = browser.new_context(viewport={"width": 1280, "height": 800})
     ctx.add_init_script(CLEAR_APP_STORAGE)
-    ctx.add_init_script(_PIN_NUDGE)
     page = ctx.new_page()
     try:
         _open_drawer(page, [_BM_A])
@@ -209,7 +197,6 @@ def test_delete_via_swipe(browser):
     수정 회귀."""
     ctx = browser.new_context(viewport=MOBILE_VIEWPORT, user_agent=IPHONE_UA)
     ctx.add_init_script(CLEAR_APP_STORAGE)
-    ctx.add_init_script(_PIN_NUDGE)
     page = ctx.new_page()
     try:
         _open_drawer(page, [_BM_A])
@@ -242,7 +229,6 @@ def test_cancel_delete_confirm_closes_swipe(browser):
     즉시 닫는다."""
     ctx = browser.new_context(viewport=MOBILE_VIEWPORT, user_agent=IPHONE_UA)
     ctx.add_init_script(CLEAR_APP_STORAGE)
-    ctx.add_init_script(_PIN_NUDGE)
     page = ctx.new_page()
     try:
         _open_drawer(page, [_BM_A])

--- a/tests/e2e/test_settings.py
+++ b/tests/e2e/test_settings.py
@@ -70,8 +70,14 @@ def test_book_order_vulgate(browser):
         # 기본값은 canonical(OFF); 켜면 vulgate.
         assert sw.is_checked() is False
         sw.click()
-        page.wait_for_timeout(100)
-        assert _ls(page, "bible-book-order") == "vulgate"
+        # 책 순서 변경은 목록 뷰를 다시 그린다(route()) → 설정 팝오버가 닫힌다.
+        # 따라서 토글 직후 같은 스위치를 다시 보지 말고, 영속값을 확인한 뒤
+        # 설정을 다시 열어 반영 상태(체크 + 캡션)를 검증한다.
+        page.wait_for_function(
+            "() => localStorage.getItem('bible-book-order') === 'vulgate'"
+        )
+        pop = open_settings(page)
+        sw = pop.get_by_role("switch", name="외경")
         assert sw.is_checked() is True
         assert pop.locator(".settings-toggle-caption").first.inner_text() == "구약에 포함"
     finally:
@@ -86,11 +92,17 @@ def test_book_order_canonical(browser):
     try:
         _open(page)
         pop = open_settings(page)
+        pop.get_by_role("switch", name="외경").click()  # → vulgate (route() 로 팝오버 닫힘)
+        page.wait_for_function(
+            "() => localStorage.getItem('bible-book-order') === 'vulgate'"
+        )
+        pop = open_settings(page)
+        pop.get_by_role("switch", name="외경").click()  # → canonical (다시 팝오버 닫힘)
+        page.wait_for_function(
+            "() => localStorage.getItem('bible-book-order') === 'canonical'"
+        )
+        pop = open_settings(page)
         sw = pop.get_by_role("switch", name="외경")
-        sw.click()  # → vulgate
-        sw.click()  # → canonical
-        page.wait_for_timeout(100)
-        assert _ls(page, "bible-book-order") == "canonical"
         assert sw.is_checked() is False
         assert pop.locator(".settings-toggle-caption").first.inner_text() == "별도 섹션에 표시"
     finally:

--- a/tests/e2e/test_settings.py
+++ b/tests/e2e/test_settings.py
@@ -218,8 +218,10 @@ def test_cache_clear_removes_caches(browser):
     """캐시 비우기 버튼 클릭 → clearAllCaches()가 실행되어 심어둔 캐시를 삭제한다.
 
     service_workers="block"으로 SW 간섭을 차단해 캐시 상태를 안정적으로 검증한다.
+    (블록하지 않으면 clearAllCaches 내부의 reg.unregister()가 headless chromium
+    에서 resolve 되지 않아 location.reload()까지 못 가고 테스트가 멈춘다.)
     """
-    ctx = browser.new_context()
+    ctx = browser.new_context(service_workers="block")
     ctx.add_init_script(CLEAR_APP_STORAGE)
     ctx.add_init_script("window.confirm = () => true;")  # bypass clearAllCaches confirm
     page = ctx.new_page()
@@ -232,10 +234,14 @@ def test_cache_clear_removes_caches(browser):
         has_before = page.evaluate("async () => await caches.has('e2e-test')")
         assert has_before, "e2e-test cache should exist before clear"
 
-        # clearAllCaches: confirm → delete all → location.reload()
-        with page.expect_navigation():
-            open_settings(page).get_by_role("button", name="캐시 비우기").click()
-        page.wait_for_selector("#search-input")
+        # clearAllCaches: confirm → delete all → location.reload().
+        # expect_navigation() is racy for in-page reloads; instead drop a window
+        # sentinel and wait for the reload to wipe it (fresh document), then for
+        # the shell to re-render. wait_for_function survives the navigation.
+        page.evaluate("() => { window.__preReload = true; }")
+        open_settings(page).get_by_role("button", name="캐시 비우기").click()
+        page.wait_for_function("() => window.__preReload === undefined")
+        page.wait_for_selector("#search-input", state="attached")
 
         has_after = page.evaluate("async () => await caches.has('e2e-test')")
         assert not has_after, "e2e-test cache should be deleted after reload"

--- a/tests/e2e/test_tabbar.py
+++ b/tests/e2e/test_tabbar.py
@@ -97,7 +97,11 @@ def test_search_button_morphs_to_input(mobile_context):
     # 모핑 상태 + 하단 입력(모핑 입력 pill)이 보여야 한다.
     page.wait_for_selector("#tab-dock.searching", timeout=5_000)
     page.wait_for_selector("#tab-search-input:not([hidden])", timeout=5_000)
-    page.wait_for_selector("#tab-search[aria-current='page']", timeout=5_000)
+    # In searching mode the search circle morphs into the input pill, so
+    # #tab-search is hidden — assert the state is set (attached), not visible.
+    page.wait_for_selector(
+        "#tab-search[aria-current='page']", state="attached", timeout=5_000
+    )
 
 
 def test_scroll_collapse_and_home_expands_without_nav(mobile_context):


### PR DESCRIPTION
헤드리스 chromium 에서 멈추거나 실패하던 e2e 묶음을 원인별로 해소. 모두 앱 코드
회귀가 아니라 테스트 환경·상호작용 문제다. (베이스: `release/1.6.4`)

세 커밋, 성격별 분리:

1. **헤드리스 대기·SW 간섭** (`462534c`)
   - `wait_app_ready`: `#search-input` 가시 → attached 대기 (모바일은 헤더가
     `display:none` 이라 가시 대기가 무한 타임아웃).
   - tabbar 모핑: 모핑 후 `#tab-search` 가 숨으므로 `aria-current` 검사를 attached 로.
   - 캐시 비우기: `service_workers="block"` + reload 센티넬 대기 (SW unregister 가
     헤드리스에서 resolve 안 돼 멈추던 문제).

2. **앱 실제 동작에 맞춤** (`eafdcfe`) — 헤드리스 무관, headed 로도 동일 실패
   - settings 책순서: 토글이 `route()` 로 팝오버를 닫는 실제 동작에 맞춰 재오픈 후 검증.
   - folder 토글: 행 중심이 액션 버튼에 가려 center-click 이 토글에 안 닿음 →
     `.bm-folder-name` 클릭으로 변경.

3. **설치 권유 너지 억제** (`564d5a2`) — 탭바 실패의 진짜 원인
   - `maybeShowInstallNudge` 기본 상태(`{visits:0, nextShow:1}`)가 첫 방문에 발동 →
     `#install-scrim` 이 탭바를 덮어 `#tab-search` 클릭을 가로채 8건 타임아웃.
   - `CLEAR_APP_STORAGE` 에 `neverShow` 너지 상태를 심어 억제. 일부 북마크 테스트가
     파일별로 직접 심던 우회를 중앙화(그 우회들은 중복·무해, 후속 정리 대상).

## 검증 (로컬, http://localhost:8080)
- `test_tabbar.py` 11 통과 (이전 8건 타임아웃 30s+ → 전체 22s)
- `test_install_guide.py` 19 통과 (너지 표시 테스트는 자체 init 사용, 영향 없음)
- `test_settings.py`·`test_bookmark_folders.py`·`test_search.py` 통과
- 유닛/tsc 는 본 변경(e2e 전용)과 무관 — CI Unit tests 로 확인

> 발견 기록: 처음엔 `aria-current` 변경이 tabbar 모핑 실패를 고친다고 봤으나,
> 실제 원인은 클릭을 가로막던 설치 너지 오버레이였다. `aria-current` 변경은 클릭
> 성공 이후 단계라 단독으론 부족했고(커밋 3에 상세), 너지 억제와 함께여야 통과한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to Playwright e2e tests and fixtures; production behavior is unchanged.
> 
> **Overview**
> E2E-only hardening for headless Chromium and flaky interactions—no application code changes.
> 
> **Centralized install nudge suppression:** `CLEAR_APP_STORAGE` now seeds `bible-install-nudge` with `neverShow: true` after wiping keys, so the first-visit `#install-scrim` no longer blocks tab-bar clicks. Per-file `_PIN_NUDGE` / `SUPPRESS_INSTALL_NUDGE` init scripts were removed from bookmark tests.
> 
> **Wait semantics:** `wait_app_ready` waits for `#search-input` with `state="attached"` (mobile hides the header search bar). Tab-bar search morphing asserts `#tab-search[aria-current='page']` as attached when the control is hidden during morph.
> 
> **Settings & cache:** 외경 toggles re-open settings after `route()` closes the popover and use `wait_for_function` on `localStorage`. Cache-clear uses `service_workers="block"` and a reload sentinel instead of `expect_navigation()`.
> 
> **Interaction fixes:** Folder expand/collapse tests click `.bm-folder-name` instead of `.bm-folder-row` so Playwright does not hit overlay action buttons.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9848cee364c6d5f6d7a5f37e039326ce8c5420ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->