### PR TITLE
feat: 절 선택 범위를 앵커 기반(Shift+클릭·홀드+탭)으로 교체

### DIFF
--- a/docs/decisions/010-bookmark-feature.md
+++ b/docs/decisions/010-bookmark-feature.md
@@ -232,6 +232,13 @@ ARIA tree widget(`role="tree"`, `role="treeitem"`, `role="group"`).
 >   선택 모드에서는 `pointerdown` 에 `preventDefault` 를 걸지 않아(스크롤 보존; 텍스트
 >   선택은 `body.verse-select-active { user-select:none }` 로 차단) 자유 스크롤이 된다.
 >   슬라이드 드래그 코드와 `VerseSelectDrag` 타입은 제거.
+> - **수명 가드(Bugbot 리뷰 대응):** 포인터는 `setPointerCapture` 로 잡아 손가락이
+>   article 밖에서 떼지거나 드리프트해도 pointermove/up/cancel 이 article 로 retarget
+>   되어 타이머·`_activePointers` 가 확실히 정리된다(캡처는 스크롤을 막지 않음 — 팬이
+>   시작되면 브라우저가 `pointercancel` 로 캡처를 해제하고, 핸들러는 이를 abort 로
+>   처리). 롱프레스 타이머 콜백과 pointerup 토글 모두 `readingContext.verseSelectMode`
+>   (타이머는 `article.isConnected` 도) 를 확인해, 모드 종료/네비게이션 후 늦은 발화가
+>   상태를 되살리지 않게 한다.
 > - 선택 모드 진입(읽기 화면 롱프레스 300ms / 드로어 "절 선택" 버튼) 시 앵커를
 >   초기화하고, 롱프레스 진입 절을 첫 앵커로 둔다. 유닛 테스트: `tests/unit/views.test.js`
 >   `_verseRangeVrefs` 7케이스 추가(`node --test` 734 통과).

--- a/docs/decisions/010-bookmark-feature.md
+++ b/docs/decisions/010-bookmark-feature.md
@@ -216,20 +216,24 @@ ARIA tree widget(`role="tree"`, `role="treeitem"`, `role="group"`).
 > 종전 선택 모드의 범위 선택은 한 절을 누른 채 손가락을 끌면(`pointermove` +
 > `document.elementFromPoint`) 시작 절~현재 절이 실시간으로 칠해지는 **슬라이드
 > 드래그**였다. 그러나 모바일에서 패닝하는 손가락이 페이지 스크롤과 경합해 사실상
-> 동작하지 않았다(끌면 화면만 스크롤). → **앵커 기반 모델**로 교체:
+> 동작하지 않았다(끌면 화면만 스크롤). → **기억된 앵커 기반 모델**로 교체:
 > - **상태:** `readingContext.selectAnchor`(`string | null`) — 마지막으로 개별 토글된
 >   절의 `data-vref`. 일반 탭/클릭은 그 절을 토글하고 앵커를 그리로 옮긴다(해제면 null).
-> - **데스크탑:** 절을 클릭해 앵커를 잡고 다른 절을 **Shift+클릭** → 앵커~타깃 전체 선택
->   (파일 탐색기·에디터 표준 관용구). `pointerdown` 에서 `e.shiftKey` 분기.
-> - **모바일:** 한 절을 **누른 채(정지)** 다른 절을 **두 번째 손가락으로 탭** → 두 절
->   사이 전체 선택. 정지한 두 터치점은 스크롤을 시작시키지 않아 슬라이드의 스크롤
->   경합 문제가 없다. `_activePointers`(pointerId→`{vref, consumed}`) 맵으로 멀티터치를
->   추적하고, 범위를 만든 포인터는 `consumed` 표시해 이후 `pointerup` 토글을 막는다.
+>   반복 탭으로 **비연속 절**을 모은다.
+> - **범위 확장(앵커→타깃, additive):** 앵커가 기억돼 있어 두 끝점이 한 화면에 같이
+>   보일 필요가 없다 — 시작 절을 탭하고 임의 거리만큼 스크롤한 뒤 끝 절을 지정한다.
+>   - **데스크탑:** 끝 절을 **Shift+클릭**. `pointerdown` 의 `e.shiftKey` 분기에서 즉시 확장.
+>   - **모바일:** 끝 절을 **롱프레스**(약 300ms 길게 누르기 — 모바일의 "Shift" 역할).
+>     선택 모드 안에서는 `pointerdown` 이 per-pointer 타이머(`LONG_PRESS_MS`)를 걸고,
+>     >10px 드리프트(스크롤)나 빠른 lift(=탭) 면 타이머를 취소한다(`_activePointers`
+>     맵). 손가락을 끝까지 물고 있을 필요가 없어 스크롤 경합이 없다.
 > - 두 경로 모두 순수 헬퍼 `_verseRangeVrefs(allVrefs, anchor, target, unitFn)`
->   (views.js `VERSE_SELECTION` 블록, 양방향·운문 다중부분 경계 확장)로 범위를 계산하고
->   **additive** 로 더한다. 슬라이드 드래그 코드와 `VerseSelectDrag` 타입은 제거.
-> - 선택 모드 진입(롱프레스 300ms / 드로어 "절 선택" 버튼) 시 앵커를 초기화하고,
->   롱프레스 진입 절을 첫 앵커로 둔다. 유닛 테스트: `tests/unit/views.test.js`
+>   (views.js `VERSE_SELECTION` 블록, 양방향·운문 다중부분 경계 확장)로 범위를 계산.
+>   선택 모드에서는 `pointerdown` 에 `preventDefault` 를 걸지 않아(스크롤 보존; 텍스트
+>   선택은 `body.verse-select-active { user-select:none }` 로 차단) 자유 스크롤이 된다.
+>   슬라이드 드래그 코드와 `VerseSelectDrag` 타입은 제거.
+> - 선택 모드 진입(읽기 화면 롱프레스 300ms / 드로어 "절 선택" 버튼) 시 앵커를
+>   초기화하고, 롱프레스 진입 절을 첫 앵커로 둔다. 유닛 테스트: `tests/unit/views.test.js`
 >   `_verseRangeVrefs` 7케이스 추가(`node --test` 734 통과).
 
 **헤더 북마크 아이콘** (`.title-bookmark-btn`): `buildBookmarkHeaderBtn()` 호출.

--- a/docs/decisions/010-bookmark-feature.md
+++ b/docs/decisions/010-bookmark-feature.md
@@ -212,6 +212,26 @@ ARIA tree widget(`role="tree"`, `role="treeitem"`, `role="group"`).
 > 절 선택 숨김(1,1,1)을 이겨 축소 중 진입 시 액션 바 뒤로 비쳤던 버그를
 > `display: none !important` 로 해소.
 
+> **개정 (2026-06-13): 범위 선택을 한-손가락 슬라이드 → 앵커 기반으로 교체.**
+> 종전 선택 모드의 범위 선택은 한 절을 누른 채 손가락을 끌면(`pointermove` +
+> `document.elementFromPoint`) 시작 절~현재 절이 실시간으로 칠해지는 **슬라이드
+> 드래그**였다. 그러나 모바일에서 패닝하는 손가락이 페이지 스크롤과 경합해 사실상
+> 동작하지 않았다(끌면 화면만 스크롤). → **앵커 기반 모델**로 교체:
+> - **상태:** `readingContext.selectAnchor`(`string | null`) — 마지막으로 개별 토글된
+>   절의 `data-vref`. 일반 탭/클릭은 그 절을 토글하고 앵커를 그리로 옮긴다(해제면 null).
+> - **데스크탑:** 절을 클릭해 앵커를 잡고 다른 절을 **Shift+클릭** → 앵커~타깃 전체 선택
+>   (파일 탐색기·에디터 표준 관용구). `pointerdown` 에서 `e.shiftKey` 분기.
+> - **모바일:** 한 절을 **누른 채(정지)** 다른 절을 **두 번째 손가락으로 탭** → 두 절
+>   사이 전체 선택. 정지한 두 터치점은 스크롤을 시작시키지 않아 슬라이드의 스크롤
+>   경합 문제가 없다. `_activePointers`(pointerId→`{vref, consumed}`) 맵으로 멀티터치를
+>   추적하고, 범위를 만든 포인터는 `consumed` 표시해 이후 `pointerup` 토글을 막는다.
+> - 두 경로 모두 순수 헬퍼 `_verseRangeVrefs(allVrefs, anchor, target, unitFn)`
+>   (views.js `VERSE_SELECTION` 블록, 양방향·운문 다중부분 경계 확장)로 범위를 계산하고
+>   **additive** 로 더한다. 슬라이드 드래그 코드와 `VerseSelectDrag` 타입은 제거.
+> - 선택 모드 진입(롱프레스 300ms / 드로어 "절 선택" 버튼) 시 앵커를 초기화하고,
+>   롱프레스 진입 절을 첫 앵커로 둔다. 유닛 테스트: `tests/unit/views.test.js`
+>   `_verseRangeVrefs` 7케이스 추가(`node --test` 734 통과).
+
 **헤더 북마크 아이콘** (`.title-bookmark-btn`): `buildBookmarkHeaderBtn()` 호출.
 아이콘: Material Icons `bookmarks` SVG. 장 북마크 여부 표시 제거
 (`.has-bookmark` 클래스 및 관련 CSS 삭제).

--- a/js/app/bookmark-verse-select.js
+++ b/js/app/bookmark-verse-select.js
@@ -49,6 +49,7 @@ function updateVerseSelectionBoundaries(scope) {
 function enterVerseSelectMode(bookId, chapter) {
   readingContext.verseSelectMode = true;
   readingContext.selectedVerses.clear();
+  readingContext.selectAnchor = null;
   readingContext.bookId = bookId;
   readingContext.chapter = chapter;
   document.body.classList.add("verse-select-active");
@@ -60,6 +61,7 @@ function enterVerseSelectMode(bookId, chapter) {
 function exitVerseSelectMode() {
   readingContext.verseSelectMode = false;
   readingContext.selectedVerses.clear();
+  readingContext.selectAnchor = null;
   document.body.classList.remove("verse-select-active");
   $verseSelectBar.hidden = true;
   document.querySelectorAll(".verse-selected, .verse-selected-join-prev, .verse-selected-join-next")

--- a/js/app/bookmark.js
+++ b/js/app/bookmark.js
@@ -14,7 +14,6 @@
 /** @typedef {import("../types").BookmarkTreeNode} BookmarkTreeNode */
 /** @typedef {import("../types").BookmarkTreeBookmark} BookmarkTreeBookmark */
 /** @typedef {import("../types").BookmarkTreeFolder} BookmarkTreeFolder */
-/** @typedef {import("../types").VerseSelectDrag} VerseSelectDrag */
 /** @typedef {import("../types").DragState} DragState */
 /** @typedef {import("../types").BooksData} BooksData */
 

--- a/js/app/reading-context.js
+++ b/js/app/reading-context.js
@@ -12,15 +12,13 @@
 // hot-path (e.g. scroll-tracking writes `chapter` on every chapter render)
 // and JS object property access is the simplest cross-module mutation.
 
-/** @typedef {import("../types").VerseSelectDrag} VerseSelectDrag */
-
 /**
  * @typedef {Object} ReadingContext
  * @property {string | null} bookId      — id of the book currently rendered, or null on home/list views
  * @property {number | null} chapter     — chapter number currently rendered, or null
  * @property {boolean} verseSelectMode   — true when the user has entered verse-selection (long-press / FAB)
  * @property {Set<string>} selectedVerses — data-vref strings of currently selected verses
- * @property {VerseSelectDrag | null} verseSelectDrag — in-flight pointer drag during selection, or null
+ * @property {string | null} selectAnchor — data-vref of the last individually tapped verse; the anchor for range selection (Shift+click / hold-and-tap)
  */
 
 /** @type {ReadingContext} */
@@ -29,7 +27,7 @@ const readingContext = {
   chapter: null,
   verseSelectMode: false,
   selectedVerses: new Set(),
-  verseSelectDrag: null,
+  selectAnchor: null,
 };
 
 window.readingContext = readingContext;

--- a/js/app/views.js
+++ b/js/app/views.js
@@ -1214,8 +1214,13 @@ function renderChapter(data, book, opts) {
       const vs = t.closest(".verse[data-vref]");
       if (!vs) return;
       const vref = vs.getAttribute("data-vref") ?? "";
-      // Desktop: Shift+click extends from the anchor immediately.
-      if (e.shiftKey && readingContext.selectAnchor && selectRange(readingContext.selectAnchor, vref)) {
+      // Desktop: Shift+click extends from the anchor (or, with no anchor yet,
+      // acts as a plain toggle that sets the anchor). Handled fully here and
+      // returns, so it never also arms the tap/long-press path below — that
+      // would leave a spurious toggle queued for the matching pointerup.
+      if (e.shiftKey) {
+        if (readingContext.selectAnchor) selectRange(readingContext.selectAnchor, vref);
+        else toggleVerse(vref);
         return;
       }
       // Otherwise arm a long-press: holding in place extends the range from the
@@ -1226,6 +1231,10 @@ function renderChapter(data, book, opts) {
       const entry = { vref, x: e.clientX, y: e.clientY, timer: /** @type {ReturnType<typeof setTimeout> | null} */ (null), longPressed: false, moved: false };
       entry.timer = setTimeout(() => {
         entry.timer = null;
+        // Guard against firing after the user left select mode or navigated
+        // away while the finger was still down (the pointerup that would have
+        // cleared this timer never arrived in the same view).
+        if (!readingContext.verseSelectMode || !article.isConnected) return;
         entry.longPressed = true;
         if (readingContext.selectAnchor) selectRange(readingContext.selectAnchor, vref);
         else toggleVerse(vref); // no anchor yet → behave like a tap (select + set anchor)
@@ -1239,6 +1248,7 @@ function renderChapter(data, book, opts) {
     _longPressStartY = e.clientY;
     _longPressTimer = setTimeout(() => {
       _longPressTimer = null;
+      if (!article.isConnected) return; // view was replaced before the press matured
       enterVerseSelectMode(book.id, ch);
       const vref = vs.getAttribute("data-vref");
       if (vref) {

--- a/js/app/views.js
+++ b/js/app/views.js
@@ -1240,6 +1240,12 @@ function renderChapter(data, book, opts) {
         else toggleVerse(vref); // no anchor yet → behave like a tap (select + set anchor)
       }, LONG_PRESS_MS);
       _activePointers.set(e.pointerId, entry);
+      // Capture the pointer so the matching pointermove/up/cancel always reach
+      // this article — even if the finger lifts or drifts outside it — so the
+      // timer and entry are reliably cleared. Capture does NOT block scrolling:
+      // when a pan begins the browser fires pointercancel (releasing capture),
+      // which our handler treats as an abort.
+      try { article.setPointerCapture(e.pointerId); } catch { /* pointer already released */ }
       return;
     }
     const vs = t.closest(".verse[data-vref]");
@@ -1294,7 +1300,9 @@ function renderChapter(data, book, opts) {
       _activePointers.delete(e.pointerId);
       // A quick tap (no long-press, no scroll-drift) toggles the verse. A
       // long-press already extended the range; a drifted pointer was a scroll.
-      if (!entry.longPressed && !entry.moved) toggleVerse(entry.vref);
+      // Guard verseSelectMode: if the mode ended while the finger was down
+      // (cancel / copy / navigation), a late pointerup must not re-toggle.
+      if (!entry.longPressed && !entry.moved && readingContext.verseSelectMode) toggleVerse(entry.vref);
       return;
     }
     cancelLongPress(e);

--- a/js/app/views.js
+++ b/js/app/views.js
@@ -1152,21 +1152,25 @@ function renderChapter(data, book, opts) {
   //
   // Inside select mode, range selection is anchored on the last individually
   // tapped verse (readingContext.selectAnchor):
-  //   • Desktop — click a verse, then Shift+click another to fill the range.
-  //   • Mobile  — hold one verse and tap another with a second finger to fill
-  //     the range. A one-finger slide is deliberately NOT used: a panning
-  //     finger fights the page scroll, whereas two still touch points never
-  //     start a scroll.
-  // A plain tap/click toggles a single verse and moves the anchor there.
+  //   • A plain tap/click toggles a single verse and moves the anchor there —
+  //     repeated taps build a non-contiguous selection.
+  //   • To fill a range, extend from the anchor to another verse. The page
+  //     stays scrollable, so the two endpoints need not share a screen:
+  //       – Desktop: Shift+click the far verse.
+  //       – Mobile:  long-press the far verse (the mobile equivalent of Shift).
+  //     A held finger is NOT required across the range — the anchor is
+  //     remembered — so the user can tap the start, scroll any distance, then
+  //     long-press the end.
   /** @type {ReturnType<typeof setTimeout> | null} */
   let _longPressTimer = null;
   let _longPressStartX = 0;
   let _longPressStartY = 0;
 
-  // In-flight touches in select mode: pointerId → { vref, consumed }. `consumed`
-  // marks a pointer whose pointerdown already drove a range selection, so its
-  // later pointerup must not also toggle the verse.
-  /** @type {Map<number, { vref: string, consumed: boolean }>} */
+  const LONG_PRESS_MS = 300;
+  // In-flight touches in select mode: pointerId → per-pointer gesture state.
+  // `timer` fires the long-press range extension; `longPressed`/`moved` decide
+  // whether the pointerup should still toggle (a plain tap) or do nothing.
+  /** @type {Map<number, { vref: string, x: number, y: number, timer: ReturnType<typeof setTimeout> | null, longPressed: boolean, moved: boolean }>} */
   const _activePointers = new Map();
 
   // Refresh verse-highlight classes + dock after mutating selectedVerses.
@@ -1210,24 +1214,23 @@ function renderChapter(data, book, opts) {
       const vs = t.closest(".verse[data-vref]");
       if (!vs) return;
       const vref = vs.getAttribute("data-vref") ?? "";
-      e.preventDefault(); // suppress native text selection / iOS callout
-      // Desktop: Shift+click extends the selection from the existing anchor.
+      // Desktop: Shift+click extends from the anchor immediately.
       if (e.shiftKey && readingContext.selectAnchor && selectRange(readingContext.selectAnchor, vref)) {
-        _activePointers.set(e.pointerId, { vref, consumed: true });
         return;
       }
-      // Mobile: a second finger landing on a different verse while the first is
-      // still held selects the range between the held verse and this one.
-      let heldVref = null;
-      for (const p of _activePointers.values()) {
-        if (p.vref && p.vref !== vref) { heldVref = p.vref; break; }
-      }
-      if (heldVref && selectRange(heldVref, vref)) {
-        for (const p of _activePointers.values()) p.consumed = true;
-        _activePointers.set(e.pointerId, { vref, consumed: true });
-        return;
-      }
-      _activePointers.set(e.pointerId, { vref, consumed: false });
+      // Otherwise arm a long-press: holding in place extends the range from the
+      // anchor; a quick lift (handled in pointerup) toggles the single verse. We
+      // do NOT preventDefault — that would block the page scroll the user needs
+      // to reach a far range endpoint (text selection is already suppressed by
+      // body.verse-select-active { user-select: none }).
+      const entry = { vref, x: e.clientX, y: e.clientY, timer: /** @type {ReturnType<typeof setTimeout> | null} */ (null), longPressed: false, moved: false };
+      entry.timer = setTimeout(() => {
+        entry.timer = null;
+        entry.longPressed = true;
+        if (readingContext.selectAnchor) selectRange(readingContext.selectAnchor, vref);
+        else toggleVerse(vref); // no anchor yet → behave like a tap (select + set anchor)
+      }, LONG_PRESS_MS);
+      _activePointers.set(e.pointerId, entry);
       return;
     }
     const vs = t.closest(".verse[data-vref]");
@@ -1245,7 +1248,7 @@ function renderChapter(data, book, opts) {
         readingContext.selectAnchor = vref;
         refreshSelection();
       }
-    }, 300);
+    }, LONG_PRESS_MS);
   });
 
   const cancelLongPress = (e) => {
@@ -1259,22 +1262,41 @@ function renderChapter(data, book, opts) {
     _longPressTimer = null;
   };
 
-  article.addEventListener("pointermove", cancelLongPress);
+  article.addEventListener("pointermove", (e) => {
+    // Cancel a pending in-mode long-press once the finger drifts >10px — the
+    // user is scrolling (to reach a far verse), not pressing-and-holding.
+    const entry = _activePointers.get(e.pointerId);
+    if (entry && !entry.longPressed) {
+      const dx = e.clientX - entry.x;
+      const dy = e.clientY - entry.y;
+      if (dx * dx + dy * dy >= 100) {
+        entry.moved = true;
+        if (entry.timer) { clearTimeout(entry.timer); entry.timer = null; }
+      }
+    }
+    cancelLongPress(e);
+  });
 
   article.addEventListener("pointerup", (e) => {
-    if (readingContext.verseSelectMode) {
-      const entry = _activePointers.get(e.pointerId);
-      if (entry) {
-        _activePointers.delete(e.pointerId);
-        if (!entry.consumed) toggleVerse(entry.vref);
-      }
+    const entry = _activePointers.get(e.pointerId);
+    if (entry) {
+      if (entry.timer) { clearTimeout(entry.timer); entry.timer = null; }
+      _activePointers.delete(e.pointerId);
+      // A quick tap (no long-press, no scroll-drift) toggles the verse. A
+      // long-press already extended the range; a drifted pointer was a scroll.
+      if (!entry.longPressed && !entry.moved) toggleVerse(entry.vref);
       return;
     }
     cancelLongPress(e);
   });
 
   article.addEventListener("pointercancel", (e) => {
-    if (readingContext.verseSelectMode) { _activePointers.delete(e.pointerId); return; }
+    const entry = _activePointers.get(e.pointerId);
+    if (entry) {
+      if (entry.timer) clearTimeout(entry.timer);
+      _activePointers.delete(e.pointerId);
+      return;
+    }
     cancelLongPress(e);
   });
 

--- a/js/app/views.js
+++ b/js/app/views.js
@@ -800,6 +800,39 @@ function _verseSelectionUnit(article, vref) {
   }
   return [vref];
 }
+
+// Inclusive list of data-vref strings spanning anchor→target (in either
+// direction) given the document-order array `allVrefs`. Used by anchored range
+// selection (desktop Shift+click, mobile hold-and-tap). Each endpoint is
+// expanded to its whole pure-poetry unit via `unitFn` so a range edge that
+// lands on one line-part of a multi-part verse still pulls in the rest.
+/**
+ * @param {string[]} allVrefs
+ * @param {string} anchorVref
+ * @param {string} targetVref
+ * @param {(vref: string) => string[]} [unitFn]
+ * @returns {string[]}
+ */
+function _verseRangeVrefs(allVrefs, anchorVref, targetVref, unitFn) {
+  const ai = allVrefs.indexOf(anchorVref);
+  const ti = allVrefs.indexOf(targetVref);
+  if (ai === -1 || ti === -1) return [];
+  let lo = ai <= ti ? ai : ti;
+  let hi = ai <= ti ? ti : ai;
+  if (unitFn) {
+    const loUnit = unitFn(allVrefs[lo]);
+    if (loUnit.length > 1) {
+      const f = allVrefs.indexOf(loUnit[0]);
+      if (f !== -1 && f < lo) lo = f;
+    }
+    const hiUnit = unitFn(allVrefs[hi]);
+    if (hiUnit.length > 1) {
+      const l = allVrefs.indexOf(hiUnit[hiUnit.length - 1]);
+      if (l !== -1 && l > hi) hi = l;
+    }
+  }
+  return allVrefs.slice(lo, hi + 1);
+}
 // ── END VERSE_SELECTION ──
 
 // Render a list of verses into `article` as inline verse spans + inter-verse
@@ -1112,12 +1145,63 @@ function renderChapter(data, book, opts) {
     announce(`${vs.getAttribute("data-vref")}절`);
   });
 
-  // Long-press (300ms) to enter verse selection mode.
-  // pointermove only cancels after >10px of movement to tolerate natural finger drift.
+  // ── Verse selection gestures ──
+  // Outside select mode: a 300ms long-press on a verse enters select mode and
+  // selects that verse (pointermove only cancels after >10px to tolerate
+  // natural finger drift).
+  //
+  // Inside select mode, range selection is anchored on the last individually
+  // tapped verse (readingContext.selectAnchor):
+  //   • Desktop — click a verse, then Shift+click another to fill the range.
+  //   • Mobile  — hold one verse and tap another with a second finger to fill
+  //     the range. A one-finger slide is deliberately NOT used: a panning
+  //     finger fights the page scroll, whereas two still touch points never
+  //     start a scroll.
+  // A plain tap/click toggles a single verse and moves the anchor there.
   /** @type {ReturnType<typeof setTimeout> | null} */
   let _longPressTimer = null;
   let _longPressStartX = 0;
   let _longPressStartY = 0;
+
+  // In-flight touches in select mode: pointerId → { vref, consumed }. `consumed`
+  // marks a pointer whose pointerdown already drove a range selection, so its
+  // later pointerup must not also toggle the verse.
+  /** @type {Map<number, { vref: string, consumed: boolean }>} */
+  const _activePointers = new Map();
+
+  // Refresh verse-highlight classes + dock after mutating selectedVerses.
+  const refreshSelection = () => {
+    article.querySelectorAll(".verse[data-vref]").forEach((v) => {
+      v.classList.toggle("verse-selected", readingContext.selectedVerses.has(v.getAttribute("data-vref") ?? ""));
+    });
+    updateVerseSelectionBoundaries(article);
+    updateVerseSelectBar();
+  };
+
+  // Additively select every verse from `anchorVref` to `targetVref` inclusive,
+  // then move the anchor to the target. Returns false if the range is empty.
+  const selectRange = (anchorVref, targetVref) => {
+    const allVrefs = [...article.querySelectorAll(".verse[data-vref]")]
+      .map((v) => v.getAttribute("data-vref") ?? "");
+    const range = _verseRangeVrefs(allVrefs, anchorVref, targetVref,
+      (vref) => _verseSelectionUnit(article, vref));
+    if (!range.length) return false;
+    for (const r of range) readingContext.selectedVerses.add(r);
+    readingContext.selectAnchor = targetVref;
+    refreshSelection();
+    return true;
+  };
+
+  // Toggle a single verse's selection unit; the anchor follows a selection and
+  // clears on a deselection.
+  const toggleVerse = (vref) => {
+    const unit = _verseSelectionUnit(article, vref);
+    const wasSelected = unit.some((r) => readingContext.selectedVerses.has(r));
+    if (wasSelected) unit.forEach((r) => readingContext.selectedVerses.delete(r));
+    else unit.forEach((r) => readingContext.selectedVerses.add(r));
+    readingContext.selectAnchor = wasSelected ? null : vref;
+    refreshSelection();
+  };
 
   article.addEventListener("pointerdown", (e) => {
     const t = e.target;
@@ -1125,13 +1209,25 @@ function renderChapter(data, book, opts) {
     if (readingContext.verseSelectMode) {
       const vs = t.closest(".verse[data-vref]");
       if (!vs) return;
-      e.preventDefault(); // prevent text selection during drag
-      const allVerses = /** @type {HTMLElement[]} */ ([...article.querySelectorAll(".verse[data-vref]")]);
-      const startIdx = allVerses.indexOf(/** @type {HTMLElement} */ (vs));
-      const startUnit = _verseSelectionUnit(article, vs.getAttribute("data-vref") ?? "");
-      const isAdding = !startUnit.some((r) => readingContext.selectedVerses.has(r));
-      readingContext.verseSelectDrag = { startIdx, allVerses, isAdding, moved: false, snapshot: new Set(readingContext.selectedVerses) };
-      article.setPointerCapture(e.pointerId);
+      const vref = vs.getAttribute("data-vref") ?? "";
+      e.preventDefault(); // suppress native text selection / iOS callout
+      // Desktop: Shift+click extends the selection from the existing anchor.
+      if (e.shiftKey && readingContext.selectAnchor && selectRange(readingContext.selectAnchor, vref)) {
+        _activePointers.set(e.pointerId, { vref, consumed: true });
+        return;
+      }
+      // Mobile: a second finger landing on a different verse while the first is
+      // still held selects the range between the held verse and this one.
+      let heldVref = null;
+      for (const p of _activePointers.values()) {
+        if (p.vref && p.vref !== vref) { heldVref = p.vref; break; }
+      }
+      if (heldVref && selectRange(heldVref, vref)) {
+        for (const p of _activePointers.values()) p.consumed = true;
+        _activePointers.set(e.pointerId, { vref, consumed: true });
+        return;
+      }
+      _activePointers.set(e.pointerId, { vref, consumed: false });
       return;
     }
     const vs = t.closest(".verse[data-vref]");
@@ -1146,14 +1242,12 @@ function renderChapter(data, book, opts) {
         for (const r of _verseSelectionUnit(article, vref)) {
           readingContext.selectedVerses.add(r);
         }
-        article.querySelectorAll(".verse[data-vref]").forEach((v) => {
-          v.classList.toggle("verse-selected", readingContext.selectedVerses.has(v.getAttribute("data-vref") ?? ""));
-        });
-        updateVerseSelectionBoundaries(article);
-        updateVerseSelectBar();
+        readingContext.selectAnchor = vref;
+        refreshSelection();
       }
     }, 300);
   });
+
   const cancelLongPress = (e) => {
     if (!_longPressTimer) return;
     if (e && e.type === "pointermove") {
@@ -1165,77 +1259,22 @@ function renderChapter(data, book, opts) {
     _longPressTimer = null;
   };
 
-  article.addEventListener("pointermove", (e) => {
-    if (readingContext.verseSelectDrag) {
-      const target = document.elementFromPoint(e.clientX, e.clientY);
-      const vs = /** @type {HTMLElement | null} */ (target && target.closest(".verse[data-vref]"));
-      if (!vs) return;
-      const { startIdx, allVerses, isAdding, snapshot } = readingContext.verseSelectDrag;
-      const currentIdx = allVerses.indexOf(vs);
-      if (currentIdx === -1) return;
-      if (!readingContext.verseSelectDrag.moved && currentIdx === startIdx) return;
-      readingContext.verseSelectDrag.moved = true;
-      const [lo, hi] = startIdx <= currentIdx ? [startIdx, currentIdx] : [currentIdx, startIdx];
-      readingContext.selectedVerses = new Set(snapshot);
-      for (let i = lo; i <= hi; i++) {
-        const vref = allVerses[i].getAttribute("data-vref") ?? "";
-        if (isAdding) readingContext.selectedVerses.add(vref);
-        else readingContext.selectedVerses.delete(vref);
-      }
-      // Pure-poetry verses are atomic: if any part falls in [lo, hi], extend
-      // the toggle to all parts of that verse number.
-      const seenNums = new Set();
-      for (let i = lo; i <= hi; i++) {
-        const vref = allVerses[i].getAttribute("data-vref") ?? "";
-        const m = vref.match(/^(\d+)/);
-        const num = m ? m[1] : vref;
-        if (seenNums.has(num)) continue;
-        seenNums.add(num);
-        const unit = _verseSelectionUnit(article, vref);
-        if (unit.length === 1) continue;
-        if (isAdding) unit.forEach((r) => readingContext.selectedVerses.add(r));
-        else unit.forEach((r) => readingContext.selectedVerses.delete(r));
-      }
-      allVerses.forEach((v) => {
-        const vref = v.getAttribute("data-vref") ?? "";
-        v.classList.toggle("verse-selected", readingContext.selectedVerses.has(vref));
-      });
-      updateVerseSelectionBoundaries(article);
-      updateVerseSelectBar();
-      return;
-    }
-    cancelLongPress(e);
-  });
+  article.addEventListener("pointermove", cancelLongPress);
 
   article.addEventListener("pointerup", (e) => {
-    if (readingContext.verseSelectDrag) {
-      if (!readingContext.verseSelectDrag.moved) {
-        // Simple tap: toggle the verse's selection unit (whole verse for pure
-        // poetry, single line otherwise).
-        const vs = readingContext.verseSelectDrag.allVerses[readingContext.verseSelectDrag.startIdx];
-        if (vs) {
-          const vref = vs.getAttribute("data-vref") ?? "";
-          const unit = _verseSelectionUnit(article, vref);
-          if (readingContext.verseSelectDrag.isAdding) {
-            unit.forEach((r) => readingContext.selectedVerses.add(r));
-          } else {
-            unit.forEach((r) => readingContext.selectedVerses.delete(r));
-          }
-          readingContext.verseSelectDrag.allVerses.forEach((v) => {
-            v.classList.toggle("verse-selected", readingContext.selectedVerses.has(v.getAttribute("data-vref") ?? ""));
-          });
-          updateVerseSelectionBoundaries(article);
-          updateVerseSelectBar();
-        }
+    if (readingContext.verseSelectMode) {
+      const entry = _activePointers.get(e.pointerId);
+      if (entry) {
+        _activePointers.delete(e.pointerId);
+        if (!entry.consumed) toggleVerse(entry.vref);
       }
-      readingContext.verseSelectDrag = null;
       return;
     }
     cancelLongPress(e);
   });
 
   article.addEventListener("pointercancel", (e) => {
-    if (readingContext.verseSelectDrag) { readingContext.verseSelectDrag = null; return; }
+    if (readingContext.verseSelectMode) { _activePointers.delete(e.pointerId); return; }
     cancelLongPress(e);
   });
 
@@ -1361,6 +1400,7 @@ const appViewsRouting = {
   initCompactHeader, initScrollElevation,
   renderError,
   _verseSelectionUnit,
+  _verseRangeVrefs,
 };
 window.appViewsRouting = appViewsRouting;
 
@@ -1382,7 +1422,7 @@ export {
   setTitle, setTitleWithChapterPicker,
   buildDivisionTabs, divisionLabels, divisionOrder, effectiveDivision,
   initCompactHeader, initScrollElevation,
-  _verseSelectionUnit,
+  _verseSelectionUnit, _verseRangeVrefs,
   DIVISION_LABELS,
   renderBookList, renderChapterList, renderChapter, renderPrologue,
   renderLoading, renderError,

--- a/js/types.d.ts
+++ b/js/types.d.ts
@@ -418,22 +418,6 @@ export interface SearchHistoryEntry {
   ts: number | null;
 }
 
-// Active during a touch/pointer drag over verse rows in select mode
-// (module-state `_verseSelectDrag`).
-export interface VerseSelectDrag {
-  startIdx: number;
-  allVerses: HTMLElement[];
-  isAdding: boolean;
-  moved: boolean;
-  /**
-   * Snapshot of `readingContext.selectedVerses` taken at pointerdown so that
-   * a subsequent pointerup with no drag movement can revert (deselect what
-   * was tentatively highlighted during the in-flight drag). Optional because
-   * older drag-init paths set this lazily.
-   */
-  snapshot?: Set<string>;
-}
-
 // Active during a bookmark-list reorder drag (module-state `_dragState`).
 export interface DragState {
   id: string;
@@ -774,7 +758,7 @@ export interface ReadingContext {
   chapter: number | null;
   verseSelectMode: boolean;
   selectedVerses: Set<string>;
-  verseSelectDrag: VerseSelectDrag | null;
+  selectAnchor: string | null;
 }
 
 // ── App bookmark facade (js/app/bookmark.js) ────────────────────────────────

--- a/tests/unit/views.test.js
+++ b/tests/unit/views.test.js
@@ -20,8 +20,9 @@
 //     with addEventListener + classList + hidden + querySelector + contains.
 //   - COMPACT_HEADER block — initCompactHeader. Hysteretic 60px / 10px
 //     scroll-based class toggle. Window scroll listener stub.
-//   - VERSE_SELECTION block — _verseSelectionUnit. Pure-poetry multi-part
-//     grouping vs per-line selection control.
+//   - VERSE_SELECTION block — _verseSelectionUnit (pure-poetry multi-part
+//     grouping vs per-line selection control) + _verseRangeVrefs (anchor→target
+//     inclusive range, either direction, poetry-unit boundary expansion).
 //   - VERSE_NUMBER block — formatVerseNumber. Verse-number display string:
 //     plain / dual [N_M] / LXX-only [_N] / cross-ref / range / part.
 
@@ -280,7 +281,11 @@ function loadVerseSelection() {
   vm.runInContext(extractBlock("VERSE_SELECTION"), ctx, {
     filename: "views-verse-selection.js",
   });
-  return { ctx, verseSelectionUnit: ctx._verseSelectionUnit };
+  return {
+    ctx,
+    verseSelectionUnit: ctx._verseSelectionUnit,
+    verseRangeVrefs: ctx._verseRangeVrefs,
+  };
 }
 
 /** @param {Array<[string, boolean]>} verses [vref, isPoetry] tuples */
@@ -1048,6 +1053,52 @@ test("_verseSelectionUnit: groups by integer prefix, not contamination across ne
 test("_verseSelectionUnit: null article → defensive [vref]", () => {
   const h = loadVerseSelection();
   assert.deepEqual(h.verseSelectionUnit(null, "3a"), ["3a"]);
+});
+
+test("_verseRangeVrefs: forward range is inclusive of both endpoints", () => {
+  const h = loadVerseSelection();
+  const all = ["1", "2", "3", "4", "5"];
+  assert.deepEqual(h.verseRangeVrefs(all, "2", "4"), ["2", "3", "4"]);
+});
+
+test("_verseRangeVrefs: backward range (anchor after target) yields same span", () => {
+  const h = loadVerseSelection();
+  const all = ["1", "2", "3", "4", "5"];
+  assert.deepEqual(h.verseRangeVrefs(all, "4", "2"), ["2", "3", "4"]);
+});
+
+test("_verseRangeVrefs: same anchor and target → that single verse", () => {
+  const h = loadVerseSelection();
+  const all = ["1", "2", "3"];
+  assert.deepEqual(h.verseRangeVrefs(all, "2", "2"), ["2"]);
+});
+
+test("_verseRangeVrefs: unknown endpoint → empty (defensive)", () => {
+  const h = loadVerseSelection();
+  const all = ["1", "2", "3"];
+  assert.deepEqual(h.verseRangeVrefs(all, "2", "9"), []);
+  assert.deepEqual(h.verseRangeVrefs(all, "x", "2"), []);
+});
+
+test("_verseRangeVrefs: endpoint inside a poetry unit expands to the whole unit", () => {
+  const h = loadVerseSelection();
+  const all = ["1", "2a", "2b", "2c", "3", "4a", "4b"];
+  // target "2b" pulls in 2a/2c; anchor "4a" pulls in 4b.
+  const unit = (vref) => {
+    if (vref.startsWith("2")) return ["2a", "2b", "2c"];
+    if (vref.startsWith("4")) return ["4a", "4b"];
+    return [vref];
+  };
+  assert.deepEqual(
+    h.verseRangeVrefs(all, "4a", "2b", unit),
+    ["2a", "2b", "2c", "3", "4a", "4b"],
+  );
+});
+
+test("_verseRangeVrefs: without unitFn, no boundary expansion", () => {
+  const h = loadVerseSelection();
+  const all = ["1", "2a", "2b", "2c", "3"];
+  assert.deepEqual(h.verseRangeVrefs(all, "2b", "3"), ["2b", "2c", "3"]);
 });
 
 // ── VERSE_NUMBER ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## 요약

절 선택 모드의 **범위 선택**을 한-손가락 슬라이드 드래그에서 **기억된 앵커(anchor) 기반 모델**로 교체합니다. 종전 슬라이드 방식은 모바일에서 패닝하는 손가락이 페이지 스크롤과 경합해 사실상 동작하지 않았습니다(끌면 화면만 스크롤됨).

## 동작

- **탭/클릭**: 단일 절 토글 + 앵커 이동. 반복 탭으로 **비연속 절** 선택(기존 유지).
- **범위 확장 (앵커→타깃, additive)**: 앵커가 기억되므로 두 끝점이 한 화면에 같이 보일 필요가 없습니다 — **시작 절 탭 → 자유 스크롤 → 끝 절 지정**.
  - **데스크탑**: 끝 절을 **Shift+클릭** (파일 탐색기·에디터 표준 관용구).
  - **모바일**: 끝 절을 **롱프레스(약 300ms 길게 누르기)** — 모바일의 "Shift" 역할.
- 손가락을 끝까지 물고 있을 필요가 없어 **화면 분량 제약이 사라지고** 스크롤 경합도 없습니다.
- 롱프레스 300ms / 드로어 "절 선택" 버튼 진입은 그대로, 진입 절이 첫 앵커가 됩니다.

## 변경 내용

- `readingContext.selectAnchor`(`string | null`) 상태 추가 — 마지막 개별 토글 절의 `data-vref`.
- 선택 모드 `pointerdown`은 per-pointer 롱프레스 타이머(`_activePointers` 맵)를 걸고, >10px 드리프트(스크롤)나 빠른 lift(=탭)면 타이머 취소. 선택 모드에서 `preventDefault` 미적용 → 자유 스크롤 보존(텍스트 선택은 `user-select:none`으로 차단).
- 순수 헬퍼 `_verseRangeVrefs(allVrefs, anchor, target, unitFn)` — 양방향·운문 다중부분 경계 확장. `views.js` `VERSE_SELECTION` 마커 블록.
- 슬라이드 드래그 핸들러 + `VerseSelectDrag` 타입 제거 (`reading-context.js`·`types.d.ts`·`bookmark.js` 정리).
- ADR-010 개정 블록(2026-06-13) 추가.

## 테스트

- `_verseRangeVrefs` 유닛 7케이스 추가 → `node --test tests/unit/*.test.js` **734 통과**.
- `tsc -p tsconfig.json` / `tsconfig.worker.json` 0 error.
- ⚠️ 모바일 롱프레스 확장 / 스크롤 후 확장 / 데스크탑 Shift+클릭은 실제 브라우저 e2e 수동 확인 권장(CI 미실행).

https://claude.ai/code/session_01NwghbUmURTDCpNpeG66zEp

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core chapter pointer/gesture handling and shared `readingContext`; regressions in tap vs long-press vs scroll are possible though guarded and unit-tested for range math.
> 
> **Overview**
> Replaces **in-mode slide-drag range selection** (pointer drag + `elementFromPoint`) with an **anchor-based model** so users can tap a start verse, scroll freely, then extend the range to a distant end verse—fixing mobile scroll fighting the old gesture.
> 
> **Behavior:** `readingContext.selectAnchor` tracks the last individually toggled `data-vref`. Plain taps still build non-contiguous selections. **Desktop** uses **Shift+click** on the far verse; **mobile** uses a **~300ms long-press** on the far verse (with >10px drift canceling the timer for scroll). Range fills are **additive** via new helper `_verseRangeVrefs` (bidirectional, pure-poetry unit expansion). Select-mode `pointerdown` no longer calls `preventDefault`, so scrolling works; `setPointerCapture` plus `verseSelectMode` / `article.isConnected` guards avoid stale toggles after exit or navigation.
> 
> **Cleanup:** `VerseSelectDrag` and `verseSelectDrag` are removed from types and `reading-context.js`; enter/exit verse-select resets `selectAnchor` and long-press entry sets the first anchor. ADR-010 documents the change; **7 unit tests** cover `_verseRangeVrefs`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e71c1ffa825a33ad92db124f25b690e18d02d809. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->