### PR TITLE
fix: 절 선택 진입 롱프레스 민감도 완화 (300ms→500ms)

### DIFF
--- a/docs/decisions/010-bookmark-feature.md
+++ b/docs/decisions/010-bookmark-feature.md
@@ -239,9 +239,19 @@ ARIA tree widget(`role="tree"`, `role="treeitem"`, `role="group"`).
 >   처리). 롱프레스 타이머 콜백과 pointerup 토글 모두 `readingContext.verseSelectMode`
 >   (타이머는 `article.isConnected` 도) 를 확인해, 모드 종료/네비게이션 후 늦은 발화가
 >   상태를 되살리지 않게 한다.
-> - 선택 모드 진입(읽기 화면 롱프레스 300ms / 드로어 "절 선택" 버튼) 시 앵커를
+> - 선택 모드 진입(읽기 화면 롱프레스 / 드로어 "절 선택" 버튼) 시 앵커를
 >   초기화하고, 롱프레스 진입 절을 첫 앵커로 둔다. 유닛 테스트: `tests/unit/views.test.js`
 >   `_verseRangeVrefs` 7케이스 추가(`node --test` 734 통과).
+
+> **개정 (2026-06-13): 선택 모드 진입 롱프레스 민감도 완화 — 300ms → 500ms.**
+> 읽기 중 손가락을 텍스트 위에 잠깐 얹거나 스크롤 직전 멈칫하는 0.3초가
+> 의도치 않게 절 선택 모드로 진입하던 오작동을 해소. 진입 임계값을 iOS·Android
+> 표준 롱프레스에 맞춰 **500ms**로 상향했다. 진입은 "정지한 손가락"과 "의도적
+> 누름"을 지속 시간으로만 구분하므로(이동 >10px 취소는 유지) 임계 시간이 유일한
+> 레버다. 한편 **선택 모드 안에서의 범위 확장 롱프레스는 300ms 유지** — 이미
+> 모드에 들어와 의도적으로 조작 중인 사용자의 제스처라 반응성을 지킨다.
+> `views.js` 의 단일 `LONG_PRESS_MS=300` 상수를 두 경로로 분리:
+> `ENTER_SELECT_MS=500`(진입) · `RANGE_EXTEND_MS=300`(범위 확장).
 
 **헤더 북마크 아이콘** (`.title-bookmark-btn`): `buildBookmarkHeaderBtn()` 호출.
 아이콘: Material Icons `bookmarks` SVG. 장 북마크 여부 표시 제거

--- a/js/app/views.js
+++ b/js/app/views.js
@@ -1146,9 +1146,12 @@ function renderChapter(data, book, opts) {
   });
 
   // ── Verse selection gestures ──
-  // Outside select mode: a 300ms long-press on a verse enters select mode and
+  // Outside select mode: a 500ms long-press on a verse enters select mode and
   // selects that verse (pointermove only cancels after >10px to tolerate
-  // natural finger drift).
+  // natural finger drift). 500ms — not a snappier value — is deliberate: this
+  // is the false-positive-prone path, so a finger merely *resting* on the text
+  // while reading (or pausing before a scroll) must clear the platform-standard
+  // long-press window rather than tripping the mode on a brief 300ms touch.
   //
   // Inside select mode, range selection is anchored on the last individually
   // tapped verse (readingContext.selectAnchor):
@@ -1166,7 +1169,12 @@ function renderChapter(data, book, opts) {
   let _longPressStartX = 0;
   let _longPressStartY = 0;
 
-  const LONG_PRESS_MS = 300;
+  // Entering select mode is the false-positive-prone path (a finger merely
+  // resting on the text while reading must NOT arm it), so it uses the longer,
+  // platform-standard 500ms threshold. Range extension *inside* select mode is
+  // a deliberate gesture by an already-engaged user, so it stays snappier.
+  const ENTER_SELECT_MS = 500;
+  const RANGE_EXTEND_MS = 300;
   // In-flight touches in select mode: pointerId → per-pointer gesture state.
   // `timer` fires the long-press range extension; `longPressed`/`moved` decide
   // whether the pointerup should still toggle (a plain tap) or do nothing.
@@ -1238,7 +1246,7 @@ function renderChapter(data, book, opts) {
         entry.longPressed = true;
         if (readingContext.selectAnchor) selectRange(readingContext.selectAnchor, vref);
         else toggleVerse(vref); // no anchor yet → behave like a tap (select + set anchor)
-      }, LONG_PRESS_MS);
+      }, RANGE_EXTEND_MS);
       _activePointers.set(e.pointerId, entry);
       // Capture the pointer so the matching pointermove/up/cancel always reach
       // this article — even if the finger lifts or drifts outside it — so the
@@ -1264,7 +1272,7 @@ function renderChapter(data, book, opts) {
         readingContext.selectAnchor = vref;
         refreshSelection();
       }
-    }, LONG_PRESS_MS);
+    }, ENTER_SELECT_MS);
   });
 
   const cancelLongPress = (e) => {


### PR DESCRIPTION
## 문제

읽기 모드에서 절을 `pointerdown`하면 **300ms** 타이머가 걸리고, 그 안에 손가락이 10px 이상 움직이지 않으면 절 선택 모드로 진입한다(`js/app/views.js`). 300ms는 너무 짧아서 — iOS·Android 표준 롱프레스는 ~500ms — 책을 읽다 손가락을 텍스트 위에 잠깐 얹거나 스크롤 직전 멈칫하는 0.3초가 그대로 모드 진입으로 이어졌다.

## 진단

진입 경로는 "정지한 손가락"과 "의도적 누름"을 **지속 시간으로만** 구분한다. 이동(>10px) 취소는 이미 있으므로 남은 레버는 진입 임계 시간이다.

## 변경

- 진입 임계값 **300ms → 500ms**(플랫폼 표준 롱프레스). 우발적 진입 창을 좁힌다.
- 선택 모드 **안에서의 범위 확장 롱프레스는 300ms 유지** — 이미 모드에 들어와 의도적으로 조작 중인 사용자라 반응성을 지킨다.
- 단일 `LONG_PRESS_MS=300` 상수를 두 경로로 분리: `ENTER_SELECT_MS=500` · `RANGE_EXTEND_MS=300`.
- ADR-010 에 개정 블록 추가.

## 테스트

`node --test tests/unit/*.test.js` — **734 통과**. 롱프레스 타이밍은 유닛 테스트 대상이 아니며(헬퍼 `_verseRangeVrefs`만 테스트), 모바일 실기기 체감 확인 권장.

https://claude.ai/code/session_01CUgyrq5ZEszgcUEEGEeJ28

---
_Generated by [Claude Code](https://claude.ai/code/session_01CUgyrq5ZEszgcUEEGEeJ28)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized gesture timing in chapter reading pointer handlers; no data, auth, or routing changes. Manual mobile feel-check is the main validation gap.
> 
> **Overview**
> Reduces accidental **verse select mode** entry while reading by lengthening the outside-mode long-press from **300ms to 500ms** (closer to typical mobile long-press timing). Brief touches or pauses before scrolling should no longer flip into selection as often; the **>10px move** cancel behavior is unchanged.
> 
> **In-mode range extension** (mobile equivalent of Shift+click) still uses **300ms** so anchored range selection stays responsive once the user is already in select mode.
> 
> Implementation replaces a single `LONG_PRESS_MS` with `ENTER_SELECT_MS` and `RANGE_EXTEND_MS` in `views.js`, with inline comments explaining the split. **ADR-010** documents the 2026-06-13 revision.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1278d4aa03694bde530a9b3caf273c8e672a757b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->