### PR TITLE
chore: Claude Code 훅 3종 가져오기

### DIFF
--- a/.claude/hooks/doc-reminder.sh
+++ b/.claude/hooks/doc-reminder.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Stop hook (sync, non-blocking; just prints a systemMessage).
+# If source code changed but the docs that track "what currently works"
+# (CLAUDE.md / anything under docs/) were NOT touched, nudge to update them
+# before merge. Self-suppressing: the moment you edit CLAUDE.md or a docs/ file,
+# this goes quiet. Rationale: feedback_documentation.
+set -u
+PROJECT="/home/joshua/projects/common-bible"
+cd "$PROJECT" || exit 0
+
+# Final path column of each porcelain line (handles renames: "R old -> new").
+p=$(git status --porcelain 2>/dev/null | awk '{print $NF}')
+
+# Code changed?
+printf '%s\n' "$p" | grep -qE '^(js/|css/|index\.html|sw\.js)' || exit 0
+# Docs already being updated alongside? -> stay quiet.
+printf '%s\n' "$p" | grep -qE '^(CLAUDE\.md|docs/)' && exit 0
+
+jq -cn '{systemMessage:"📝 코드가 바뀌었는데 CLAUDE.md \"현재 상태\"·docs/worklog.md·관련 ADR은 아직 그대로입니다. 머지 전 갱신을 확인하세요."}'
+exit 0

--- a/.claude/hooks/doc-reminder.sh
+++ b/.claude/hooks/doc-reminder.sh
@@ -5,7 +5,9 @@
 # before merge. Self-suppressing: the moment you edit CLAUDE.md or a docs/ file,
 # this goes quiet. Rationale: feedback_documentation.
 set -u
-PROJECT="/home/joshua/projects/common-bible"
+# Project root: $CLAUDE_PROJECT_DIR when set by Claude Code, else derived from
+# this script's location so the hook is portable across clone paths.
+PROJECT="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
 cd "$PROJECT" || exit 0
 
 # Final path column of each porcelain line (handles renames: "R old -> new").

--- a/.claude/hooks/typecheck-js.sh
+++ b/.claude/hooks/typecheck-js.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# PostToolUse(Edit|Write|MultiEdit) hook.
+# If the just-edited file is under common-bible/js/ (a .js or .ts file), run the
+# project type-check (tsc x2 via `npm run typecheck`). On failure, print the
+# errors to stderr and exit 2 so Claude Code feeds them straight back to the
+# model to fix immediately. Non-js/ edits are a no-op. Type discipline: ADR-012.
+#
+# Reads the hook input JSON on stdin; uses tool_input.file_path.
+set -u
+PROJECT="/home/joshua/projects/common-bible"
+
+f=$(jq -r '.tool_input.file_path // empty')
+case "$f" in
+  "$PROJECT"/js/*.js | "$PROJECT"/js/*.ts) ;;   # under js/, fall through
+  *) exit 0 ;;                                   # anything else: skip
+esac
+
+o=$(cd "$PROJECT" && npm run typecheck 2>&1) || {
+  printf '%s\n' "$o" | tail -n 30 >&2
+  exit 2
+}
+exit 0

--- a/.claude/hooks/typecheck-js.sh
+++ b/.claude/hooks/typecheck-js.sh
@@ -7,7 +7,10 @@
 #
 # Reads the hook input JSON on stdin; uses tool_input.file_path.
 set -u
-PROJECT="/home/joshua/projects/common-bible"
+# Project root: Claude Code passes $CLAUDE_PROJECT_DIR when invoking hooks; fall
+# back to deriving it from this script's location (PROJECT/.claude/hooks/x.sh) so
+# the hook works in any clone path, not just the one it was authored in.
+PROJECT="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
 
 f=$(jq -r '.tool_input.file_path // empty')
 case "$f" in

--- a/.claude/hooks/verify-on-stop.sh
+++ b/.claude/hooks/verify-on-stop.sh
@@ -6,7 +6,9 @@
 # silent. The unit suite is ~32s, so this MUST run async (non-blocking); only a
 # failure pulls anyone back. Clean tree / docs-only change -> no-op.
 set -u
-PROJECT="/home/joshua/projects/common-bible"
+# Project root: $CLAUDE_PROJECT_DIR when set by Claude Code, else derived from
+# this script's location so the hook is portable across clone paths.
+PROJECT="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
 cd "$PROJECT" || exit 0
 
 # Gate: only when there are uncommitted .js files under js/ or tests/unit/.

--- a/.claude/hooks/verify-on-stop.sh
+++ b/.claude/hooks/verify-on-stop.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Stop hook (configured async + asyncRewake).
+# When the working tree has uncommitted .js changes under js/ or tests/unit/,
+# run the type-check then the full unit suite. On failure -> exit 2, which (with
+# asyncRewake) re-wakes the model with the output so it can fix. On success ->
+# silent. The unit suite is ~32s, so this MUST run async (non-blocking); only a
+# failure pulls anyone back. Clean tree / docs-only change -> no-op.
+set -u
+PROJECT="/home/joshua/projects/common-bible"
+cd "$PROJECT" || exit 0
+
+# Gate: only when there are uncommitted .js files under js/ or tests/unit/.
+git status --porcelain -- js tests/unit 2>/dev/null | grep -qE '\.js$' || exit 0
+
+o=$(npm run typecheck 2>&1 && npm test 2>&1) || {
+  printf '%s\n' "$o" | tail -n 40 >&2
+  exit 2
+}
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -18,6 +18,7 @@
           {
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/verify-on-stop.sh",
+            "async": true,
             "asyncRewake": true,
             "statusMessage": "유닛 테스트 실행 중..."
           },

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,32 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/typecheck-js.sh",
+            "statusMessage": "타입 검사 중..."
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/verify-on-stop.sh",
+            "asyncRewake": true,
+            "statusMessage": "유닛 테스트 실행 중..."
+          },
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/doc-reminder.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## 개요

`project-claude/hooks` 의 세 스크립트를 이 저장소의 `.claude/` 로 가져오고 `.claude/settings.json` 에 연결한다. 그동안 로컬 체크아웃에만 존재하던 검증 훅을 버전관리·공유 대상으로 올린다.

## 훅 3종

| 이벤트 | 스크립트 | 동작 |
|---|---|---|
| PostToolUse(Edit\|Write\|MultiEdit) | `typecheck-js.sh` | `js/*.{js,ts}` 편집 시 `npm run typecheck`, 실패 시 exit 2 로 모델에 오류 피드백 |
| Stop (asyncRewake) | `verify-on-stop.sh` | 미커밋 `.js` 변경 있을 때만 백그라운드로 typecheck + 유닛 스위트(~32s), 실패만 모델 재기상 |
| Stop | `doc-reminder.sh` | 코드만 바뀌고 CLAUDE.md·docs/ 안 바뀌면 갱신 리마인더(systemMessage) |

## 가져오면서 고친 것

원본 스크립트의 `PROJECT` 경로가 대문자 `Projects` 로 박혀 있어 이 체크아웃(소문자 `projects`)에선 `cd`·`jq` 매칭이 빗나가 무동작 — 소문자로 교정.

## 검증

- `jq -e` 스키마 검증 통과
- 세 훅 합성 stdin 파이프 테스트: typecheck 비-js no-op / 실제 `js/app.js` typecheck 통과, doc-reminder·verify-on-stop 게이트 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adds local Claude Code hook scripts and config; no production app, auth, or data-path changes.
> 
> **Overview**
> Adds version-controlled **Claude Code automation** under `.claude/`: three bash hooks plus `settings.json` so the whole team gets the same agent-time checks.
> 
> After edits to `js/*.{js,ts}`, **PostToolUse** runs `npm run typecheck` and returns failures to the model (exit 2). On **Stop**, an async hook runs typecheck and the full unit suite when there are uncommitted `.js` changes under `js/` or `tests/unit/` (failures re-wake the session); a sync hook nudges updating `CLAUDE.md` / `docs/` when app code changed but those docs did not.
> 
> Hooks resolve the project root via `$CLAUDE_PROJECT_DIR` or the script path so they work across clone locations (fixing a hard-coded path issue from the imported scripts).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 454f284b7307b1f9155e48159abd210a819efc49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->