### PR TITLE
fix: 운문 내어쓰기가 곱슬 따옴표를 인식하도록 확장 (ADR-039 대비)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2798,8 +2798,16 @@ mark.search-highlight {
   margin-right: 0;
 }
 
+/* Pull the leading quote into the gutter by its own advance width, so the
+   first letter lands on the poetry baseline. Widths measured in Noto Serif KR:
+   " 0.389em · “ ” 0.444em · ' ‘ ’ 0.222em. Modifiers must follow the base
+   rule — same specificity, later wins. */
 .verse.verse-poetry .hanging-quote {
   margin-left: -0.4em;
+}
+
+.verse.verse-poetry .hanging-quote--curly {
+  margin-left: -0.444em;
 }
 
 .verse.verse-poetry .hanging-quote--single {

--- a/js/app/citations.js
+++ b/js/app/citations.js
@@ -65,7 +65,7 @@ window.appCitations = (() => {
       .join(";");
   }
 
-  const { el, clearNode } = window.appHelpers;
+  const { el, clearNode, hangingQuoteClass } = window.appHelpers;
   const { createOverlay, attachSheetDrag, attachSheetResize } = window.appOverlay;
 
   /**
@@ -674,9 +674,8 @@ window.appCitations = (() => {
           }
 
           // Hanging punctuation for poetry quote lines (parity with main render).
-          if (isPoetry && (line[0] === '"' || line[0] === "'")) {
-            const hqCls = line[0] === '"'
-              ? "hanging-quote" : "hanging-quote hanging-quote--single";
+          const hqCls = isPoetry ? hangingQuoteClass(line[0]) : "";
+          if (hqCls) {
             span.appendChild(el("span", { className: hqCls }, line[0]));
             _appendLineText(span, line.slice(1));
           } else {

--- a/js/app/helpers.js
+++ b/js/app/helpers.js
@@ -65,6 +65,25 @@ window.appHelpers = (() => {
   }
 
   /**
+   * Hanging punctuation (ADR-006): a poetry line that opens with a quote
+   * pulls that quote into the indent gutter so the first letter stays on
+   * the baseline. Straight and curly forms both qualify — bible source is
+   * typeset with " / ', the liturgical psalter with “ / ‘ (ADR-039) — and
+   * both directions hang, since a line may begin with a closing quote.
+   * Single quotes are narrower, hence the smaller offset class.
+   * Returns "" when the character does not open or close a quote.
+   * @param {string | undefined} ch
+   * @returns {string}
+   */
+  function hangingQuoteClass(ch) {
+    if (ch === '"' || ch === "“" || ch === "”") return "hanging-quote";
+    if (ch === "'" || ch === "‘" || ch === "’") {
+      return "hanging-quote hanging-quote--single";
+    }
+    return "";
+  }
+
+  /**
    * Toggle background `inert` + `aria-hidden` for elements outside the
    * currently active modal/drawer. Selectors should match the elements
    * that need to be excluded from focus and screen reader output.
@@ -161,7 +180,7 @@ window.appHelpers = (() => {
     return box;
   }
 
-  return { _$, chUnit, el, clearNode, setInert, trapFocus, dragReleaseAction, emptyState };
+  return { _$, chUnit, el, clearNode, hangingQuoteClass, setInert, trapFocus, dragReleaseAction, emptyState };
 })();
 
 // ESM module marker (ADR-019). No runtime effect; signals TypeScript that

--- a/js/app/helpers.js
+++ b/js/app/helpers.js
@@ -70,13 +70,15 @@ window.appHelpers = (() => {
    * the baseline. Straight and curly forms both qualify — bible source is
    * typeset with " / ', the liturgical psalter with “ / ‘ (ADR-039) — and
    * both directions hang, since a line may begin with a closing quote.
-   * Single quotes are narrower, hence the smaller offset class.
+   * Each modifier carries the offset for that glyph's advance width; curly
+   * doubles are wider than straight ones, singles narrower than both.
    * Returns "" when the character does not open or close a quote.
    * @param {string | undefined} ch
    * @returns {string}
    */
   function hangingQuoteClass(ch) {
-    if (ch === '"' || ch === "“" || ch === "”") return "hanging-quote";
+    if (ch === '"') return "hanging-quote";
+    if (ch === "“" || ch === "”") return "hanging-quote hanging-quote--curly";
     if (ch === "'" || ch === "‘" || ch === "’") {
       return "hanging-quote hanging-quote--single";
     }

--- a/js/app/views.js
+++ b/js/app/views.js
@@ -21,7 +21,7 @@
 // (settings-ui / state-machine read it) so it is not imported here.
 import { showAudioPlayer, hideAudioBar } from "./audio-player.js";
 
-const { _$, el, clearNode, chUnit } = window.appHelpers;
+const { _$, el, clearNode, chUnit, hangingQuoteClass } = window.appHelpers;
 const { createOverlay } = window.appOverlay;
 const {
   loadBookOrder, loadStartupBehavior,
@@ -1006,10 +1006,9 @@ function appendVerses(article, verses, opts = {}) {
         const segTextOpts = (!isPoetry && segWillShowChip && isLastSegLine)
           ? { noTrailingSpace: true } : undefined;
         // Hanging punctuation: pull leading quote outside the indent.
-        // Single quote is narrower, so it uses a smaller offset (see .hanging-quote--single).
-        if (isPoetry && (line[0] === '"' || line[0] === "'")) {
-          const cls = line[0] === '"' ? "hanging-quote" : "hanging-quote hanging-quote--single";
-          span.appendChild(el("span", { className: cls }, line[0]));
+        const hqCls = isPoetry ? hangingQuoteClass(line[0]) : "";
+        if (hqCls) {
+          span.appendChild(el("span", { className: hqCls }, line[0]));
           appendSegText(span, line.slice(1), segTextOpts);
         } else {
           appendSegText(span, line, segTextOpts);

--- a/tests/unit/citations.test.js
+++ b/tests/unit/citations.test.js
@@ -25,6 +25,19 @@ const APP_PATH = path.resolve(__dirname, "../../js/app/citations.js");
 const APP_SOURCE = fs.readFileSync(APP_PATH, "utf8")
   .replace(/\nexport\s*\{\s*\}\s*;?\s*$/, "");
 
+// `hangingQuoteClass` comes from the real helpers.js rather than a stub — a
+// hand-copied version would drift from production silently. helpers.js only
+// defines functions at load, so an empty context is enough to evaluate it.
+const HELPERS_PATH = path.resolve(__dirname, "../../js/app/helpers.js");
+const HELPERS_SOURCE = fs.readFileSync(HELPERS_PATH, "utf8")
+  .replace(/\nexport\s*\{\s*\}\s*;?\s*$/, "");
+const { hangingQuoteClass } = (() => {
+  const helperCtx = vm.createContext({});
+  helperCtx.window = helperCtx;
+  vm.runInContext(HELPERS_SOURCE, helperCtx, { filename: "helpers.js" });
+  return helperCtx.appHelpers;
+})();
+
 // ── Minimal DOM element stub ─────────────────────────────────────────────────
 // `el(tag, attrs, ...children)` returns a plain object. Mirrors the
 // signature of window.appHelpers.el so citations.js code that builds DOM via
@@ -59,6 +72,7 @@ function loadCitations() {
   ctx.appHelpers = {
     el: makeStubEl(),
     clearNode: (n) => { n.children = []; },
+    hangingQuoteClass,
     trapFocus: () => () => {},
   };
   // citations.js destructures createOverlay at module load (ADR-032); these

--- a/tests/unit/helpers.test.js
+++ b/tests/unit/helpers.test.js
@@ -373,12 +373,13 @@ test("hangingQuoteClass: straight double quote hangs with the wide offset", () =
   assert.equal(h.helpers.hangingQuoteClass('"'), "hanging-quote");
 });
 
-test("hangingQuoteClass: curly double quotes hang, both directions", () => {
+test("hangingQuoteClass: curly double quotes hang with their own offset", () => {
   const h = loadHelpers();
   // Liturgical psalter text is typeset with “ ” (ADR-039). A poetry line may
-  // open with either, so both hang exactly as the straight form used to.
-  assert.equal(h.helpers.hangingQuoteClass("“"), "hanging-quote");
-  assert.equal(h.helpers.hangingQuoteClass("”"), "hanging-quote");
+  // open with either, and both are wider than the straight form (0.444em vs
+  // 0.389em), so they carry the --curly offset.
+  assert.equal(h.helpers.hangingQuoteClass("“"), "hanging-quote hanging-quote--curly");
+  assert.equal(h.helpers.hangingQuoteClass("”"), "hanging-quote hanging-quote--curly");
 });
 
 test("hangingQuoteClass: straight single quote gets the narrow offset", () => {

--- a/tests/unit/helpers.test.js
+++ b/tests/unit/helpers.test.js
@@ -12,6 +12,7 @@
 //   - chUnit (psalm vs everything else)
 //   - el (createElement + attrs + children)
 //   - clearNode (firstChild loop)
+//   - hangingQuoteClass (leading quote → gutter class, straight + curly)
 //   - setInert (inert + aria-hidden toggle on selector matches)
 //   - trapFocus (Tab / Shift-Tab cycling within a container)
 //   - dragReleaseAction (bottom-sheet drag-resize release thresholds)
@@ -363,6 +364,55 @@ test("clearNode: only removes direct children (not deeper)", () => {
   // The grandchild is still attached to its (now-detached) parent
   assert.equal(child._children.length, 1);
   assert.equal(child._children[0], grandchild);
+});
+
+// ── hangingQuoteClass ───────────────────────────────────────────────────────
+
+test("hangingQuoteClass: straight double quote hangs with the wide offset", () => {
+  const h = loadHelpers();
+  assert.equal(h.helpers.hangingQuoteClass('"'), "hanging-quote");
+});
+
+test("hangingQuoteClass: curly double quotes hang, both directions", () => {
+  const h = loadHelpers();
+  // Liturgical psalter text is typeset with “ ” (ADR-039). A poetry line may
+  // open with either, so both hang exactly as the straight form used to.
+  assert.equal(h.helpers.hangingQuoteClass("“"), "hanging-quote");
+  assert.equal(h.helpers.hangingQuoteClass("”"), "hanging-quote");
+});
+
+test("hangingQuoteClass: straight single quote gets the narrow offset", () => {
+  const h = loadHelpers();
+  assert.equal(
+    h.helpers.hangingQuoteClass("'"),
+    "hanging-quote hanging-quote--single",
+  );
+});
+
+test("hangingQuoteClass: curly single quotes get the narrow offset", () => {
+  const h = loadHelpers();
+  assert.equal(
+    h.helpers.hangingQuoteClass("‘"),
+    "hanging-quote hanging-quote--single",
+  );
+  assert.equal(
+    h.helpers.hangingQuoteClass("’"),
+    "hanging-quote hanging-quote--single",
+  );
+});
+
+test("hangingQuoteClass: non-quote characters do not hang", () => {
+  const h = loadHelpers();
+  assert.equal(h.helpers.hangingQuoteClass("주"), "");
+  assert.equal(h.helpers.hangingQuoteClass("("), "");
+  assert.equal(h.helpers.hangingQuoteClass("¶"), "");
+});
+
+test("hangingQuoteClass: empty line and undefined do not hang", () => {
+  const h = loadHelpers();
+  // `line[0]` is undefined on an empty line — must not throw or hang.
+  assert.equal(h.helpers.hangingQuoteClass(undefined), "");
+  assert.equal(h.helpers.hangingQuoteClass(""), "");
 });
 
 // ── setInert ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## 배경

전례시편 마크다운(`common-bible-data/liturgical/psalter/`)의 본문 인용부호를 곱슬 따옴표로 전환했다. 그런데 앱은 운문 행의 내어쓰기(ADR-006 hanging punctuation)를 `line[0] === '"'` 로 판정한다. `“` 나 `‘` 로 시작하는 행은 내어쓰기가 적용되지 않는다.

지금 당장 깨지지는 않는다 — 전례시편을 렌더하는 코드가 아직 없기 때문이다. 하지만 ADR-039 시편 렌더링이 붙는 순간 바로 드러나고, 나중에 성서 본문(`source/`)까지 전환하면 운문 첫 행 내어쓰기가 **전부** 사라진다. 미리 막아 둔다.

## 변경

- `helpers.js` 에 순수 함수 `hangingQuoteClass()` 신설. `views.js` 와 `citations.js` 에 복제돼 있던 판정을 한곳으로 모았다.
- 곧은·곱슬, 여는·닫는 6종을 모두 인식한다. 기존 코드가 `"` 의 방향을 가리지 않고 내어쓰던 동작을 그대로 보존하려고 `”`·`’` 도 받는다.
- 곱슬 겹따옴표는 곧은 것보다 넓다(Noto Serif KR 기준 0.444em 대 0.389em). `.hanging-quote--curly` 를 두어 전용 오프셋을 준다. 홑따옴표는 곧은·곱슬 모두 0.222em 이라 기존 `--single` 을 그대로 쓴다.

## 검증

- 유닛 **798 통과** (792 → 798, `hangingQuoteClass` 6 케이스 추가)
- `tsc --noEmit` 통과
- e2e **215 통과** (`test_a11y_axe.py` 는 선택적 의존성 미설치로 제외)

tsc 는 ESM 런타임 파손을 못 잡으므로 실제 브라우저로도 확인했다. `/1chr/16` 의 JSON 응답을 곱슬 따옴표로 바꿔치기해 렌더한 결과:

| | 수정 전 | 수정 후 |
|---|---|---|
| `.hanging-quote` 개수 | 0 | 3 |
| 첫 글자와 운문 기준선 차이 | — | +0.02px |
| 콘솔·페이지 오류 | — | 없음 |

`--curly` 오프셋이 없었다면 +0.79px 어긋난다. 곧은 따옴표는 -0.19px 로 변함없다.

## 후속

- `docs/known-issues.md` §3.2 가 이 문제를 미해결로 적어 두었다. 다만 §3 은 `docs/adr-036-liturgical-calendar` 브랜치에 있고 아직 main 에 없다. 그 브랜치가 머지된 뒤 §3.2 를 해소됨으로 갱신한다.
- ADR-006 은 데이터 저장소에서 v2.4 로 갱신했다 (`common-bible-data@ac66e78`).
- `source/` 성서 본문 전환은 별건으로 남아 있다 (§3.3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized poetry typography and shared render helper; no auth, data, or API changes. Regression risk is limited to verse/citation poetry line layout.
> 
> **Overview**
> Poetry **hanging punctuation** (ADR-006) no longer keys only on straight `"` / `'`. The PR centralizes quote detection in **`hangingQuoteClass()`** in `helpers.js` and uses it from **`views.js`** and **`citations.js`** instead of duplicated inline checks.
> 
> **Behavior:** Six quote forms are recognized (straight and curly, open and close). Curly double quotes get a new **`.hanging-quote--curly`** offset (`-0.444em` in Noto Serif KR) because they are wider than straight doubles; singles keep **`.hanging-quote--single`**.
> 
> **Tests:** Unit coverage for `hangingQuoteClass` in `helpers.test.js`; `citations.test.js` loads the real helper to avoid drift.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 293e007861327ee90a5481379518225f4b807fc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->